### PR TITLE
Version 0.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.4.9</version>
+  <version>0.4.10</version>
   
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>3.2.0_228</version>
+      <version>3.3.0_265</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -28,7 +28,7 @@ public class Bot {
 	private static final String mainClass = "com.tisawesomeness.minecord.Main";
 	public static final String helpServer = "https://discord.io/minecord";
 	public static final String website = "https://minecord.github.io";
-	private static final String version = "0.4.9";
+	private static final String version = "0.4.10";
 	
 	public static JDA jda;
 	private static Listener listener;

--- a/src/com/tisawesomeness/minecord/command/admin/EvalCommand.java
+++ b/src/com/tisawesomeness/minecord/command/admin/EvalCommand.java
@@ -1,10 +1,15 @@
 package com.tisawesomeness.minecord.command.admin;
 
+import java.util.regex.Pattern;
+
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 
 import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.command.Command;
+import com.tisawesomeness.minecord.util.MessageUtils;
+
+import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 
 public class EvalCommand extends Command {
@@ -53,9 +58,19 @@ public class EvalCommand extends Command {
 		if (output == null) {
 			return new Result(Outcome.ERROR, ":x: Invalid javascript.");
 		}
-		//Prevent accidental @everyone
-		String outputStr = output.toString().replaceAll("@everyone", "@.everyone").replaceAll("@here", "@.here");
-		return new Result(Outcome.SUCCESS, outputStr);
+		
+		//Prevent @everyone and revealing token
+		String outputStr = output.toString()
+			.replaceAll("@everyone", "[everyone]")
+			.replaceAll("@here", "[here]")
+			.replaceAll(Pattern.quote(e.getJDA().getToken()), "[redacted]");
+		
+		EmbedBuilder eb = new EmbedBuilder();
+		eb.addField("Input", "```js\n" + code + "\n```", false);
+		eb.addField("Output", "```js\n" + outputStr + "\n```", false);
+		eb = MessageUtils.addFooter(eb);
+		
+		return new Result(Outcome.SUCCESS, eb.build());
 		
 	}
 

--- a/src/com/tisawesomeness/minecord/command/utility/CodesCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/CodesCommand.java
@@ -26,9 +26,9 @@ public class CodesCommand extends Command {
 	public Result run(String[] args, MessageReceivedEvent e) {
 		
 		String m = "**Chat Codes:**" +
-				"\n" + "Copy-Paste symbol: §" +
-				"\n" + "MOTD code: \\u00A7" +
-				"\n" + "Most servers with plugins let you use & instead of § in chat and config files." +
+				"\n" + "Copy-Paste symbol: `§`" +
+				"\n" + "MOTD code: `\\u00A7`" +
+				"\n" + "Most servers with plugins let you use `&` instead of `§` in chat and config files." +
 				"\n" + "http://i.imgur.com/MWCFs5S.png" +
 				"\n" + "http://i.imgur.com/cWYjhkN.png";
 		return new Result(Outcome.SUCCESS, m);


### PR DESCRIPTION
- Updated JDA so channel categories don't break the bot
- Added embed to `&eval`
- `&eval` will not accidentally reveal the token
- Put symbols for `&codes` in code blocks