### PR TITLE
Version 0.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.12.0</version>
+  <version>0.12.1</version>
   
   <repositories>
     <repository>

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -40,7 +40,7 @@ public class Bot {
 	public static final String helpServer = "https://minecord.github.io/support";
 	public static final String website = "https://minecord.github.io";
 	public static final String github = "https://github.com/Tisawesomeness/Minecord";
-	private static final String version = "0.12.0";
+	private static final String version = "0.12.1";
 	public static final String javaVersion = "1.8";
 	public static final String jdaVersion = "4.1.1_151";
 	public static final Color color = Color.GREEN;

--- a/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
@@ -29,7 +29,7 @@ public class IngredientCommand extends Command {
 
 	public String getHelp() {
 		return "Searches for the recipes containing an ingredient.\n" +
-			"Items and recipes are from Java Edition 1.7 to 1.15.\n" +
+			"Items and recipes are from Java Edition 1.7 to 1.16.\n" +
 			"All recipe types are searchable, including brewing.\n" +
 			"\n" +
 			Item.help + "\n";

--- a/src/com/tisawesomeness/minecord/command/utility/ItemCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/ItemCommand.java
@@ -24,7 +24,7 @@ public class ItemCommand extends Command {
 
 	public String getHelp() {
 		return "Searches for a Minecraft item.\n" +
-			"Items are from Java Edition 1.7 to 1.15.\n" +
+			"Items are from Java Edition 1.7 to 1.16.\n" +
 			"\n" +
 			Item.help + "\n";
 	}

--- a/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
@@ -31,7 +31,7 @@ public class RecipeCommand extends Command {
 
 	public String getHelp() {
 		return "Shows the recipes for an item.\n" +
-			"Items and recipes are from Java Edition 1.7 to 1.15.\n" +
+			"Items and recipes are from Java Edition 1.7 to 1.16.\n" +
 			"All recipe types are searchable, including brewing.\n" +
 			"\n" +
 			Item.help + "\n";


### PR DESCRIPTION
- Fix `&help item`, `&help recipe`, and `&help ingredient` saying that Minecord supports up to 1.15 instead of 1.16.