### PR TITLE
Version 0.11.0

### DIFF
--- a/items.json
+++ b/items.json
@@ -159,6 +159,7 @@
         "previously": "Oak Wood Plank",
         "search_names": [
           "Oak Wood Planks",
+          "Oak Wood Plank",
           "Oak Plank",
           "Wood Planks",
           "Wood Plank",
@@ -178,6 +179,7 @@
         "previously": "Spruce Wood Plank",
         "search_names": [
           "Spruce Wood Planks",
+          "Spruce Wood Plank",
           "Spruce Plank"
         ],
         "display_name": "Spruce Planks"
@@ -194,6 +196,7 @@
         "previously": "Birch Wood Plank",
         "search_names": [
           "Birch Wood Planks",
+          "Birch Wood Plank",
           "Birch Plank"
         ],
         "display_name": "Birch Planks"
@@ -210,6 +213,7 @@
         "previously": "Jungle Wood Plank",
         "search_names": [
           "Jungle Wood Planks",
+          "Jungle Wood Plank",
           "Jungle Plank"
         ],
         "display_name": "Jungle Planks"
@@ -226,6 +230,7 @@
         "previously": "Acacia Wood Plank",
         "search_names": [
           "Acacia Wood Planks",
+          "Acacia Wood Plank",
           "Acacia Plank"
         ],
         "display_name": "Acacia Planks"
@@ -242,6 +247,7 @@
         "previously": "Dark Oak Wood Plank",
         "search_names": [
           "Dark Oak Wood Planks",
+          "Dark Oak Wood Plank",
           "Dark Oak Plank",
           "Dark Wood Planks",
           "Dark Wood Plank",
@@ -1331,12 +1337,14 @@
   "minecraft.smooth_quartz": {
     "lang": {
       "en_US": {
-        "previously": "Double Quartz Slab",
-        "display_name": "Smooth Quartz"
+        "previously": "Smooth Quartz",
+        "previously2": "Double Quartz Slab",
+        "display_name": "Smooth Quartz Block"
       }
     },
     "properties": {
       "data": 7,
+      "image_key": "Smooth Quartz",
       "actual_id": "minecraft.double_stone_slab",
       "id": 43
     }
@@ -7434,11 +7442,11 @@
   "minecraft.clay_ball": {
     "lang": {
       "en_US": {
+        "previous_conflict": true,
         "search_names": [
-          "Clay Ball"
+          "Clay (ball)"
         ],
-        "display_name": "Clay",
-        "name_conflict": true
+        "display_name": "Clay Ball"
       }
     },
     "properties": {
@@ -8497,18 +8505,24 @@
       "id": 383
     }
   },
-  "minecraft.zombie_pigman_spawn_egg": {
+  "minecraft.zombified_piglin_spawn_egg": {
     "lang": {
       "en_US": {
-        "previously": "Spawn Zombie Pigman",
+        "previously": "Zombie Pigman Spawn Egg",
+        "previously2": "Spawn Zombie Pigman",
         "search_names": [
-          "Zombie Pigman Egg"
+          "Zombie Pigman Egg",
+          "Zombified Pigman Spawn Egg",
+          "Zombified Pigman Egg",
+          "Spawn Zombified Pigman",
+          "Zombified Piglin Egg"
         ],
-        "display_name": "Zombie Pigman Spawn Egg"
+        "display_name": "Zombified Piglin Spawn Egg"
       }
     },
     "properties": {
       "data": 57,
+      "previous_id": "minecraft.zombie_pigman_spawn_egg",
       "id": 383
     }
   },
@@ -9892,17 +9906,6 @@
       "version": "1.9"
     }
   },
-  "minecraft.shield.Yellow": {
-    "lang": {
-      "en_US": {
-        "display_name": "Yellow Shield"
-      }
-    },
-    "properties": {
-      "id": 442,
-      "version": "1.9"
-    }
-  },
   "minecraft.shield.black": {
     "lang": {
       "en_US": {
@@ -10006,6 +10009,17 @@
     "lang": {
       "en_US": {
         "display_name": "Magenta Shield"
+      }
+    },
+    "properties": {
+      "id": 442,
+      "version": "1.9"
+    }
+  },
+  "minecraft.shield.orange": {
+    "lang": {
+      "en_US": {
+        "display_name": "Orange Shield"
       }
     },
     "properties": {
@@ -12115,7 +12129,8 @@
   "minecraft.bamboo_sapling": {
     "lang": {
       "en_US": {
-        "display_name": "Bamboo Sapling"
+        "previously": "Bamboo Sapling",
+        "display_name": "Bamboo Shoot"
       }
     },
     "properties": {
@@ -13297,6 +13312,1346 @@
     },
     "properties": {
       "version": "1.15"
+    }
+  },
+  "minecraft.ancient_debris": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Debris",
+          "Netherite Ore"
+        ],
+        "display_name": "Ancient Debris"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.basalt": {
+    "lang": {
+      "en_US": {
+        "display_name": "Basalt"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.blackstone": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Black Stone"
+        ],
+        "display_name": "Blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.blackstone_slab": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Black Stone Slab"
+        ],
+        "display_name": "Blackstone Slab"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.blackstone_stairs": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Black Stone Stairs",
+          "Black Stone Stair",
+          "Blackstone Stair"
+        ],
+        "display_name": "Blackstone Stairs"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.blackstone_wall": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Black Stone Wall"
+        ],
+        "display_name": "Blackstone Wall"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.chain": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Kunai",
+          "Kunai with",
+          "Kunai with Chain"
+        ],
+        "display_name": "Chain"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.chiseled_nether_bricks": {
+    "lang": {
+      "en_US": {
+        "display_name": "Chiseled Nether Bricks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.chiseled_polished_blackstone": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Chiseled Polished Black Stone",
+          "Polished Chiseled Black Stone",
+          "Polished Chiseled Blackstone"
+        ],
+        "display_name": "Chiseled Polished Blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.cracked_nether_bricks": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cracked Nether Bricks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.cracked_polished_blackstone_bricks": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Polished Cracked Blackstone Bricks",
+          "Polished Cracked Black Stone Bricks",
+          "Cracked Polished Black Stone Bricks",
+          "Polished Cracked Blackstone Brick",
+          "Polished Cracked Black Stone Brick",
+          "Cracked Polished Black Stone Brick",
+          "Cracked Polished Blackstone Brick"
+        ],
+        "display_name": "Cracked Polished Blackstone Bricks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_button": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Wood Button"
+        ],
+        "display_name": "Crimson Button"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_door": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Wood Door"
+        ],
+        "display_name": "Crimson Door"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_fence": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Wood Fence"
+        ],
+        "display_name": "Crimson Fence"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_fence_gate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Wood Fence Gate",
+          "Crimson Wood Gate",
+          "Crimson Gate"
+        ],
+        "display_name": "Crimson Fence Gate"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_fungus": {
+    "lang": {
+      "en_US": {
+        "display_name": "Crimson Fungus"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_hyphae": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Wood"
+        ],
+        "display_name": "Crimson Hyphae"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_nylium": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Grass"
+        ],
+        "display_name": "Crimson Nylium"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_planks": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Wood Planks",
+          "Crimson Wood Plank",
+          "Crimson Plank"
+        ],
+        "display_name": "Crimson Planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_pressure_plate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Wood Pressure Plate",
+          "Crimson Wood Plate",
+          "Crimson Plate"
+        ],
+        "display_name": "Crimson Pressure Plate"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_roots": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Root"
+        ],
+        "display_name": "Crimson Roots"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_sign": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Wood Sign"
+        ],
+        "display_name": "Crimson Sign"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_slab": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Wood Slab"
+        ],
+        "display_name": "Crimson Slab"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_stairs": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Wood Stairs",
+          "Crimson Wood Stair",
+          "Crimson Stair"
+        ],
+        "display_name": "Crimson Stairs"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_stem": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Stems",
+          "Crimson Log"
+        ],
+        "display_name": "Crimson Stem"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_trapdoor": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Wood Trap Door",
+          "Crimson Wood Trapdoor",
+          "Crimson Trap Door"
+        ],
+        "display_name": "Crimson Trapdoor"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.crimson_wall_sign": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Wood Wall Sign"
+        ],
+        "display_name": "Crimson Wall Sign"
+      }
+    },
+    "properties": {
+      "image_key": "Crimson Sign",
+      "version": "1.16"
+    }
+  },
+  "minecraft.crying_obsidian": {
+    "lang": {
+      "en_US": {
+        "display_name": "Crying Obsidian"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.gilded_blackstone": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Gilded Black Stone",
+          "Gold Black Stone",
+          "Gold Blackstone"
+        ],
+        "display_name": "Gilded Blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.hoglin_spawn_egg": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Spawn Hoglin",
+          "Hoglin Egg",
+          "Dedodated Ham Spawn Egg",
+          "Spawn Dedodated Ham",
+          "Dedodated Ham Egg"
+        ],
+        "display_name": "Hoglin Spawn Egg"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.lodestone": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Lode Stone"
+        ],
+        "display_name": "Lodestone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.lodestone_compass": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Lode Stone Compass"
+        ],
+        "display_name": "Lodestone Compass"
+      }
+    },
+    "properties": {
+      "image_key": "Compass",
+      "version": "1.16"
+    }
+  },
+  "minecraft.music_disc_pigstep": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Pigstep Disc",
+          "Music Disc Pigstep",
+          "Disc Pigstep",
+          "Lena Raine - Pigstep",
+          "Best Song"
+        ],
+        "lore": "Lena Raine - Pigstep",
+        "display_name": "Music Disc",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Music Disc Pigstep",
+      "version": "1.16"
+    }
+  },
+  "minecraft.nether_gold_ore": {
+    "lang": {
+      "en_US": {
+        "display_name": "Nether Gold Ore"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.nether_sprouts": {
+    "lang": {
+      "en_US": {
+        "display_name": "Nether Sprouts"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.netherite_axe": {
+    "lang": {
+      "en_US": {
+        "display_name": "Netherite Axe"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.netherite_block": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Netherite Block"
+        ],
+        "display_name": "Block of Netherite"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.netherite_boots": {
+    "lang": {
+      "en_US": {
+        "display_name": "Netherite Boots"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.netherite_chestplate": {
+    "lang": {
+      "en_US": {
+        "display_name": "Netherite Chestplate"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.netherite_helmet": {
+    "lang": {
+      "en_US": {
+        "display_name": "Netherite Helmet"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.netherite_hoe": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Flex"
+        ],
+        "display_name": "Netherite Hoe"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.netherite_ingot": {
+    "lang": {
+      "en_US": {
+        "display_name": "Netherite Ingot"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.netherite_leggings": {
+    "lang": {
+      "en_US": {
+        "display_name": "Netherite Leggings"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.netherite_pickaxe": {
+    "lang": {
+      "en_US": {
+        "display_name": "Netherite Pickaxe"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.netherite_scrap": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Scrap"
+        ],
+        "display_name": "Netherite Scrap"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.netherite_shovel": {
+    "lang": {
+      "en_US": {
+        "display_name": "Netherite Shovel"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.netherite_sword": {
+    "lang": {
+      "en_US": {
+        "display_name": "Netherite Sword"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.piglin_banner_pattern": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Snout Banner Pattern",
+          "Piglin Banner Pattern",
+          "Snout Pattern",
+          "Piglin Pattern"
+        ],
+        "lore": "Snout",
+        "display_name": "Banner Pattern",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.piglin_spawn_egg": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Spawn Piglin",
+          "Piglin Egg",
+          "Pigman Spawn Egg",
+          "Spawn Pigman",
+          "Pigman Egg"
+        ],
+        "display_name": "Piglin Spawn Egg"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.polished_basalt": {
+    "lang": {
+      "en_US": {
+        "display_name": "Polished Basalt"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.polished_blackstone": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Polished Black Stone"
+        ],
+        "display_name": "Polished Blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.polished_blackstone_brick_slab": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Polished Black Stone Brick Slab"
+        ],
+        "display_name": "Polished Blackstone Brick Slab"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.polished_blackstone_brick_stairs": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Polished Black Stone Brick Stairs",
+          "Polished Black Stone Brick Stair",
+          "Polished Blackstone Brick Stairs"
+        ],
+        "display_name": "Polished Blackstone Brick Stairs"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.polished_blackstone_brick_wall": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Polished Black Stone Brick Wall"
+        ],
+        "display_name": "Polished Blackstone Brick Wall"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.polished_blackstone_bricks": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Polished Black Stone Bricks",
+          "Polished Black Stone Brick",
+          "Polished Blackstone Brick"
+        ],
+        "display_name": "Polished Blackstone Bricks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.polished_blackstone_button": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Polished Black Stone Button"
+        ],
+        "display_name": "Polished Blackstone Button"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.polished_blackstone_pressure_plate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Polished Black Stone Pressure Plate",
+          "Polished Black Stone Plate",
+          "Polished Blackstone Plate"
+        ],
+        "display_name": "Polished Blackstone Pressure Plate"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.polished_blackstone_slab": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Polished Black Stone Slab"
+        ],
+        "display_name": "Polished Blackstone Slab"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.polished_blackstone_stairs": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Polished Black Stone Stairs",
+          "Polished Black Stone Stair",
+          "Polished Blackstone Stair"
+        ],
+        "display_name": "Polished Blackstone Stairs"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.polished_blackstone_wall": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Polished Black Stone Wall"
+        ],
+        "display_name": "Polished Blackstone Wall"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.potted_crimson_fungus": {
+    "lang": {
+      "en_US": {
+        "display_name": "Potted Crimson Fungus"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.potted_crimson_roots": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Potted Crimson Root"
+        ],
+        "display_name": "Potted Crimson Roots"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.potted_warped_fungus": {
+    "lang": {
+      "en_US": {
+        "display_name": "Potted Warped Fungus"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.potted_warped_roots": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Potted Warped Root"
+        ],
+        "display_name": "Potted Warped Roots"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.quartz_bricks": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Quartz Brick"
+        ],
+        "display_name": "Quartz Bricks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.respawn_anchor": {
+    "lang": {
+      "en_US": {
+        "display_name": "Respawn Anchor"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.shroomlight": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Shroom Light"
+        ],
+        "display_name": "Shroomlight"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.soul_campfire": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Soul Camp Fire",
+          "Blue Campfire",
+          "Blue Camp Fire"
+        ],
+        "display_name": "Soul Campfire"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.soul_fire": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Blue Fire"
+        ],
+        "display_name": "Soul Fire"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.soul_lantern": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Blue Lantern"
+        ],
+        "display_name": "Soul Lantern"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.soul_soil": {
+    "lang": {
+      "en_US": {
+        "display_name": "Soul Soil"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.soul_torch": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Blue Torch"
+        ],
+        "display_name": "Soul Torch"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.soul_wall_torch": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Blue Wall Torch"
+        ],
+        "display_name": "Soul Wall Torch"
+      }
+    },
+    "properties": {
+      "image_key": "Soul Torch",
+      "version": "1.16"
+    }
+  },
+  "minecraft.strider_spawn_egg": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Spawn Strider",
+          "Strider Egg"
+        ],
+        "display_name": "Strider Spawn Egg"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.stripped_crimson_hyphae": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Stripped Crimson Wood"
+        ],
+        "display_name": "Stripped Crimson Hyphae"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.stripped_crimson_stem": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Stripped Crimson Stems",
+          "Stripped Crimson Log"
+        ],
+        "display_name": "Stripped Crimson Stem"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.stripped_warped_hyphae": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Stripped Warped Wood"
+        ],
+        "display_name": "Stripped Warped Hyphae"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.stripped_warped_stem": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Stripped Warped Log"
+        ],
+        "display_name": "Stripped Warped Stem"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.target": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Target Block"
+        ],
+        "display_name": "Target"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.twisting_vines": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Vines"
+        ],
+        "display_name": "Twisting Vines"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.twisting_vines_plant": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Vines Plant"
+        ],
+        "display_name": "Twisting Vines Plant"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_button": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Wood Button"
+        ],
+        "display_name": "Warped Button"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_door": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Wood Door"
+        ],
+        "display_name": "Warped Door"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_fence": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Wood Fence"
+        ],
+        "display_name": "Warped Fence"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_fence_gate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Wood Fence Gate",
+          "Warped Wood Gate",
+          "Warped Gate"
+        ],
+        "display_name": "Warped Fence Gate"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_fungus": {
+    "lang": {
+      "en_US": {
+        "display_name": "Warped Fungus"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_fungus_on_a_stick": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Fungus on a Stick"
+        ],
+        "display_name": "Warped Fungus on a Stick"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_hyphae": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Wood"
+        ],
+        "display_name": "Warped Hyphae"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_nylium": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Grass"
+        ],
+        "display_name": "Warped Nylium"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_planks": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Wood Planks",
+          "Wapred Wood Plank",
+          "Warped Plank"
+        ],
+        "display_name": "Warped Planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_pressure_plate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Wood Pressure Plate",
+          "Warped Wood Plate",
+          "Warped Plate"
+        ],
+        "display_name": "Warped Pressure Plate"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_roots": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Root"
+        ],
+        "display_name": "Warped Roots"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_sign": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Wood Sign"
+        ],
+        "display_name": "Warped Sign"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_slab": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Wood Slab"
+        ],
+        "display_name": "Warped Slab"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_stairs": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Wood Stairs",
+          "Warped Wood Stair",
+          "Warped Stair"
+        ],
+        "display_name": "Warped Stairs"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_stem": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Log"
+        ],
+        "display_name": "Warped Stem"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_trapdoor": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Wood Trap Door",
+          "Warped Wood Trapdoor",
+          "Warped Trap Door"
+        ],
+        "display_name": "Warped Trapdoor"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_wall_sign": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Wood Wall Sign"
+        ],
+        "display_name": "Warped Wall Sign"
+      }
+    },
+    "properties": {
+      "image_key": "Warped Sign",
+      "version": "1.16"
+    }
+  },
+  "minecraft.warped_wart_block": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Warped Nether Wart Block",
+          "Warped Nether Wart"
+        ],
+        "display_name": "Warped Wart Block"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.weeping_vines": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Vines"
+        ],
+        "display_name": "Weeping Vines"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.weeping_vines_plant": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Crimson Vines Plant"
+        ],
+        "display_name": "Weeping Vines Plant"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "minecraft.zoglin_spawn_egg": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Spawn Zoglin",
+          "Zoglin Egg",
+          "Spawn Zombie Hoglin",
+          "Zombie Hoglin Egg",
+          "Zombie Hoglin Spawn Egg",
+          "Spawn Zombified Hoglin",
+          "Zombified Hoglin Egg",
+          "Zombified Hoglin Spawn Egg"
+        ],
+        "display_name": "Zoglin Spawn Egg"
+      }
+    },
+    "properties": {
+      "version": "1.16"
     }
   },
   "minecraft.lingering_potion.effect.awkward": {

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.10.1</version>
+  <version>0.11.0</version>
   
   <repositories>
     <repository>

--- a/recipes.json
+++ b/recipes.json
@@ -154,7 +154,8 @@
     },
     "properties": {
       "version": "1.14"
-    }
+    },
+    "group": "sign"
   },
   "acacia_slab": {
     "result": {
@@ -915,11 +916,6 @@
     "result": {
       "item": "minecraft:beetroot_soup"
     },
-    "pattern": [
-      "BBB",
-      "BBB",
-      " U "
-    ],
     "ingredients": [
       {
         "item": "minecraft:bowl"
@@ -947,14 +943,6 @@
     "lang": {
       "en_US": {
         "notes": "Before 1.14, recipe is shaped."
-      }
-    },
-    "key": {
-      "B": {
-        "item": "minecraft:beetroot"
-      },
-      "U": {
-        "item": "minecraft:bowl"
       }
     },
     "properties": {
@@ -1116,7 +1104,8 @@
     },
     "properties": {
       "version": "1.14"
-    }
+    },
+    "group": "sign"
   },
   "birch_slab": {
     "result": {
@@ -1631,6 +1620,96 @@
       "removed": "1.14"
     },
     "group": "wool"
+  },
+  "blackstone_slab": {
+    "result": {
+      "item": "minecraft:blackstone_slab",
+      "count": 6
+    },
+    "pattern": [
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "blackstone_slab_from_blackstone_stonecutting": {
+    "result": "minecraft:blackstone_slab",
+    "ingredient": {
+      "item": "minecraft:blackstone"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "blackstone_stairs": {
+    "result": {
+      "item": "minecraft:blackstone_stairs",
+      "count": 4
+    },
+    "pattern": [
+      "#  ",
+      "## ",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "blackstone_stairs_from_blackstone_stonecutting": {
+    "result": "minecraft:blackstone_stairs",
+    "ingredient": {
+      "item": "minecraft:blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "blackstone_wall": {
+    "result": {
+      "item": "minecraft:blackstone_wall",
+      "count": 6
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "blackstone_wall_from_blackstone_stonecutting": {
+    "result": "minecraft:blackstone_wall",
+    "ingredient": {
+      "item": "minecraft:blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
   },
   "blast_furnace": {
     "result": {
@@ -2952,6 +3031,28 @@
       }
     }
   },
+  "chain": {
+    "result": {
+      "item": "minecraft:chain"
+    },
+    "pattern": [
+      "N",
+      "I",
+      "N"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "I": {
+        "item": "minecraft:iron_ingot"
+      },
+      "N": {
+        "item": "minecraft:iron_nugget"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
   "chainmail_boots": {
     "result": {
       "item": "minecraft:chainmail_boots"
@@ -3029,7 +3130,7 @@
   "charcoal": {
     "result": "minecraft:charcoal",
     "ingredient": {
-      "tag": "minecraft:logs"
+      "tag": "minecraft:logs_that_burn"
     },
     "type": "minecraft:smelting",
     "experience": 0.15,
@@ -3073,6 +3174,75 @@
       "B": {
         "item": "minecraft:minecart"
       }
+    }
+  },
+  "chiseled_nether_bricks": {
+    "result": {
+      "item": "minecraft:chiseled_nether_bricks"
+    },
+    "pattern": [
+      "#",
+      "#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:nether_brick_slab"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "chiseled_nether_bricks_from_nether_bricks_stonecutting": {
+    "result": "minecraft:chiseled_nether_bricks",
+    "ingredient": {
+      "item": "minecraft:nether_bricks"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "chiseled_polished_blackstone": {
+    "result": {
+      "item": "minecraft:chiseled_polished_blackstone"
+    },
+    "pattern": [
+      "#",
+      "#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:polished_blackstone_slab"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "chiseled_polished_blackstone_from_blackstone_stonecutting": {
+    "result": "minecraft:chiseled_polished_blackstone",
+    "ingredient": {
+      "item": "minecraft:blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "chiseled_polished_blackstone_from_polished_blackstone_stonecutting": {
+    "result": "minecraft:chiseled_polished_blackstone",
+    "ingredient": {
+      "item": "minecraft:polished_blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
     }
   },
   "chiseled_quartz_block": {
@@ -3705,6 +3875,30 @@
       }
     }
   },
+  "cracked_nether_bricks": {
+    "result": "minecraft:cracked_nether_bricks",
+    "ingredient": {
+      "item": "minecraft:nether_bricks"
+    },
+    "type": "minecraft:smelting",
+    "experience": 0.1,
+    "properties": {
+      "version": "1.16"
+    },
+    "cookingtime": 200
+  },
+  "cracked_polished_blackstone_bricks": {
+    "result": "minecraft:cracked_polished_blackstone_bricks",
+    "ingredient": {
+      "item": "minecraft:polished_blackstone_bricks"
+    },
+    "type": "minecraft:smelting",
+    "experience": 0.1,
+    "properties": {
+      "version": "1.16"
+    },
+    "cookingtime": 200
+  },
   "cracked_stone_bricks": {
     "result": "minecraft:cracked_stone_bricks",
     "ingredient": {
@@ -3751,6 +3945,207 @@
     "properties": {
       "version": "1.14"
     }
+  },
+  "crimson_button": {
+    "result": {
+      "item": "minecraft:crimson_button"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:crimson_planks"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_button"
+  },
+  "crimson_door": {
+    "result": {
+      "item": "minecraft:crimson_door",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:crimson_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_door"
+  },
+  "crimson_fence": {
+    "result": {
+      "item": "minecraft:crimson_fence",
+      "count": 3
+    },
+    "pattern": [
+      "W#W",
+      "W#W"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:stick"
+      },
+      "W": {
+        "item": "minecraft:crimson_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_fence"
+  },
+  "crimson_fence_gate": {
+    "result": {
+      "item": "minecraft:crimson_fence_gate"
+    },
+    "pattern": [
+      "#W#",
+      "#W#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:stick"
+      },
+      "W": {
+        "item": "minecraft:crimson_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_fence_gate"
+  },
+  "crimson_hyphae": {
+    "result": {
+      "item": "minecraft:crimson_hyphae",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:crimson_stem"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "bark"
+  },
+  "crimson_planks": {
+    "result": {
+      "item": "minecraft:crimson_planks",
+      "count": 4
+    },
+    "ingredients": [
+      {
+        "tag": "minecraft:crimson_stems"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.16"
+    },
+    "group": "planks"
+  },
+  "crimson_pressure_plate": {
+    "result": {
+      "item": "minecraft:crimson_pressure_plate"
+    },
+    "pattern": [
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:crimson_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_pressure_plate"
+  },
+  "crimson_sign": {
+    "result": {
+      "item": "minecraft:crimson_sign",
+      "count": 3
+    },
+    "pattern": [
+      "###",
+      "###",
+      " X "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:crimson_planks"
+      },
+      "X": {
+        "item": "minecraft:stick"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "sign"
+  },
+  "crimson_stairs": {
+    "result": {
+      "item": "minecraft:crimson_stairs",
+      "count": 4
+    },
+    "pattern": [
+      "#  ",
+      "## ",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:crimson_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_stairs"
+  },
+  "crimson_trapdoor": {
+    "result": {
+      "item": "minecraft:crimson_trapdoor",
+      "count": 2
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:crimson_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_trapdoor"
   },
   "crossbow": {
     "result": {
@@ -4359,7 +4754,8 @@
     },
     "properties": {
       "version": "1.14"
-    }
+    },
+    "group": "sign"
   },
   "dark_oak_slab": {
     "result": {
@@ -6475,8 +6871,11 @@
     "type": "minecraft:crafting_shaped",
     "key": {
       "#": {
-        "item": "minecraft:cobblestone"
+        "tag": "minecraft:furnace_materials"
       }
+    },
+    "properties": {
+      "animated": true
     }
   },
   "furnace_minecart": {
@@ -6594,7 +6993,7 @@
   "gold_ingot_from_blasting": {
     "result": "minecraft:gold_ingot",
     "ingredient": {
-      "item": "minecraft:gold_ore"
+      "tag": "minecraft:gold_ores"
     },
     "type": "minecraft:blasting",
     "experience": 1,
@@ -8462,7 +8861,8 @@
     },
     "properties": {
       "version": "1.14"
-    }
+    },
+    "group": "sign"
   },
   "jungle_slab": {
     "result": {
@@ -10513,6 +10913,28 @@
       }
     ]
   },
+  "lodestone": {
+    "result": {
+      "item": "minecraft:lodestone"
+    },
+    "pattern": [
+      "SSS",
+      "S#S",
+      "SSS"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "S": {
+        "item": "minecraft:chiseled_stone_bricks"
+      },
+      "#": {
+        "item": "minecraft:netherite_ingot"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
   "loom": {
     "result": {
       "item": "minecraft:loom"
@@ -11495,6 +11917,236 @@
       "version": "1.10"
     }
   },
+  "netherite_axe_smithing": {
+    "result": {
+      "item": "minecraft:netherite_axe"
+    },
+    "type": "minecraft:smithing",
+    "properties": {
+      "version": "1.16"
+    },
+    "base": {
+      "item": "minecraft:diamond_axe"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    }
+  },
+  "netherite_block": {
+    "result": {
+      "item": "minecraft:netherite_block"
+    },
+    "pattern": [
+      "###",
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:netherite_ingot"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "netherite_boots_smithing": {
+    "result": {
+      "item": "minecraft:netherite_boots"
+    },
+    "type": "minecraft:smithing",
+    "properties": {
+      "version": "1.16"
+    },
+    "base": {
+      "item": "minecraft:diamond_boots"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    }
+  },
+  "netherite_chestplate_smithing": {
+    "result": {
+      "item": "minecraft:netherite_chestplate"
+    },
+    "type": "minecraft:smithing",
+    "properties": {
+      "version": "1.16"
+    },
+    "base": {
+      "item": "minecraft:diamond_chestplate"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    }
+  },
+  "netherite_helmet_smithing": {
+    "result": {
+      "item": "minecraft:netherite_helmet"
+    },
+    "type": "minecraft:smithing",
+    "properties": {
+      "version": "1.16"
+    },
+    "base": {
+      "item": "minecraft:diamond_helmet"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    }
+  },
+  "netherite_hoe_smithing": {
+    "result": {
+      "item": "minecraft:netherite_hoe"
+    },
+    "type": "minecraft:smithing",
+    "properties": {
+      "version": "1.16"
+    },
+    "base": {
+      "item": "minecraft:diamond_hoe"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    }
+  },
+  "netherite_ingot": {
+    "result": {
+      "item": "minecraft:netherite_ingot"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:netherite_scrap"
+      },
+      {
+        "item": "minecraft:netherite_scrap"
+      },
+      {
+        "item": "minecraft:netherite_scrap"
+      },
+      {
+        "item": "minecraft:netherite_scrap"
+      },
+      {
+        "item": "minecraft:gold_ingot"
+      },
+      {
+        "item": "minecraft:gold_ingot"
+      },
+      {
+        "item": "minecraft:gold_ingot"
+      },
+      {
+        "item": "minecraft:gold_ingot"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "netherite_ingot"
+  },
+  "netherite_ingot_from_netherite_block": {
+    "result": {
+      "item": "minecraft:netherite_ingot",
+      "count": 9
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:netherite_block"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "netherite_ingot"
+  },
+  "netherite_leggings_smithing": {
+    "result": {
+      "item": "minecraft:netherite_leggings"
+    },
+    "type": "minecraft:smithing",
+    "properties": {
+      "version": "1.16"
+    },
+    "base": {
+      "item": "minecraft:diamond_leggings"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    }
+  },
+  "netherite_pickaxe_smithing": {
+    "result": {
+      "item": "minecraft:netherite_pickaxe"
+    },
+    "type": "minecraft:smithing",
+    "properties": {
+      "version": "1.16"
+    },
+    "base": {
+      "item": "minecraft:diamond_pickaxe"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    }
+  },
+  "netherite_scrap": {
+    "result": "minecraft:netherite_scrap",
+    "ingredient": {
+      "item": "minecraft:ancient_debris"
+    },
+    "type": "minecraft:smelting",
+    "experience": 2,
+    "properties": {
+      "version": "1.16"
+    },
+    "cookingtime": 200
+  },
+  "netherite_scrap_from_blasting": {
+    "result": "minecraft:netherite_scrap",
+    "ingredient": {
+      "item": "minecraft:ancient_debris"
+    },
+    "type": "minecraft:blasting",
+    "experience": 2,
+    "properties": {
+      "version": "1.16"
+    },
+    "cookingtime": 100
+  },
+  "netherite_shovel_smithing": {
+    "result": {
+      "item": "minecraft:netherite_shovel"
+    },
+    "type": "minecraft:smithing",
+    "properties": {
+      "version": "1.16"
+    },
+    "base": {
+      "item": "minecraft:diamond_shovel"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    }
+  },
+  "netherite_sword_smithing": {
+    "result": {
+      "item": "minecraft:netherite_sword"
+    },
+    "type": "minecraft:smithing",
+    "properties": {
+      "version": "1.16"
+    },
+    "base": {
+      "item": "minecraft:diamond_sword"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    }
+  },
   "night_vision_lingering_potion": {
     "result": "minecraft.lingering_potion.effect.night_vision",
     "reagent": {
@@ -11709,7 +12361,8 @@
       "X": {
         "item": "minecraft:stick"
       }
-    }
+    },
+    "group": "sign"
   },
   "oak_slab": {
     "result": {
@@ -12642,6 +13295,417 @@
       "version": "1.14"
     }
   },
+  "polished_basalt": {
+    "result": {
+      "item": "minecraft:polished_basalt",
+      "count": 4
+    },
+    "pattern": [
+      "SS",
+      "SS"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "S": {
+        "item": "minecraft:basalt"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_basalt_from_basalt_stonecutting": {
+    "result": "minecraft:polished_basalt",
+    "ingredient": {
+      "item": "minecraft:basalt"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone": {
+    "result": {
+      "item": "minecraft:polished_blackstone",
+      "count": 4
+    },
+    "pattern": [
+      "SS",
+      "SS"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "S": {
+        "item": "minecraft:blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_brick_slab": {
+    "result": {
+      "item": "minecraft:polished_blackstone_brick_slab",
+      "count": 6
+    },
+    "pattern": [
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:polished_blackstone_bricks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_brick_slab_from_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_brick_slab",
+    "ingredient": {
+      "item": "minecraft:blackstone"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_brick_slab_from_polished_blackstone_bricks_stonecutting": {
+    "result": "minecraft:polished_blackstone_brick_slab",
+    "ingredient": {
+      "item": "minecraft:polished_blackstone_bricks"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_brick_slab_from_polished_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_brick_slab",
+    "ingredient": {
+      "item": "minecraft:polished_blackstone"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_brick_stairs": {
+    "result": {
+      "item": "minecraft:polished_blackstone_brick_stairs",
+      "count": 4
+    },
+    "pattern": [
+      "#  ",
+      "## ",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:polished_blackstone_bricks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_brick_stairs_from_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_brick_stairs",
+    "ingredient": {
+      "item": "minecraft:blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_brick_stairs_from_polished_blackstone_bricks_stonecutting": {
+    "result": "minecraft:polished_blackstone_brick_stairs",
+    "ingredient": {
+      "item": "minecraft:polished_blackstone_bricks"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_brick_stairs_from_polished_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_brick_stairs",
+    "ingredient": {
+      "item": "minecraft:polished_blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_brick_wall": {
+    "result": {
+      "item": "minecraft:polished_blackstone_brick_wall",
+      "count": 6
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:polished_blackstone_bricks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_brick_wall_from_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_brick_wall",
+    "ingredient": {
+      "item": "minecraft:blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_brick_wall_from_polished_blackstone_bricks_stonecutting": {
+    "result": "minecraft:polished_blackstone_brick_wall",
+    "ingredient": {
+      "item": "minecraft:polished_blackstone_bricks"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_brick_wall_from_polished_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_brick_wall",
+    "ingredient": {
+      "item": "minecraft:polished_blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_bricks": {
+    "result": {
+      "item": "minecraft:polished_blackstone_bricks",
+      "count": 4
+    },
+    "pattern": [
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:polished_blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_bricks_from_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_bricks",
+    "ingredient": {
+      "item": "minecraft:blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_bricks_from_polished_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_bricks",
+    "ingredient": {
+      "item": "minecraft:polished_blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_button": {
+    "result": {
+      "item": "minecraft:polished_blackstone_button"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:polished_blackstone"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_from_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone",
+    "ingredient": {
+      "item": "minecraft:blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_pressure_plate": {
+    "result": {
+      "item": "minecraft:polished_blackstone_pressure_plate"
+    },
+    "pattern": [
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:polished_blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_slab": {
+    "result": {
+      "item": "minecraft:polished_blackstone_slab",
+      "count": 6
+    },
+    "pattern": [
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:polished_blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_slab_from_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_slab",
+    "ingredient": {
+      "item": "minecraft:blackstone"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_slab_from_polished_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_slab",
+    "ingredient": {
+      "item": "minecraft:polished_blackstone"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_stairs": {
+    "result": {
+      "item": "minecraft:polished_blackstone_stairs",
+      "count": 4
+    },
+    "pattern": [
+      "#  ",
+      "## ",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:polished_blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_stairs_from_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_stairs",
+    "ingredient": {
+      "item": "minecraft:blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_stairs_from_polished_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_stairs",
+    "ingredient": {
+      "item": "minecraft:polished_blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_wall": {
+    "result": {
+      "item": "minecraft:polished_blackstone_wall",
+      "count": 6
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:polished_blackstone"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_wall_from_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_wall",
+    "ingredient": {
+      "item": "minecraft:blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "polished_blackstone_wall_from_polished_blackstone_stonecutting": {
+    "result": "minecraft:polished_blackstone_wall",
+    "ingredient": {
+      "item": "minecraft:polished_blackstone"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
   "polished_diorite": {
     "result": {
       "item": "minecraft:polished_diorite",
@@ -13542,6 +14606,36 @@
       }
     }
   },
+  "quartz_bricks": {
+    "result": {
+      "item": "minecraft:quartz_bricks",
+      "count": 4
+    },
+    "pattern": [
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:quartz_block"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "quartz_bricks_from_quartz_block_stonecutting": {
+    "result": "minecraft:quartz_bricks",
+    "ingredient": {
+      "item": "minecraft:quartz_block"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.16"
+    }
+  },
   "quartz_from_blasting": {
     "result": "minecraft:quartz",
     "ingredient": {
@@ -13667,11 +14761,6 @@
     "result": {
       "item": "minecraft:rabbit_stew"
     },
-    "pattern": [
-      " R ",
-      "CPM",
-      " B "
-    ],
     "ingredients": [
       {
         "item": "minecraft:baked_potato"
@@ -13693,23 +14782,6 @@
     "lang": {
       "en_US": {
         "notes": "Before 1.14, recipe is shaped."
-      }
-    },
-    "key": {
-      "P": {
-        "item": "minecraft:baked_potato"
-      },
-      "R": {
-        "item": "minecraft:cooked_rabbit"
-      },
-      "B": {
-        "item": "minecraft:bowl"
-      },
-      "C": {
-        "item": "minecraft:carrot"
-      },
-      "M": {
-        "item": "minecraft:brown_mushroom"
       }
     },
     "properties": {
@@ -13721,11 +14793,6 @@
     "result": {
       "item": "minecraft:rabbit_stew"
     },
-    "pattern": [
-      " R ",
-      "CPM",
-      " B "
-    ],
     "ingredients": [
       {
         "item": "minecraft:baked_potato"
@@ -13747,23 +14814,6 @@
     "lang": {
       "en_US": {
         "notes": "Before 1.14, recipe is shaped."
-      }
-    },
-    "key": {
-      "P": {
-        "item": "minecraft:baked_potato"
-      },
-      "R": {
-        "item": "minecraft:cooked_rabbit"
-      },
-      "B": {
-        "item": "minecraft:bowl"
-      },
-      "C": {
-        "item": "minecraft:carrot"
-      },
-      "M": {
-        "item": "minecraft:red_mushroom"
       }
     },
     "properties": {
@@ -14461,6 +15511,28 @@
       "I": {
         "item": "minecraft:stone"
       }
+    }
+  },
+  "respawn_anchor": {
+    "result": {
+      "item": "minecraft:respawn_anchor"
+    },
+    "pattern": [
+      "OOO",
+      "GGG",
+      "OOO"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "G": {
+        "item": "minecraft:glowstone"
+      },
+      "O": {
+        "item": "minecraft:crying_obsidian"
+      }
+    },
+    "properties": {
+      "version": "1.16"
     }
   },
   "sandstone": {
@@ -16461,6 +17533,86 @@
       }
     }
   },
+  "soul_campfire": {
+    "result": {
+      "item": "minecraft:soul_campfire"
+    },
+    "pattern": [
+      " S ",
+      "S#S",
+      "LLL"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "S": {
+        "item": "minecraft:stick"
+      },
+      "#": {
+        "tag": "minecraft:soul_fire_base_blocks"
+      },
+      "L": {
+        "tag": "minecraft:logs"
+      }
+    },
+    "properties": {
+      "animated": true,
+      "version": "1.16"
+    }
+  },
+  "soul_lantern": {
+    "result": {
+      "item": "minecraft:soul_lantern"
+    },
+    "pattern": [
+      "XXX",
+      "X#X",
+      "XXX"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:soul_torch"
+      },
+      "X": {
+        "item": "minecraft:iron_nugget"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "soul_torch": {
+    "result": {
+      "item": "minecraft:soul_torch",
+      "count": 4
+    },
+    "pattern": [
+      "X",
+      "#",
+      "S"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:stick"
+      },
+      "S": {
+        "tag": "minecraft:soul_fire_base_blocks"
+      },
+      "X": [
+        {
+          "item": "minecraft:coal"
+        },
+        {
+          "item": "minecraft:charcoal"
+        }
+      ]
+    },
+    "properties": {
+      "animated": true,
+      "version": "1.16"
+    }
+  },
   "spectral_arrow": {
     "result": {
       "item": "minecraft:spectral_arrow",
@@ -17131,13 +18283,13 @@
     },
     "type": "minecraft.smelting_special_sponge",
     "experience": 0.15,
-    "properties": {
-      "version": "1.8"
-    },
     "lang": {
       "en_US": {
         "notes": "The empty bucket is filled with water after smelting."
       }
+    },
+    "properties": {
+      "version": "1.8"
     },
     "cookingtime": 200
   },
@@ -17296,7 +18448,8 @@
     },
     "properties": {
       "version": "1.14"
-    }
+    },
+    "group": "sign"
   },
   "spruce_slab": {
     "result": {
@@ -17453,8 +18606,11 @@
         "item": "minecraft:stick"
       },
       "X": {
-        "item": "minecraft:cobblestone"
+        "tag": "minecraft:stone_tool_materials"
       }
+    },
+    "properties": {
+      "animated": true
     }
   },
   "stone_brick_slab": {
@@ -17627,8 +18783,11 @@
         "item": "minecraft:stick"
       },
       "X": {
-        "item": "minecraft:cobblestone"
+        "tag": "minecraft:stone_tool_materials"
       }
+    },
+    "properties": {
+      "animated": true
     }
   },
   "stone_pickaxe": {
@@ -17646,8 +18805,11 @@
         "item": "minecraft:stick"
       },
       "X": {
-        "item": "minecraft:cobblestone"
+        "tag": "minecraft:stone_tool_materials"
       }
+    },
+    "properties": {
+      "animated": true
     }
   },
   "stone_pressure_plate": {
@@ -17679,8 +18841,11 @@
         "item": "minecraft:stick"
       },
       "X": {
-        "item": "minecraft:cobblestone"
+        "tag": "minecraft:stone_tool_materials"
       }
+    },
+    "properties": {
+      "animated": true
     }
   },
   "stone_slab": {
@@ -17758,8 +18923,11 @@
         "item": "minecraft:stick"
       },
       "X": {
-        "item": "minecraft:cobblestone"
+        "tag": "minecraft:stone_tool_materials"
       }
+    },
+    "properties": {
+      "animated": true
     }
   },
   "stonecutter": {
@@ -17856,6 +19024,26 @@
     },
     "group": "bark"
   },
+  "stripped_crimson_hyphae": {
+    "result": {
+      "item": "minecraft:stripped_crimson_hyphae",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:stripped_crimson_stem"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "bark"
+  },
   "stripped_dark_oak_wood": {
     "result": {
       "item": "minecraft:stripped_dark_oak_wood",
@@ -17933,6 +19121,26 @@
     },
     "properties": {
       "version": "1.15"
+    },
+    "group": "bark"
+  },
+  "stripped_warped_hyphae": {
+    "result": {
+      "item": "minecraft:stripped_warped_hyphae",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:stripped_warped_stem"
+      }
+    },
+    "properties": {
+      "version": "1.16"
     },
     "group": "bark"
   },
@@ -18062,6 +19270,28 @@
     "type": "minecraft.brewing",
     "base": {
       "item": "minecraft.potion.effect.swiftness"
+    }
+  },
+  "target": {
+    "result": {
+      "item": "minecraft:target"
+    },
+    "pattern": [
+      " R ",
+      "RHR",
+      " R "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "R": {
+        "item": "minecraft:redstone"
+      },
+      "H": {
+        "item": "minecraft:hay_block"
+      }
+    },
+    "properties": {
+      "version": "1.16"
     }
   },
   "terracotta": {
@@ -18405,46 +19635,6 @@
       "version": "1.9"
     }
   },
-  "tipped_arrow_luck_extended": {
-    "result": {
-      "item": "minecraft.tipped_arrow.effect.luck.extended",
-      "count": 8
-    },
-    "pattern": [
-      "AAA",
-      "APA",
-      "AAA"
-    ],
-    "type": "minecraft:crafting_special_tippedarrow",
-    "key": {
-      "P": {
-        "item": "minecraft.lingering_potion.effect.luck.extended"
-      },
-      "A": {
-        "item": "minecraft:arrow"
-      }
-    }
-  },
-  "tipped_arrow_luck_ii": {
-    "result": {
-      "item": "minecraft.tipped_arrow.effect.luck.ii",
-      "count": 8
-    },
-    "pattern": [
-      "AAA",
-      "APA",
-      "AAA"
-    ],
-    "type": "minecraft:crafting_special_tippedarrow",
-    "key": {
-      "P": {
-        "item": "minecraft.lingering_potion.effect.luck.ii"
-      },
-      "A": {
-        "item": "minecraft:arrow"
-      }
-    }
-  },
   "tipped_arrow_mundane": {
     "result": {
       "item": "minecraft.tipped_arrow.effect.mundane",
@@ -18758,6 +19948,29 @@
     "key": {
       "P": {
         "item": "minecraft.lingering_potion.effect.slowness.extended"
+      },
+      "A": {
+        "item": "minecraft:arrow"
+      }
+    },
+    "properties": {
+      "version": "1.9"
+    }
+  },
+  "tipped_arrow_slowness_iv": {
+    "result": {
+      "item": "minecraft.tipped_arrow.effect.slowness.iv",
+      "count": 8
+    },
+    "pattern": [
+      "AAA",
+      "APA",
+      "AAA"
+    ],
+    "type": "minecraft:crafting_special_tippedarrow",
+    "key": {
+      "P": {
+        "item": "minecraft.lingering_potion.effect.slowness.iv"
       },
       "A": {
         "item": "minecraft:arrow"
@@ -19282,6 +20495,247 @@
     "base": {
       "item": "minecraft.potion.effect.turtle_master"
     }
+  },
+  "warped_button": {
+    "result": {
+      "item": "minecraft:warped_button"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:warped_planks"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_button"
+  },
+  "warped_door": {
+    "result": {
+      "item": "minecraft:warped_door",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:warped_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_door"
+  },
+  "warped_fence": {
+    "result": {
+      "item": "minecraft:warped_fence",
+      "count": 3
+    },
+    "pattern": [
+      "W#W",
+      "W#W"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:stick"
+      },
+      "W": {
+        "item": "minecraft:warped_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_fence"
+  },
+  "warped_fence_gate": {
+    "result": {
+      "item": "minecraft:warped_fence_gate"
+    },
+    "pattern": [
+      "#W#",
+      "#W#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:stick"
+      },
+      "W": {
+        "item": "minecraft:warped_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_fence_gate"
+  },
+  "warped_fungus_on_a_stick": {
+    "result": {
+      "item": "minecraft:warped_fungus_on_a_stick"
+    },
+    "pattern": [
+      "# ",
+      " X"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:fishing_rod"
+      },
+      "X": {
+        "item": "minecraft:warped_fungus"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    }
+  },
+  "warped_hyphae": {
+    "result": {
+      "item": "minecraft:warped_hyphae",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:warped_stem"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "bark"
+  },
+  "warped_planks": {
+    "result": {
+      "item": "minecraft:warped_planks",
+      "count": 4
+    },
+    "ingredients": [
+      {
+        "tag": "minecraft:warped_stems"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.16"
+    },
+    "group": "planks"
+  },
+  "warped_pressure_plate": {
+    "result": {
+      "item": "minecraft:warped_pressure_plate"
+    },
+    "pattern": [
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:warped_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_pressure_plate"
+  },
+  "warped_sign": {
+    "result": {
+      "item": "minecraft:warped_sign",
+      "count": 3
+    },
+    "pattern": [
+      "###",
+      "###",
+      " X "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:warped_planks"
+      },
+      "X": {
+        "item": "minecraft:stick"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "sign"
+  },
+  "warped_slab": {
+    "result": {
+      "item": "minecraft:warped_slab",
+      "count": 6
+    },
+    "pattern": [
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:warped_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_slab"
+  },
+  "warped_stairs": {
+    "result": {
+      "item": "minecraft:warped_stairs",
+      "count": 4
+    },
+    "pattern": [
+      "#  ",
+      "## ",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:warped_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_stairs"
+  },
+  "warped_trapdoor": {
+    "result": {
+      "item": "minecraft:warped_trapdoor",
+      "count": 2
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:warped_planks"
+      }
+    },
+    "properties": {
+      "version": "1.16"
+    },
+    "group": "wooden_trapdoor"
   },
   "water_breathing_lingering_potion": {
     "result": "minecraft.lingering_potion.effect.water_breathing",

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -40,7 +40,7 @@ public class Bot {
 	public static final String helpServer = "https://minecord.github.io/support";
 	public static final String website = "https://minecord.github.io";
 	public static final String github = "https://github.com/Tisawesomeness/Minecord";
-	private static final String version = "0.10.1";
+	private static final String version = "0.11.0";
 	public static final String javaVersion = "1.8";
 	public static final String jdaVersion = "4.1.1_151";
 	public static final Color color = Color.GREEN;

--- a/src/com/tisawesomeness/minecord/ReactListener.java
+++ b/src/com/tisawesomeness/minecord/ReactListener.java
@@ -7,6 +7,7 @@ import com.tisawesomeness.minecord.ReactMenu.Emote;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.MessageReaction.ReactionEmote;
+import net.dv8tion.jda.api.events.message.MessageEmbedEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
@@ -42,6 +43,19 @@ public class ReactListener extends ListenerAdapter {
             }
         }
     }
+
+    @Override
+    public void onMessageEmbed(MessageEmbedEvent e) {
+        // If embed was removed
+        if (e.getMessageEmbeds().size() == 0) {
+            HashMap<Long, ReactMenu> menus = ReactMenu.getMenus();
+            // If valid menu, delete
+            if (menus.containsKey(e.getMessageIdLong())) {
+                menus.get(e.getMessageIdLong()).disable(true);
+            }
+        }
+    }
+
     /**
      * Removes an emote, whitelisting stars for starboard purposes
      * @param e

--- a/src/com/tisawesomeness/minecord/item/Item.java
+++ b/src/com/tisawesomeness/minecord/item/Item.java
@@ -95,6 +95,9 @@ public class Item {
         if (langObj.has("previously")) {
             prevString += " " + langObj.getString("previously");
             changed = true;
+            if (langObj.has("previously2")) {
+                prevString += ", " + langObj.getString("previously2");
+            }
         }
         if (changed) {
             sb.append(prevString).append("\n");
@@ -138,12 +141,8 @@ public class Item {
         }
 
         // Sprite
-        String imageKey = displayName;
-        if (properties != null && properties.has("image_key")) {
-            imageKey = properties.getString("image_key");
-        }
         try {
-            eb.setThumbnail(new URI("https", "minecord.github.io", String.format("/item/%s.png", imageKey), null).toASCIIString());
+            eb.setThumbnail(new URI("https", "minecord.github.io", String.format("/item/%s.png", getImageKey(item)), null).toASCIIString());
         } catch (URISyntaxException ex) {
             ex.printStackTrace();
         }
@@ -165,6 +164,17 @@ public class Item {
             return searchIDs(toMatch);
         } else if (Character.isDigit(toMatch.charAt(0))) {
             return searchNumerical(toMatch, lang);
+        }
+        // Default potions special case
+        String prepped = toMatch.replace("_", " ").replace(".", " ");
+        if (prepped.equalsIgnoreCase("potion")) {
+            return "minecraft.potion.effect.water";
+        } else if (prepped.equalsIgnoreCase("splash potion")) {
+            return "minecraft.splash_potion.effect.water";
+        } else if (prepped.equalsIgnoreCase("lingering potion")) {
+            return "minecraft.lingering_potion.effect.water";
+        } else if (prepped.equalsIgnoreCase("tipped arrow")) {
+            return "minecraft.tipped_arrow.effect.water";
         }
         return searchGeneral(toMatch, lang);
     }
@@ -374,6 +384,7 @@ public class Item {
             toCheck.add(langObj.optString("block_name"));
             if (!langObj.has("previous_conflict")) {
                 toCheck.add(langObj.optString("previously"));
+                toCheck.add(langObj.optString("previously2"));
             }
             // All the custom search names
             if (langObj.has("search_names")) {
@@ -396,6 +407,7 @@ public class Item {
                 
             }
             // Equals ignore case
+            toCheck.removeIf(t -> t == null);
             toCheck.replaceAll(t -> t.toLowerCase());
             if (toCheck.contains(id)) {
                 return true;
@@ -469,6 +481,19 @@ public class Item {
     private static int getID(String item) {
         JSONObject properties = items.getJSONObject(item).optJSONObject("properties");
         return properties == null ? null : properties.optInt("id", -1);
+    }
+
+    /**
+     * Gets the name of the image file used for an item
+     * @param item The item key
+     * @return The image filename, without the extension or URL
+     */
+    private static String getImageKey(String item) {
+        JSONObject properties = items.getJSONObject(item).optJSONObject("properties");
+        if (properties != null && properties.has("image_key")) {
+            return properties.getString("image_key");
+        }
+        return getDisplayName(item, "en_US");
     }
 
 }

--- a/src/com/tisawesomeness/minecord/item/Recipe.java
+++ b/src/com/tisawesomeness/minecord/item/Recipe.java
@@ -109,6 +109,9 @@ public class Recipe {
         "minecraft:crafting_special_firework_star", "minecraft:crafting_special_firework_star_fade", "minecraft:crafting_special_firework_rocket",
         "minecraft:crafting_special_shulkerboxcoloring", "minecraft:crafting_special_suspiciousstew"
     );
+    private static List<String> otherTypes = Arrays.asList(
+        "minecraft:stonecutting", "minecraft.brewing", "minecraft:smithing"
+    );
     /**
      * Checks if a recipe type is crafting
      * @param type The type string
@@ -128,7 +131,7 @@ public class Recipe {
      * @param type The type string
      */
     private static boolean isValidType(String type) {
-        return isCrafting(type) || isSmelting(type) || type.equals("minecraft:stonecutting") || type.equals("minecraft.brewing");
+        return isCrafting(type) || isSmelting(type) || otherTypes.contains(type);
     }
 
     /**
@@ -272,6 +275,10 @@ public class Recipe {
             } else {
                 ingredients.add(base.getString("item"));
             }
+        // Smithing recipes
+        } else if (type.equals("minecraft:smithing")) {
+            ingredients.add(recipe.getJSONObject("base").getString("item"));
+            ingredients.add(recipe.getJSONObject("addition").getString("item"));
         }
         return ingredients;
     }
@@ -467,6 +474,8 @@ public class Recipe {
                     item = "minecraft.stonecutter"; break;
                 case "minecraft.brewing":
                     item = "minecraft.brewing_stand"; break;
+                case "minecraft:smithing":
+                    item = "minecraft.smithing_table"; break;
                 default:
                     item = "minecraft.crafting_table";
             }
@@ -528,7 +537,7 @@ public class Recipe {
                 c = 1;
             }
             // Find how to craft each ingredient
-            if (isCrafting(type) || isSmelting(type) || type.equals("minecraft.brewing")) {
+            if (isCrafting(type) || isSmelting(type) || type.equals("minecraft.brewing") || type.equals("minecraft:smithing")) {
                 LinkedHashSet<String> ingredientsSet = getIngredients(recipeObj);
                 if (type.equals("minecraft.brewing")) {
                     if (ingredientsSet.contains("minecraft:blaze_powder")) {

--- a/tags.json
+++ b/tags.json
@@ -1,397 +1,518 @@
 {
-    "acacia_logs": [
-      "minecraft:acacia_log",
-      "minecraft:acacia_wood",
-      "minecraft:stripped_acacia_log",
-      "minecraft:stripped_acacia_wood"
-    ],
-    "wooden_buttons": [
-      "minecraft:oak_button",
-      "minecraft:spruce_button",
-      "minecraft:birch_button",
-      "minecraft:jungle_button",
-      "minecraft:acacia_button",
-      "minecraft:dark_oak_button"
-    ],
-    "carpets": [
-      "minecraft:white_carpet",
-      "minecraft:orange_carpet",
-      "minecraft:magenta_carpet",
-      "minecraft:light_blue_carpet",
-      "minecraft:yellow_carpet",
-      "minecraft:lime_carpet",
-      "minecraft:pink_carpet",
-      "minecraft:gray_carpet",
-      "minecraft:light_gray_carpet",
-      "minecraft:cyan_carpet",
-      "minecraft:purple_carpet",
-      "minecraft:blue_carpet",
-      "minecraft:brown_carpet",
-      "minecraft:green_carpet",
-      "minecraft:red_carpet",
-      "minecraft:black_carpet"
-    ],
-    "wool": [
-      "minecraft:white_wool",
-      "minecraft:orange_wool",
-      "minecraft:magenta_wool",
-      "minecraft:light_blue_wool",
-      "minecraft:yellow_wool",
-      "minecraft:lime_wool",
-      "minecraft:pink_wool",
-      "minecraft:gray_wool",
-      "minecraft:light_gray_wool",
-      "minecraft:cyan_wool",
-      "minecraft:purple_wool",
-      "minecraft:blue_wool",
-      "minecraft:brown_wool",
-      "minecraft:green_wool",
-      "minecraft:red_wool",
-      "minecraft:black_wool"
-    ],
-    "anvil": [
-      "minecraft:anvil",
-      "minecraft:chipped_anvil",
-      "minecraft:damaged_anvil"
-    ],
-    "music_discs": [
-      "minecraft:music_disc_13",
-      "minecraft:music_disc_cat",
-      "minecraft:music_disc_blocks",
-      "minecraft:music_disc_chirp",
-      "minecraft:music_disc_far",
-      "minecraft:music_disc_mall",
-      "minecraft:music_disc_mellohi",
-      "minecraft:music_disc_stal",
-      "minecraft:music_disc_strad",
-      "minecraft:music_disc_ward",
-      "minecraft:music_disc_11",
-      "minecraft:music_disc_wait"
-    ],
-    "stairs": [
-      "minecraft:oak_stairs",
-      "minecraft:cobblestone_stairs",
-      "minecraft:spruce_stairs",
-      "minecraft:sandstone_stairs",
-      "minecraft:acacia_stairs",
-      "minecraft:jungle_stairs",
-      "minecraft:birch_stairs",
-      "minecraft:dark_oak_stairs",
-      "minecraft:nether_brick_stairs",
-      "minecraft:stone_brick_stairs",
-      "minecraft:brick_stairs",
-      "minecraft:purpur_stairs",
-      "minecraft:quartz_stairs",
-      "minecraft:red_sandstone_stairs",
-      "minecraft:prismarine_brick_stairs",
-      "minecraft:prismarine_stairs",
-      "minecraft:dark_prismarine_stairs",
-      "minecraft:polished_granite_stairs",
-      "minecraft:smooth_red_sandstone_stairs",
-      "minecraft:mossy_stone_brick_stairs",
-      "minecraft:polished_diorite_stairs",
-      "minecraft:mossy_cobblestone_stairs",
-      "minecraft:end_stone_brick_stairs",
-      "minecraft:stone_stairs",
-      "minecraft:smooth_sandstone_stairs",
-      "minecraft:smooth_quartz_stairs",
-      "minecraft:granite_stairs",
-      "minecraft:andesite_stairs",
-      "minecraft:red_nether_brick_stairs",
-      "minecraft:polished_andesite_stairs",
-      "minecraft:diorite_stairs"
-    ],
-    "arrows": [
-      "minecraft:arrow",
-      "minecraft:tipped_arrow",
-      "minecraft:spectral_arrow"
-    ],
-    "stone_bricks": [
-      "minecraft:stone_bricks",
-      "minecraft:mossy_stone_bricks",
-      "minecraft:cracked_stone_bricks",
-      "minecraft:chiseled_stone_bricks"
-    ],
-    "fishes": [
-      "minecraft:cod",
-      "minecraft:cooked_cod",
-      "minecraft:salmon",
-      "minecraft:cooked_salmon",
-      "minecraft:pufferfish",
-      "minecraft:tropical_fish"
-    ],
-    "tall_flowers": [
-      "minecraft:sunflower",
-      "minecraft:lilac",
-      "minecraft:peony",
-      "minecraft:rose_bush"
-    ],
-    "signs": [
-      "minecraft:oak_sign",
-      "minecraft:spruce_sign",
-      "minecraft:birch_sign",
-      "minecraft:acacia_sign",
-      "minecraft:jungle_sign",
-      "minecraft:dark_oak_sign"
-    ],
-    "walls": [
-      "minecraft:cobblestone_wall",
-      "minecraft:mossy_cobblestone_wall",
-      "minecraft:brick_wall",
-      "minecraft:prismarine_wall",
-      "minecraft:red_sandstone_wall",
-      "minecraft:mossy_stone_brick_wall",
-      "minecraft:granite_wall",
-      "minecraft:stone_brick_wall",
-      "minecraft:nether_brick_wall",
-      "minecraft:andesite_wall",
-      "minecraft:red_nether_brick_wall",
-      "minecraft:sandstone_wall",
-      "minecraft:end_stone_brick_wall",
-      "minecraft:diorite_wall"
-    ],
-    "leaves": [
-      "minecraft:jungle_leaves",
-      "minecraft:oak_leaves",
-      "minecraft:spruce_leaves",
-      "minecraft:dark_oak_leaves",
-      "minecraft:acacia_leaves",
-      "minecraft:birch_leaves"
-    ],
-    "wooden_stairs": [
-      "minecraft:oak_stairs",
-      "minecraft:spruce_stairs",
-      "minecraft:birch_stairs",
-      "minecraft:jungle_stairs",
-      "minecraft:acacia_stairs",
-      "minecraft:dark_oak_stairs"
-    ],
-    "rails": [
-      "minecraft:rail",
-      "minecraft:powered_rail",
-      "minecraft:detector_rail",
-      "minecraft:activator_rail"
-    ],
-    "jungle_logs": [
-      "minecraft:jungle_log",
-      "minecraft:jungle_wood",
-      "minecraft:stripped_jungle_log",
-      "minecraft:stripped_jungle_wood"
-    ],
-    "coals": [
-      "minecraft:coal",
-      "minecraft:charcoal"
-    ],
-    "lectern_books": [
-      "minecraft:written_book",
-      "minecraft:writable_book"
-    ],
-    "spruce_logs": [
-      "minecraft:spruce_log",
-      "minecraft:spruce_wood",
-      "minecraft:stripped_spruce_log",
-      "minecraft:stripped_spruce_wood"
-    ],
-    "logs": [
-      "#minecraft:dark_oak_logs",
-      "#minecraft:oak_logs",
-      "#minecraft:acacia_logs",
-      "#minecraft:birch_logs",
-      "#minecraft:jungle_logs",
-      "#minecraft:spruce_logs"
-    ],
-    "wooden_pressure_plates": [
-      "minecraft:oak_pressure_plate",
-      "minecraft:spruce_pressure_plate",
-      "minecraft:birch_pressure_plate",
-      "minecraft:jungle_pressure_plate",
-      "minecraft:acacia_pressure_plate",
-      "minecraft:dark_oak_pressure_plate"
-    ],
-    "trapdoors": [
-      "#minecraft:wooden_trapdoors",
-      "minecraft:iron_trapdoor"
-    ],
-    "wooden_fences": [
-      "minecraft:oak_fence",
-      "minecraft:spruce_fence",
-      "minecraft:birch_fence",
-      "minecraft:jungle_fence",
-      "minecraft:acacia_fence",
-      "minecraft:dark_oak_fence"
-    ],
-    "flowers": [
-      "#minecraft:small_flowers",
-      "#minecraft:tall_flowers"
-    ],
-    "buttons": [
-      "#minecraft:wooden_buttons",
-      "minecraft:stone_button"
-    ],
-    "wooden_slabs": [
-      "minecraft:oak_slab",
-      "minecraft:spruce_slab",
-      "minecraft:birch_slab",
-      "minecraft:jungle_slab",
-      "minecraft:acacia_slab",
-      "minecraft:dark_oak_slab"
-    ],
-    "boats": [
-      "minecraft:oak_boat",
-      "minecraft:spruce_boat",
-      "minecraft:birch_boat",
-      "minecraft:jungle_boat",
-      "minecraft:acacia_boat",
-      "minecraft:dark_oak_boat"
-    ],
-    "small_flowers": [
-      "minecraft:dandelion",
-      "minecraft:poppy",
-      "minecraft:blue_orchid",
-      "minecraft:allium",
-      "minecraft:azure_bluet",
-      "minecraft:red_tulip",
-      "minecraft:orange_tulip",
-      "minecraft:white_tulip",
-      "minecraft:pink_tulip",
-      "minecraft:oxeye_daisy",
-      "minecraft:cornflower",
-      "minecraft:lily_of_the_valley",
-      "minecraft:wither_rose"
-    ],
-    "banners": [
-      "minecraft:white_banner",
-      "minecraft:orange_banner",
-      "minecraft:magenta_banner",
-      "minecraft:light_blue_banner",
-      "minecraft:yellow_banner",
-      "minecraft:lime_banner",
-      "minecraft:pink_banner",
-      "minecraft:gray_banner",
-      "minecraft:light_gray_banner",
-      "minecraft:cyan_banner",
-      "minecraft:purple_banner",
-      "minecraft:blue_banner",
-      "minecraft:brown_banner",
-      "minecraft:green_banner",
-      "minecraft:red_banner",
-      "minecraft:black_banner"
-    ],
-    "dark_oak_logs": [
-      "minecraft:dark_oak_log",
-      "minecraft:dark_oak_wood",
-      "minecraft:stripped_dark_oak_log",
-      "minecraft:stripped_dark_oak_wood"
-    ],
-    "planks": [
-      "minecraft:oak_planks",
-      "minecraft:spruce_planks",
-      "minecraft:birch_planks",
-      "minecraft:jungle_planks",
-      "minecraft:acacia_planks",
-      "minecraft:dark_oak_planks"
-    ],
-    "doors": [
-      "#minecraft:wooden_doors",
-      "minecraft:iron_door"
-    ],
-    "wooden_trapdoors": [
-      "minecraft:acacia_trapdoor",
-      "minecraft:birch_trapdoor",
-      "minecraft:dark_oak_trapdoor",
-      "minecraft:jungle_trapdoor",
-      "minecraft:oak_trapdoor",
-      "minecraft:spruce_trapdoor"
-    ],
-    "sand": [
-      "minecraft:sand",
-      "minecraft:red_sand"
-    ],
-    "fences": [
-      "#minecraft:wooden_fences",
-      "minecraft:nether_brick_fence"
-    ],
-    "oak_logs": [
-      "minecraft:oak_log",
-      "minecraft:oak_wood",
-      "minecraft:stripped_oak_log",
-      "minecraft:stripped_oak_wood"
-    ],
-    "wooden_doors": [
-      "minecraft:oak_door",
-      "minecraft:spruce_door",
-      "minecraft:birch_door",
-      "minecraft:jungle_door",
-      "minecraft:acacia_door",
-      "minecraft:dark_oak_door"
-    ],
-    "beds": [
-      "minecraft:red_bed",
-      "minecraft:black_bed",
-      "minecraft:blue_bed",
-      "minecraft:brown_bed",
-      "minecraft:cyan_bed",
-      "minecraft:gray_bed",
-      "minecraft:green_bed",
-      "minecraft:light_blue_bed",
-      "minecraft:light_gray_bed",
-      "minecraft:lime_bed",
-      "minecraft:magenta_bed",
-      "minecraft:orange_bed",
-      "minecraft:pink_bed",
-      "minecraft:purple_bed",
-      "minecraft:white_bed",
-      "minecraft:yellow_bed"
-    ],
-    "birch_logs": [
-      "minecraft:birch_log",
-      "minecraft:birch_wood",
-      "minecraft:stripped_birch_log",
-      "minecraft:stripped_birch_wood"
-    ],
-    "saplings": [
-      "minecraft:oak_sapling",
-      "minecraft:spruce_sapling",
-      "minecraft:birch_sapling",
-      "minecraft:jungle_sapling",
-      "minecraft:acacia_sapling",
-      "minecraft:dark_oak_sapling"
-    ],
-    "slabs": [
-      "minecraft:stone_slab",
-      "minecraft:smooth_stone_slab",
-      "minecraft:stone_brick_slab",
-      "minecraft:sandstone_slab",
-      "minecraft:acacia_slab",
-      "minecraft:birch_slab",
-      "minecraft:dark_oak_slab",
-      "minecraft:jungle_slab",
-      "minecraft:oak_slab",
-      "minecraft:spruce_slab",
-      "minecraft:purpur_slab",
-      "minecraft:quartz_slab",
-      "minecraft:red_sandstone_slab",
-      "minecraft:brick_slab",
-      "minecraft:cobblestone_slab",
-      "minecraft:nether_brick_slab",
-      "minecraft:petrified_oak_slab",
-      "minecraft:prismarine_slab",
-      "minecraft:prismarine_brick_slab",
-      "minecraft:dark_prismarine_slab",
-      "minecraft:polished_granite_slab",
-      "minecraft:smooth_red_sandstone_slab",
-      "minecraft:mossy_stone_brick_slab",
-      "minecraft:polished_diorite_slab",
-      "minecraft:mossy_cobblestone_slab",
-      "minecraft:end_stone_brick_slab",
-      "minecraft:smooth_sandstone_slab",
-      "minecraft:smooth_quartz_slab",
-      "minecraft:granite_slab",
-      "minecraft:andesite_slab",
-      "minecraft:red_nether_brick_slab",
-      "minecraft:polished_andesite_slab",
-      "minecraft:diorite_slab",
-      "minecraft:cut_sandstone_slab",
-      "minecraft:cut_red_sandstone_slab"
-    ]
-  }
+  "acacia_logs": [
+    "minecraft:acacia_log",
+    "minecraft:acacia_wood",
+    "minecraft:stripped_acacia_log",
+    "minecraft:stripped_acacia_wood"
+  ],
+  "anvil": [
+    "minecraft:anvil",
+    "minecraft:chipped_anvil",
+    "minecraft:damaged_anvil"
+  ],
+  "arrows": [
+    "minecraft:arrow",
+    "minecraft:tipped_arrow",
+    "minecraft:spectral_arrow"
+  ],
+  "banners": [
+    "minecraft:white_banner",
+    "minecraft:orange_banner",
+    "minecraft:magenta_banner",
+    "minecraft:light_blue_banner",
+    "minecraft:yellow_banner",
+    "minecraft:lime_banner",
+    "minecraft:pink_banner",
+    "minecraft:gray_banner",
+    "minecraft:light_gray_banner",
+    "minecraft:cyan_banner",
+    "minecraft:purple_banner",
+    "minecraft:blue_banner",
+    "minecraft:brown_banner",
+    "minecraft:green_banner",
+    "minecraft:red_banner",
+    "minecraft:black_banner"
+  ],
+  "beacon_payment_items": [
+    "minecraft:netherite_ingot",
+    "minecraft:emerald",
+    "minecraft:diamond",
+    "minecraft:gold_ingot",
+    "minecraft:iron_ingot"
+  ],
+  "beds": [
+    "minecraft:red_bed",
+    "minecraft:black_bed",
+    "minecraft:blue_bed",
+    "minecraft:brown_bed",
+    "minecraft:cyan_bed",
+    "minecraft:gray_bed",
+    "minecraft:green_bed",
+    "minecraft:light_blue_bed",
+    "minecraft:light_gray_bed",
+    "minecraft:lime_bed",
+    "minecraft:magenta_bed",
+    "minecraft:orange_bed",
+    "minecraft:pink_bed",
+    "minecraft:purple_bed",
+    "minecraft:white_bed",
+    "minecraft:yellow_bed"
+  ],
+  "birch_logs": [
+    "minecraft:birch_log",
+    "minecraft:birch_wood",
+    "minecraft:stripped_birch_log",
+    "minecraft:stripped_birch_wood"
+  ],
+  "boats": [
+    "minecraft:oak_boat",
+    "minecraft:spruce_boat",
+    "minecraft:birch_boat",
+    "minecraft:jungle_boat",
+    "minecraft:acacia_boat",
+    "minecraft:dark_oak_boat"
+  ],
+  "buttons": [
+    "#minecraft:wooden_buttons",
+    "minecraft:stone_button",
+    "minecraft:polished_blackstone_button"
+  ],
+  "carpets": [
+    "minecraft:white_carpet",
+    "minecraft:orange_carpet",
+    "minecraft:magenta_carpet",
+    "minecraft:light_blue_carpet",
+    "minecraft:yellow_carpet",
+    "minecraft:lime_carpet",
+    "minecraft:pink_carpet",
+    "minecraft:gray_carpet",
+    "minecraft:light_gray_carpet",
+    "minecraft:cyan_carpet",
+    "minecraft:purple_carpet",
+    "minecraft:blue_carpet",
+    "minecraft:brown_carpet",
+    "minecraft:green_carpet",
+    "minecraft:red_carpet",
+    "minecraft:black_carpet"
+  ],
+  "coals": [
+    "minecraft:coal",
+    "minecraft:charcoal"
+  ],
+  "creeper_drop_music_discs": [
+    "minecraft:music_disc_13",
+    "minecraft:music_disc_cat",
+    "minecraft:music_disc_blocks",
+    "minecraft:music_disc_chirp",
+    "minecraft:music_disc_far",
+    "minecraft:music_disc_mall",
+    "minecraft:music_disc_mellohi",
+    "minecraft:music_disc_stal",
+    "minecraft:music_disc_strad",
+    "minecraft:music_disc_ward",
+    "minecraft:music_disc_11",
+    "minecraft:music_disc_wait"
+  ],
+  "crimson_stems": [
+    "minecraft:crimson_stem",
+    "minecraft:stripped_crimson_stem",
+    "minecraft:crimson_hyphae",
+    "minecraft:stripped_crimson_hyphae"
+  ],
+  "dark_oak_logs": [
+    "minecraft:dark_oak_log",
+    "minecraft:dark_oak_wood",
+    "minecraft:stripped_dark_oak_log",
+    "minecraft:stripped_dark_oak_wood"
+  ],
+  "doors": [
+    "#minecraft:wooden_doors",
+    "minecraft:iron_door"
+  ],
+  "fences": [
+    "#minecraft:wooden_fences",
+    "minecraft:nether_brick_fence"
+  ],
+  "fishes": [
+    "minecraft:cod",
+    "minecraft:cooked_cod",
+    "minecraft:salmon",
+    "minecraft:cooked_salmon",
+    "minecraft:pufferfish",
+    "minecraft:tropical_fish"
+  ],
+  "flowers": [
+    "#minecraft:small_flowers",
+    "#minecraft:tall_flowers"
+  ],
+  "furnace_materials": [
+    "minecraft:cobblestone",
+    "minecraft:blackstone"
+  ],
+  "gold_ores": [
+    "minecraft:gold_ore",
+    "minecraft:nether_gold_ore"
+  ],
+  "jungle_logs": [
+    "minecraft:jungle_log",
+    "minecraft:jungle_wood",
+    "minecraft:stripped_jungle_log",
+    "minecraft:stripped_jungle_wood"
+  ],
+  "leaves": [
+    "minecraft:jungle_leaves",
+    "minecraft:oak_leaves",
+    "minecraft:spruce_leaves",
+    "minecraft:dark_oak_leaves",
+    "minecraft:acacia_leaves",
+    "minecraft:birch_leaves"
+  ],
+  "lectern_books": [
+    "minecraft:written_book",
+    "minecraft:writable_book"
+  ],
+  "logs": [
+    "#minecraft:logs_that_burn",
+    "#minecraft:crimson_stems",
+    "#minecraft:warped_stems"
+  ],
+  "logs_that_burn": [
+    "#minecraft:dark_oak_logs",
+    "#minecraft:oak_logs",
+    "#minecraft:acacia_logs",
+    "#minecraft:birch_logs",
+    "#minecraft:jungle_logs",
+    "#minecraft:spruce_logs"
+  ],
+  "music_discs": [
+    "#minecraft:creeper_drop_music_discs",
+    "minecraft:music_disc_pigstep"
+  ],
+  "non_flammable_wood": [
+    "minecraft:warped_stem",
+    "minecraft:stripped_warped_stem",
+    "minecraft:warped_hyphae",
+    "minecraft:stripped_warped_hyphae",
+    "minecraft:crimson_stem",
+    "minecraft:stripped_crimson_stem",
+    "minecraft:crimson_hyphae",
+    "minecraft:stripped_crimson_hyphae",
+    "minecraft:crimson_planks",
+    "minecraft:warped_planks",
+    "minecraft:crimson_slab",
+    "minecraft:warped_slab",
+    "minecraft:crimson_pressure_plate",
+    "minecraft:warped_pressure_plate",
+    "minecraft:crimson_fence",
+    "minecraft:warped_fence",
+    "minecraft:crimson_trapdoor",
+    "minecraft:warped_trapdoor",
+    "minecraft:crimson_fence_gate",
+    "minecraft:warped_fence_gate",
+    "minecraft:crimson_stairs",
+    "minecraft:warped_stairs",
+    "minecraft:crimson_button",
+    "minecraft:warped_button",
+    "minecraft:crimson_door",
+    "minecraft:warped_door",
+    "minecraft:crimson_sign",
+    "minecraft:warped_sign"
+  ],
+  "oak_logs": [
+    "minecraft:oak_log",
+    "minecraft:oak_wood",
+    "minecraft:stripped_oak_log",
+    "minecraft:stripped_oak_wood"
+  ],
+  "piglin_loved": [
+    "#minecraft:gold_ores",
+    "minecraft:gold_block",
+    "minecraft:gilded_blackstone",
+    "minecraft:light_weighted_pressure_plate",
+    "minecraft:gold_nugget",
+    "minecraft:gold_ingot",
+    "minecraft:bell",
+    "minecraft:clock",
+    "minecraft:golden_carrot",
+    "minecraft:glistering_melon_slice",
+    "minecraft:golden_apple",
+    "minecraft:enchanted_golden_apple",
+    "minecraft:golden_helmet",
+    "minecraft:golden_chestplate",
+    "minecraft:golden_leggings",
+    "minecraft:golden_boots",
+    "minecraft:golden_horse_armor",
+    "minecraft:golden_sword",
+    "minecraft:golden_pickaxe",
+    "minecraft:golden_shovel",
+    "minecraft:golden_axe",
+    "minecraft:golden_hoe"
+  ],
+  "piglin_repellents": [
+    "minecraft:soul_torch",
+    "minecraft:soul_lantern",
+    "minecraft:soul_campfire"
+  ],
+  "planks": [
+    "minecraft:oak_planks",
+    "minecraft:spruce_planks",
+    "minecraft:birch_planks",
+    "minecraft:jungle_planks",
+    "minecraft:acacia_planks",
+    "minecraft:dark_oak_planks",
+    "minecraft:crimson_planks",
+    "minecraft:warped_planks"
+  ],
+  "rails": [
+    "minecraft:rail",
+    "minecraft:powered_rail",
+    "minecraft:detector_rail",
+    "minecraft:activator_rail"
+  ],
+  "sand": [
+    "minecraft:sand",
+    "minecraft:red_sand"
+  ],
+  "saplings": [
+    "minecraft:oak_sapling",
+    "minecraft:spruce_sapling",
+    "minecraft:birch_sapling",
+    "minecraft:jungle_sapling",
+    "minecraft:acacia_sapling",
+    "minecraft:dark_oak_sapling"
+  ],
+  "signs": [
+    "minecraft:oak_sign",
+    "minecraft:spruce_sign",
+    "minecraft:birch_sign",
+    "minecraft:acacia_sign",
+    "minecraft:jungle_sign",
+    "minecraft:dark_oak_sign",
+    "minecraft:crimson_sign",
+    "minecraft:warped_sign"
+  ],
+  "slabs": [
+    "#minecraft:wooden_slabs",
+    "minecraft:stone_slab",
+    "minecraft:smooth_stone_slab",
+    "minecraft:stone_brick_slab",
+    "minecraft:sandstone_slab",
+    "minecraft:purpur_slab",
+    "minecraft:quartz_slab",
+    "minecraft:red_sandstone_slab",
+    "minecraft:brick_slab",
+    "minecraft:cobblestone_slab",
+    "minecraft:nether_brick_slab",
+    "minecraft:petrified_oak_slab",
+    "minecraft:prismarine_slab",
+    "minecraft:prismarine_brick_slab",
+    "minecraft:dark_prismarine_slab",
+    "minecraft:polished_granite_slab",
+    "minecraft:smooth_red_sandstone_slab",
+    "minecraft:mossy_stone_brick_slab",
+    "minecraft:polished_diorite_slab",
+    "minecraft:mossy_cobblestone_slab",
+    "minecraft:end_stone_brick_slab",
+    "minecraft:smooth_sandstone_slab",
+    "minecraft:smooth_quartz_slab",
+    "minecraft:granite_slab",
+    "minecraft:andesite_slab",
+    "minecraft:red_nether_brick_slab",
+    "minecraft:polished_andesite_slab",
+    "minecraft:diorite_slab",
+    "minecraft:cut_sandstone_slab",
+    "minecraft:cut_red_sandstone_slab",
+    "minecraft:blackstone_slab",
+    "minecraft:polished_blackstone_brick_slab",
+    "minecraft:polished_blackstone_slab"
+  ],
+  "small_flowers": [
+    "minecraft:dandelion",
+    "minecraft:poppy",
+    "minecraft:blue_orchid",
+    "minecraft:allium",
+    "minecraft:azure_bluet",
+    "minecraft:red_tulip",
+    "minecraft:orange_tulip",
+    "minecraft:white_tulip",
+    "minecraft:pink_tulip",
+    "minecraft:oxeye_daisy",
+    "minecraft:cornflower",
+    "minecraft:lily_of_the_valley",
+    "minecraft:wither_rose"
+  ],
+  "soul_fire_base_blocks": [
+    "minecraft:soul_sand",
+    "minecraft:soul_soil"
+  ],
+  "spruce_logs": [
+    "minecraft:spruce_log",
+    "minecraft:spruce_wood",
+    "minecraft:stripped_spruce_log",
+    "minecraft:stripped_spruce_wood"
+  ],
+  "stairs": [
+    "#minecraft:wooden_stairs",
+    "minecraft:cobblestone_stairs",
+    "minecraft:sandstone_stairs",
+    "minecraft:nether_brick_stairs",
+    "minecraft:stone_brick_stairs",
+    "minecraft:brick_stairs",
+    "minecraft:purpur_stairs",
+    "minecraft:quartz_stairs",
+    "minecraft:red_sandstone_stairs",
+    "minecraft:prismarine_brick_stairs",
+    "minecraft:prismarine_stairs",
+    "minecraft:dark_prismarine_stairs",
+    "minecraft:polished_granite_stairs",
+    "minecraft:smooth_red_sandstone_stairs",
+    "minecraft:mossy_stone_brick_stairs",
+    "minecraft:polished_diorite_stairs",
+    "minecraft:mossy_cobblestone_stairs",
+    "minecraft:end_stone_brick_stairs",
+    "minecraft:stone_stairs",
+    "minecraft:smooth_sandstone_stairs",
+    "minecraft:smooth_quartz_stairs",
+    "minecraft:granite_stairs",
+    "minecraft:andesite_stairs",
+    "minecraft:red_nether_brick_stairs",
+    "minecraft:polished_andesite_stairs",
+    "minecraft:diorite_stairs",
+    "minecraft:blackstone_stairs",
+    "minecraft:polished_blackstone_brick_stairs",
+    "minecraft:polished_blackstone_stairs"
+  ],
+  "stone_bricks": [
+    "minecraft:stone_bricks",
+    "minecraft:mossy_stone_bricks",
+    "minecraft:cracked_stone_bricks",
+    "minecraft:chiseled_stone_bricks"
+  ],
+  "stone_tool_materials": [
+    "minecraft:cobblestone",
+    "minecraft:blackstone"
+  ],
+  "tall_flowers": [
+    "minecraft:sunflower",
+    "minecraft:lilac",
+    "minecraft:peony",
+    "minecraft:rose_bush"
+  ],
+  "trapdoors": [
+    "#minecraft:wooden_trapdoors",
+    "minecraft:iron_trapdoor"
+  ],
+  "walls": [
+    "minecraft:cobblestone_wall",
+    "minecraft:mossy_cobblestone_wall",
+    "minecraft:brick_wall",
+    "minecraft:prismarine_wall",
+    "minecraft:red_sandstone_wall",
+    "minecraft:mossy_stone_brick_wall",
+    "minecraft:granite_wall",
+    "minecraft:stone_brick_wall",
+    "minecraft:nether_brick_wall",
+    "minecraft:andesite_wall",
+    "minecraft:red_nether_brick_wall",
+    "minecraft:sandstone_wall",
+    "minecraft:end_stone_brick_wall",
+    "minecraft:diorite_wall",
+    "minecraft:blackstone_wall",
+    "minecraft:polished_blackstone_brick_wall",
+    "minecraft:polished_blackstone_wall"
+  ],
+  "warped_stems": [
+    "minecraft:warped_stem",
+    "minecraft:stripped_warped_stem",
+    "minecraft:warped_hyphae",
+    "minecraft:stripped_warped_hyphae"
+  ],
+  "wooden_buttons": [
+    "minecraft:oak_button",
+    "minecraft:spruce_button",
+    "minecraft:birch_button",
+    "minecraft:jungle_button",
+    "minecraft:acacia_button",
+    "minecraft:dark_oak_button",
+    "minecraft:crimson_button",
+    "minecraft:warped_button"
+  ],
+  "wooden_doors": [
+    "minecraft:oak_door",
+    "minecraft:spruce_door",
+    "minecraft:birch_door",
+    "minecraft:jungle_door",
+    "minecraft:acacia_door",
+    "minecraft:dark_oak_door",
+    "minecraft:crimson_door",
+    "minecraft:warped_door"
+  ],
+  "wooden_fences": [
+    "minecraft:oak_fence",
+    "minecraft:spruce_fence",
+    "minecraft:birch_fence",
+    "minecraft:jungle_fence",
+    "minecraft:acacia_fence",
+    "minecraft:dark_oak_fence",
+    "minecraft:crimson_fence",
+    "minecraft:warped_fence"
+  ],
+  "wooden_pressure_plates": [
+    "minecraft:oak_pressure_plate",
+    "minecraft:spruce_pressure_plate",
+    "minecraft:birch_pressure_plate",
+    "minecraft:jungle_pressure_plate",
+    "minecraft:acacia_pressure_plate",
+    "minecraft:dark_oak_pressure_plate",
+    "minecraft:crimson_pressure_plate",
+    "minecraft:warped_pressure_plate"
+  ],
+  "wooden_slabs": [
+    "minecraft:oak_slab",
+    "minecraft:spruce_slab",
+    "minecraft:birch_slab",
+    "minecraft:jungle_slab",
+    "minecraft:acacia_slab",
+    "minecraft:dark_oak_slab",
+    "minecraft:crimson_slab",
+    "minecraft:warped_slab"
+  ],
+  "wooden_stairs": [
+    "minecraft:oak_stairs",
+    "minecraft:spruce_stairs",
+    "minecraft:birch_stairs",
+    "minecraft:jungle_stairs",
+    "minecraft:acacia_stairs",
+    "minecraft:dark_oak_stairs",
+    "minecraft:crimson_stairs",
+    "minecraft:warped_stairs"
+  ],
+  "wooden_trapdoors": [
+    "minecraft:acacia_trapdoor",
+    "minecraft:birch_trapdoor",
+    "minecraft:dark_oak_trapdoor",
+    "minecraft:jungle_trapdoor",
+    "minecraft:oak_trapdoor",
+    "minecraft:spruce_trapdoor",
+    "minecraft:crimson_trapdoor",
+    "minecraft:warped_trapdoor"
+  ],
+  "wool": [
+    "minecraft:white_wool",
+    "minecraft:orange_wool",
+    "minecraft:magenta_wool",
+    "minecraft:light_blue_wool",
+    "minecraft:yellow_wool",
+    "minecraft:lime_wool",
+    "minecraft:pink_wool",
+    "minecraft:gray_wool",
+    "minecraft:light_gray_wool",
+    "minecraft:cyan_wool",
+    "minecraft:purple_wool",
+    "minecraft:blue_wool",
+    "minecraft:brown_wool",
+    "minecraft:green_wool",
+    "minecraft:red_wool",
+    "minecraft:black_wool"
+  ]
+}


### PR DESCRIPTION
- Added all 1.16 items and recipes.
  - This brings the total to 1295 items and 1199 recipes!
- Removing the recipe embed now deletes the message.
- Fixed item search bugs with potions.
- Self-hosters can now disable bot status by setting "game" in config to empty.
- Fixed a rare exception when `&server` requests a Minecraft server that can take requests but hasn't finished booting yet.
- Added self-hosting documentation