### PR TITLE
Version 0.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Minecord [![Codacy Badge](https://api.codacy.com/project/badge/Grade/3de0f658514246f598b40fb1bdf55af9)](https://www.codacy.com/app/Tis_awesomeness/Minecord?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Tisawesomeness/Minecord&amp;utm_campaign=Badge_Grade) [![Discord Bots](https://discordbots.org/api/widget/status/292279711034245130.png)](https://discordbots.org/bot/292279711034245130) [![Discord Bots](https://discordbots.org/api/widget/servers/292279711034245130.png)](https://discordbots.org/bot/292279711034245130) [![Discord Bots](https://discordbots.org/api/widget/upvotes/292279711034245130.png)](https://discordbots.org/bot/292279711034245130)
+# Minecord [![Discord Bots](https://discordbots.org/api/widget/status/292279711034245130.png)](https://discordbots.org/bot/292279711034245130) [![Discord Bots](https://discordbots.org/api/widget/servers/292279711034245130.png)](https://discordbots.org/bot/292279711034245130) [![Discord Bots](https://discordbots.org/api/widget/upvotes/292279711034245130.png)](https://discordbots.org/bot/292279711034245130)
 A robust Discord bot using the JDA library for various Minecraft functions.
 
 - **Official Bot Invite: https://discordapp.com/oauth2/authorize?client_id=292279711034245130&scope=bot&permissions=93248**
@@ -70,7 +70,13 @@ A robust Discord bot using the JDA library for various Minecraft functions.
 - *Owner:* The user ID of the bot owner. The bot will work when owner is 0, but it is *highly encouraged* to set this value.
 
 - *Log Channel:* The bot will send any logging messages to this channel. Set to 0 to disable.
+- *Is Self Hosted:* Leave as `true` if you are self-hosting the bot.
+- *Author:* The name of the person hosting the bot.
+- *Author Tag:* The Discord tag of the person hosting the bot.
 - *Invite:* The invite link to use in `&invite`.
+- *Help Server:* The help server link to use in `&invite`.
+- *Website:* The website to display in `&info`.
+- *Github:* A link to the source code currently running on the bot.
 - *Prefix:* The prefix of the bot. Use something else instead of `&` if you want to host your own bot alongside the main one.
 - *Game:* This is the game that the bot is playing, shown under the username. `{prefix}` and `{guilds}` are available variables.
 - *Dev Mode:* Turning this on will let you reload code using `&reload` on the fly. When hosting the bot, it's best to keep this off in order to decrease memory usage.
@@ -113,7 +119,13 @@ A robust Discord bot using the JDA library for various Minecraft functions.
     "owner": "0",
     "settings": {
         "logChannel": "0",
-        "invite": "https://discordapp.com/oauth2/authorize?client_id=292279711034245130&scope=bot&permissions=93248",
+        "isSelfHosted": true,
+        "author": "Tis_awesomeness",
+        "authorTag": "@Tis_awesomeness#8617",
+        "invite": "https://minecord.github.io/invite",
+        "helpServer": "https://minecord.github.io/support",
+        "website": "https://minecord.github.io",
+        "github": "https://github.com/Tisawesomeness/Minecord",
         "prefix": "&",
         "game": "@Minecord help | {guilds} guilds",
         "devMode": false,

--- a/config.json
+++ b/config.json
@@ -4,7 +4,13 @@
     "owner": "0",
     "settings": {
         "logChannel": "0",
+        "isSelfHosted": true,
+        "author": "Tis_awesomeness",
+        "authorTag": "@Tis_awesomeness#8617",
         "invite": "https://minecord.github.io/invite",
+        "helpServer": "https://minecord.github.io/support",
+        "website": "https://minecord.github.io",
+        "github": "https://github.com/Tisawesomeness/Minecord",
         "prefix": "&",
         "game": "@Minecord help | {guilds} guilds",
         "devMode": false,

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.12.1</version>
+  <version>0.12.2</version>
   
   <repositories>
     <repository>

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -37,6 +37,7 @@ public class Bot {
 	private static final String mainClass = "com.tisawesomeness.minecord.Main";
 	public static final String author = "Tis_awesomeness";
 	public static final String authorTag = "@Tis_awesomeness#8617";
+	public static final String invite = "https://minecord.github.io/invite";
 	public static final String helpServer = "https://minecord.github.io/support";
 	public static final String website = "https://minecord.github.io";
 	public static final String github = "https://github.com/Tisawesomeness/Minecord";

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -41,7 +41,7 @@ public class Bot {
 	public static final String helpServer = "https://minecord.github.io/support";
 	public static final String website = "https://minecord.github.io";
 	public static final String github = "https://github.com/Tisawesomeness/Minecord";
-	private static final String version = "0.12.1";
+	private static final String version = "0.12.2";
 	public static final String javaVersion = "1.8";
 	public static final String jdaVersion = "4.1.1_151";
 	public static final Color color = Color.GREEN;

--- a/src/com/tisawesomeness/minecord/Config.java
+++ b/src/com/tisawesomeness/minecord/Config.java
@@ -15,7 +15,13 @@ public class Config {
 	private static String owner;
 	
 	private static String logChannel;
+	private static boolean isSelfHosted;
+	private static String author;
+	private static String authorTag;
 	private static String invite;
+	private static String helpServer;
+	private static String website;
+	private static String github;
 	private static String prefix;
 	private static String game;
 	private static boolean devMode;
@@ -84,7 +90,22 @@ public class Config {
 			
 			JSONObject settings = config.getJSONObject("settings");
 			logChannel = settings.getString("logChannel");
-			invite = settings.getString("invite");
+			isSelfHosted = settings.getBoolean("isSelfHosted");
+			if (isSelfHosted) {
+				author = settings.getString("author");
+				authorTag = settings.getString("authorTag");
+				invite = settings.getString("invite");
+				helpServer = settings.getString("helpServer");
+				website = settings.getString("website");
+				github = settings.getString("github");
+			} else {
+				author = Bot.author;
+				authorTag = Bot.authorTag;
+				invite = Bot.invite;
+				helpServer = Bot.helpServer;
+				website = Bot.website;
+				github = Bot.github;
+			}
 			prefix = settings.getString("prefix");
 			game = settings.getString("game");
 			devMode = settings.getBoolean("devMode");
@@ -97,7 +118,11 @@ public class Config {
 			elevatedSkipCooldown = settings.getBoolean("elevatedSkipCooldown");
 			
 			JSONObject botLists = config.getJSONObject("botLists");
-			sendServerCount = botLists.getBoolean("sendServerCount");
+			if (isSelfHosted) {
+				sendServerCount = false;
+			} else {
+				sendServerCount = botLists.getBoolean("sendServerCount");
+			}
 			pwToken = botLists.getString("pwToken");
 			orgToken = botLists.getString("orgToken");
 			receiveVotes = botLists.getBoolean("receiveVotes");
@@ -124,7 +149,13 @@ public class Config {
 	public static String getOwner() {return owner;}
 
 	public static String getLogChannel() {return logChannel;}
+	public static boolean isIsSelfHosted() {return isSelfHosted;}
+	public static String getAuthor() {return author;}
+	public static String getAuthorTag() {return authorTag;}
 	public static String getInvite() {return invite;}
+	public static String getHelpServer() {return helpServer;}
+	public static String getWebsite() {return website;}
+	public static String getGithub() {return github;}
 	public static String getPrefix() {return prefix;}
 	public static String getGame() {return game;}
 	public static boolean getDevMode() {return devMode;}

--- a/src/com/tisawesomeness/minecord/command/misc/CreditsCommand.java
+++ b/src/com/tisawesomeness/minecord/command/misc/CreditsCommand.java
@@ -1,6 +1,7 @@
 package com.tisawesomeness.minecord.command.misc;
 
 import com.tisawesomeness.minecord.Bot;
+import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.command.Command;
 
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -27,9 +28,6 @@ public class CreditsCommand extends Command {
         MarkdownUtil.maskedLink("samueldcs#4675", "https://github.com/samueldcs") + " - Made the Website\n" +
         MarkdownUtil.maskedLink("DJ Electro#1677", "https://github.com/Electromaster232") + " - Supplied Hosting";
     
-    private String contrib = MarkdownUtil.maskedLink("Contribute on GitHub", Bot.github) + "\n" +
-        MarkdownUtil.maskedLink("Suggest features here", Bot.helpServer);
-    
     private String apis = "Discord API Wrapper - " + MarkdownUtil.maskedLink("JDA", "https://github.com/DV8FromTheWorld/JDA") + "\n" +
         "MC Account Info - " + MarkdownUtil.maskedLink("Mojang API", "https://wiki.vg/Mojang_API") + "\n" +
         "Skin Renders - " + MarkdownUtil.maskedLink("Crafatar", "https://crafatar.com") + "\n" +
@@ -42,16 +40,27 @@ public class CreditsCommand extends Command {
     private String host = "The public bot is proudly hosted by " + MarkdownUtil.maskedLink("Endless Hosting", "https://theendlessweb.com/")+ ".\n";
 
     public Result run(String[] args, MessageReceivedEvent e) throws Exception {
+        String contrib = MarkdownUtil.maskedLink("Contribute on GitHub", Config.getGithub()) + "\n" +
+                MarkdownUtil.maskedLink("Suggest features here", Config.getHelpServer());
+
         EmbedBuilder eb = new EmbedBuilder()
             .setTitle("Minecord Credits")
             .setColor(Bot.color)
             .setDescription("Thanks to all these great people who helped to make the bot possible. :heart:")
             .addField("Developers", devs, true)
             .addField("Contribute", contrib, true)
-            .addField("APIs Used", apis, false)
-            .addField("Hosting", host, false)
-            .addField("Special Thanks", e.getAuthor().getAsMention() + " for using Minecord!", false)
-            .setFooter("Website: " + Bot.website);
+            .addField("APIs Used", apis, false);
+        if (Config.isIsSelfHosted()) {
+            String selfHost = "This bot is self-hosted by **" + Config.getAuthor() + "**\n" +
+                "Original Website - " + MarkdownUtil.maskedLink(Bot.website, Bot.website) + "\n" +
+                "Original Help Server - " + MarkdownUtil.maskedLink(Bot.helpServer, Bot.helpServer) + "\n" +
+                "Original Github - " + MarkdownUtil.maskedLink("Source Code", Bot.github);
+            eb.addField("Self-Hosting", selfHost, false);
+        } else {
+            eb.addField("Hosting", host, false);
+        }
+        eb.addField("Special Thanks", e.getAuthor().getAsMention() + " for using Minecord!", false)
+                .setFooter("Website: " + Config.getWebsite());
         return new Result(Outcome.SUCCESS, eb.build());
     }
 

--- a/src/com/tisawesomeness/minecord/command/misc/InfoCommand.java
+++ b/src/com/tisawesomeness/minecord/command/misc/InfoCommand.java
@@ -49,6 +49,9 @@ public class InfoCommand extends Command {
 		
 		eb.setColor(Bot.color);
 		eb.addField("Author", Bot.author, true);
+		if (Config.isIsSelfHosted()) {
+			eb.addField("Self-Hoster", Config.getAuthor(), true);
+		}
 		eb.addField("Version", Bot.getVersion(), true);
 		
 		String guilds = Bot.shardManager.getGuilds().size() + "";
@@ -69,9 +72,9 @@ public class InfoCommand extends Command {
 		eb.addField("JDA Version", MarkdownUtil.monospace(Bot.jdaVersion), true);
 
 		String links = MarkdownUtil.maskedLink("INVITE", Config.getInvite()) + " | " +
-			MarkdownUtil.maskedLink("SUPPORT", Bot.helpServer) + " | " +
-			MarkdownUtil.maskedLink("WEBSITE", Bot.website) + " | " +
-			MarkdownUtil.maskedLink("GITHUB", Bot.github);
+			MarkdownUtil.maskedLink("SUPPORT", Config.getHelpServer()) + " | " +
+			MarkdownUtil.maskedLink("WEBSITE", Config.getWebsite()) + " | " +
+			MarkdownUtil.maskedLink("GITHUB", Config.getGithub());
 		eb.addField("Links", "**" + links + "**", false);
 		
 		eb = MessageUtils.addFooter(eb);

--- a/src/com/tisawesomeness/minecord/command/misc/InviteCommand.java
+++ b/src/com/tisawesomeness/minecord/command/misc/InviteCommand.java
@@ -7,6 +7,7 @@ import com.tisawesomeness.minecord.util.MessageUtils;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.utils.MarkdownUtil;
 
 public class InviteCommand extends Command {
 	
@@ -25,9 +26,9 @@ public class InviteCommand extends Command {
 	
 	public Result run(String[] args, MessageReceivedEvent e) {
 		EmbedBuilder eb = new EmbedBuilder();
-		eb.addField("Invite me!", Config.getInvite(), false);
-		eb.addField("Help server", Bot.helpServer, false);
-		eb.addField("Website", Bot.website, true);
+		eb.addField("Invite me!", MarkdownUtil.maskedLink(Config.getInvite(), Config.getInvite()), false);
+		eb.addField("Help server", MarkdownUtil.maskedLink(Config.getHelpServer(), Config.getHelpServer()), false);
+		eb.addField("Website", MarkdownUtil.maskedLink(Config.getWebsite(), Config.getWebsite()), true);
 		eb.setColor(Bot.color);
 		eb = MessageUtils.addFooter(eb);
 		return new Result(Outcome.SUCCESS, eb.build());

--- a/src/com/tisawesomeness/minecord/command/misc/VoteCommand.java
+++ b/src/com/tisawesomeness/minecord/command/misc/VoteCommand.java
@@ -1,6 +1,7 @@
 package com.tisawesomeness.minecord.command.misc;
 
 import com.tisawesomeness.minecord.Bot;
+import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.command.Command;
 import com.tisawesomeness.minecord.util.MessageUtils;
 
@@ -24,7 +25,8 @@ public class VoteCommand extends Command {
 
     public Result run(String[] args, MessageReceivedEvent e) throws Exception {
         String m = "Top.gg: " + MarkdownUtil.maskedLink("VOTE", "https://top.gg/bot/292279711034245130/vote");
-        return new Result(Outcome.SUCCESS, MessageUtils.embedMessage("Vote for Minecord!", null, m, Bot.color));
+        String title = Config.isIsSelfHosted() ? "Vote for the main bot!" : "Vote for Minecord!";
+        return new Result(Outcome.SUCCESS, MessageUtils.embedMessage(title, null, m, Bot.color));
     }
 
 }

--- a/src/com/tisawesomeness/minecord/util/DiscordUtils.java
+++ b/src/com/tisawesomeness/minecord/util/DiscordUtils.java
@@ -25,11 +25,11 @@ public class DiscordUtils {
 	 */
 	public static String parseConstants(String input) {
 		return input
-			.replace("{author}", Bot.author)
-			.replace("{author_tag}", Bot.authorTag)
-			.replace("{help_server}", Bot.helpServer)
-			.replace("{website}", Bot.website)
-			.replace("{github}", Bot.github)
+			.replace("{author}", Config.getAuthor())
+			.replace("{author_tag}", Config.getAuthorTag())
+			.replace("{help_server}", Config.getHelpServer())
+			.replace("{website}", Config.getWebsite())
+			.replace("{github}", Config.getGithub())
 			.replace("{java_ver}", Bot.javaVersion)
 			.replace("{jda_ver}", Bot.jdaVersion)
 			.replace("{version}", Bot.getVersion())


### PR DESCRIPTION
- Added option in the config for self-hosters to change bot links in `&info`, `&invite`, and `&credits` while still giving credit to the original bot