### PR TITLE
Version 0.13.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>4.4.0_351</version>
+      <version>4.4.0_352</version>
       <exclusions>
         <exclusion>
           <groupId>club.minnced</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.13.7</version>
+  <version>0.13.8</version>
 
   <repositories>
     <repository>

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -35,9 +35,9 @@ public class Bot {
 	public static final String helpServer = "https://minecord.github.io/support";
 	public static final String website = "https://minecord.github.io";
 	public static final String github = "https://github.com/Tisawesomeness/Minecord";
-	private static final String version = "0.13.7";
+	private static final String version = "0.13.8";
 	public static final String javaVersion = "1.8";
-	public static final String jdaVersion = "4.3.0_350";
+	public static final String jdaVersion = "4.3.0_352";
 	public static final Color color = Color.GREEN;
 
 	public static ShardManager shardManager;

--- a/src/com/tisawesomeness/minecord/command/general/GuildCommand.java
+++ b/src/com/tisawesomeness/minecord/command/general/GuildCommand.java
@@ -3,7 +3,6 @@ package com.tisawesomeness.minecord.command.general;
 import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.command.Command;
 import com.tisawesomeness.minecord.database.Database;
-import com.tisawesomeness.minecord.util.DateUtils;
 import com.tisawesomeness.minecord.util.DiscordUtils;
 import com.tisawesomeness.minecord.util.MessageUtils;
 
@@ -13,6 +12,7 @@ import net.dv8tion.jda.api.entities.Guild.BoostTier;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
+import net.dv8tion.jda.api.utils.TimeFormat;
 import net.dv8tion.jda.api.utils.TimeUtil;
 
 public class GuildCommand extends Command {
@@ -79,7 +79,7 @@ public class GuildCommand extends Command {
             .addField("Verification Level", g.getVerificationLevel().toString(), true)
             .addField("Owner", MarkdownSanitizer.escape(owner.getAsTag()), true)
             .addField("Owner ID", owner.getId(), true)
-            .addField("Created", DateUtils.getDateAgo(TimeUtil.getTimeCreated(g)), false);
+            .addField("Created", TimeFormat.RELATIVE.format(TimeUtil.getTimeCreated(g)), true);
          if (g.getBoostTier() == BoostTier.UNKNOWN) {
             eb.addField("Boosts", g.getBoostCount() + " (Unknown Tier)", true);
         } else {

--- a/src/com/tisawesomeness/minecord/command/general/PermsCommand.java
+++ b/src/com/tisawesomeness/minecord/command/general/PermsCommand.java
@@ -105,17 +105,26 @@ public class PermsCommand extends Command {
         }
 
         EnumSet<Permission> perms = c.getGuild().getSelfMember().getPermissions(c);
-        String m = String.format("**Bot Permissions for %s:**", c.getName()) +
+        String m = String.format("**Bot Permissions for %s:**", c.getAsMention()) +
             "\nView channels: " + DiscordUtils.getBoolEmote(perms.contains(Permission.VIEW_CHANNEL)) +
             "\nRead messages: " + DiscordUtils.getBoolEmote(perms.contains(Permission.MESSAGE_READ)) +
             "\nRead message history: " + DiscordUtils.getBoolEmote(perms.contains(Permission.MESSAGE_HISTORY)) +
             "\nWrite messages: " + DiscordUtils.getBoolEmote(perms.contains(Permission.MESSAGE_WRITE)) +
             "\nEmbed links: " + DiscordUtils.getBoolEmote(perms.contains(Permission.MESSAGE_EMBED_LINKS)) +
+            "\nAttach files: " + DiscordUtils.getBoolEmote(perms.contains(Permission.MESSAGE_ATTACH_FILES)) +
             "\nAdd reactions: " + DiscordUtils.getBoolEmote(perms.contains(Permission.MESSAGE_ADD_REACTION)) +
             "\nManage messages: " + DiscordUtils.getBoolEmote(perms.contains(Permission.MESSAGE_MANAGE)) +
+            "\nCan upload favicons: " + getFaviconEmote(perms) +
             "\nCan use reaction menus: " + getMenuEmote(perms);
         
         return new Result(Outcome.SUCCESS, m);
+    }
+
+    private static String getFaviconEmote(EnumSet<Permission> perms) {
+        if (perms.contains(Permission.MESSAGE_ATTACH_FILES)) {
+            return ":white_check_mark:";
+        }
+        return ":x: Give attach files permissions and add reactions permissions to fix";
     }
 
     private static String getMenuEmote(EnumSet<Permission> perms) {
@@ -123,9 +132,9 @@ public class PermsCommand extends Command {
             if (perms.contains(Permission.MESSAGE_MANAGE)) {
                 return ":white_check_mark:";
             }
-            return ":warning: Partial, users must remove reactions manually, give manage messages perms to fix";
+            return ":warning: Partial, users must remove reactions manually, give manage messages permissions to fix";
         }
-        return ":x:";
+        return ":x: Give embed links and add reactions permissions to fix";
     }
     
 }

--- a/src/com/tisawesomeness/minecord/command/general/RoleCommand.java
+++ b/src/com/tisawesomeness/minecord/command/general/RoleCommand.java
@@ -4,7 +4,6 @@ import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.command.Command;
 import com.tisawesomeness.minecord.database.Database;
 import com.tisawesomeness.minecord.util.ColorUtils;
-import com.tisawesomeness.minecord.util.DateUtils;
 import com.tisawesomeness.minecord.util.DiscordUtils;
 import com.tisawesomeness.minecord.util.MessageUtils;
 
@@ -12,6 +11,7 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.utils.TimeFormat;
 
 import java.util.List;
 
@@ -93,7 +93,7 @@ public class RoleCommand extends Command {
             .addField("Mentionable?", role.isMentionable() ? "Yes" : "No", true)
             .addField("Hoisted?", role.isHoisted() ? "Yes" : "No", true)
             .addField("Managed?", role.isManaged() ? "Yes" : "No", true)
-            .addField("Role Created", DateUtils.getDateAgo(role.getTimeCreated()), false);
+            .addField("Role Created", TimeFormat.RELATIVE.format(role.getTimeCreated()), true);
 
         return new Result(Outcome.SUCCESS, MessageUtils.addFooter(eb).build());
     }

--- a/src/com/tisawesomeness/minecord/command/general/RoleCommand.java
+++ b/src/com/tisawesomeness/minecord/command/general/RoleCommand.java
@@ -10,6 +10,7 @@ import com.tisawesomeness.minecord.util.MessageUtils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.RoleIcon;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.utils.TimeFormat;
 
@@ -84,6 +85,7 @@ public class RoleCommand extends Command {
             return new Result(Outcome.WARNING, ":warning: That role does not exist.");
         }
 
+        Role.RoleTags tags = role.getTags();
         EmbedBuilder eb = new EmbedBuilder()
             .setTitle(role.getName().substring(0, Math.min(MessageEmbed.TITLE_MAX_LENGTH, role.getName().length())))
             .setColor(role.getColorRaw())
@@ -92,8 +94,26 @@ public class RoleCommand extends Command {
             .addField("Position", (role.getPosition() + 2) + "/" + roles.size(), true) // Position corrected so @everyone is pos 1
             .addField("Mentionable?", role.isMentionable() ? "Yes" : "No", true)
             .addField("Hoisted?", role.isHoisted() ? "Yes" : "No", true)
-            .addField("Managed?", role.isManaged() ? "Yes" : "No", true)
-            .addField("Role Created", TimeFormat.RELATIVE.format(role.getTimeCreated()), true);
+            .addField("Integration?", tags.isIntegration() ? "Yes" : "No", true);
+        if (tags.isIntegration()) {
+            eb.addField("Integration ID", tags.getIntegrationId(), true);
+        }
+        eb.addField("Bot?", tags.isBot() ? "Yes" : "No", true);
+        if (tags.isBot()) {
+            eb.addField("Bot ID", tags.getBotId(), true);
+        }
+        eb.addField("Boost?", tags.isBoost() ? "Yes" : "No", true);
+
+        RoleIcon icon = role.getIcon();
+        if (icon != null) {
+            if (icon.isEmoji()) {
+                eb.addField("Role Icon Emoji", icon.getEmoji(), true);
+            } else {
+                eb.setThumbnail(icon.getIconUrl());
+            }
+        }
+
+        eb.addField("Role Created", TimeFormat.RELATIVE.format(role.getTimeCreated()), false);
 
         return new Result(Outcome.SUCCESS, MessageUtils.addFooter(eb).build());
     }

--- a/src/com/tisawesomeness/minecord/command/general/UserCommand.java
+++ b/src/com/tisawesomeness/minecord/command/general/UserCommand.java
@@ -3,7 +3,6 @@ package com.tisawesomeness.minecord.command.general;
 import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.command.Command;
 import com.tisawesomeness.minecord.database.Database;
-import com.tisawesomeness.minecord.util.DateUtils;
 import com.tisawesomeness.minecord.util.DiscordUtils;
 import com.tisawesomeness.minecord.util.MessageUtils;
 
@@ -15,6 +14,7 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
+import net.dv8tion.jda.api.utils.TimeFormat;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -148,10 +148,10 @@ public class UserCommand extends Command {
             .addField("ID", u.getId(), true)
             .addField("Nickname", mem.getNickname() == null ? "None" : MarkdownSanitizer.escape(mem.getNickname()), true)
             .addField("Bot?", u.isBot() ? "Yes" : "No", true)
-            .addField("Joined Server", DateUtils.getDateAgo(mem.getTimeJoined()), false)
-            .addField("Created Account", DateUtils.getDateAgo(u.getTimeCreated()), false);
+            .addField("Joined Server", TimeFormat.RELATIVE.format(mem.getTimeJoined()), false)
+            .addField("Created Account", TimeFormat.RELATIVE.format(u.getTimeCreated()), false);
         if (mem.getTimeBoosted() != null) {
-            eb.addField("Boosted", DateUtils.getDateAgo(mem.getTimeBoosted()), false);
+            eb.addField("Boosted", TimeFormat.RELATIVE.format(mem.getTimeBoosted()), false);
         }
         eb.addField("Roles", roles.toString(), false);
         return new Result(Outcome.SUCCESS, MessageUtils.addFooter(eb).build());

--- a/src/com/tisawesomeness/minecord/command/player/HistoryCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/HistoryCommand.java
@@ -2,13 +2,13 @@ package com.tisawesomeness.minecord.command.player;
 
 import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.command.Command;
-import com.tisawesomeness.minecord.util.DateUtils;
 import com.tisawesomeness.minecord.util.MessageUtils;
 import com.tisawesomeness.minecord.util.NameUtils;
 import com.tisawesomeness.minecord.util.RequestUtils;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.utils.TimeFormat;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -82,7 +82,7 @@ public class HistoryCommand extends Command {
 			String name = change.getString("name");
 			String date;
 			if (change.has("changedToAt")) {
-				date = DateUtils.getDateAgo(change.getLong("changedToAt"));
+				date = TimeFormat.RELATIVE.format(change.getLong("changedToAt"));
 			} else {
 				date = "Original";
 			}

--- a/src/com/tisawesomeness/minecord/command/player/ProfileCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/ProfileCommand.java
@@ -2,7 +2,6 @@ package com.tisawesomeness.minecord.command.player;
 
 import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.command.Command;
-import com.tisawesomeness.minecord.util.DateUtils;
 import com.tisawesomeness.minecord.util.MessageUtils;
 import com.tisawesomeness.minecord.util.NameUtils;
 import com.tisawesomeness.minecord.util.RequestUtils;
@@ -10,6 +9,7 @@ import com.tisawesomeness.minecord.util.RequestUtils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.utils.MarkdownUtil;
+import net.dv8tion.jda.api.utils.TimeFormat;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -112,7 +112,7 @@ public class ProfileCommand extends Command {
 			String nameChange = change.getString("name");
 			String date;
 			if (change.has("changedToAt")) {
-				date = DateUtils.getDateAgoShort(change.getLong("changedToAt"));
+				date = TimeFormat.RELATIVE.format(change.getLong("changedToAt"));
 			} else {
 				date = "Original";
 			}

--- a/src/com/tisawesomeness/minecord/command/utility/ServerCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/ServerCommand.java
@@ -132,7 +132,7 @@ public class ServerCommand extends Command {
 		} else {
 			String favicon = reply.getFavicon().replace("\n", "");
 			if (favicon.contains(",")) {
-				if (e.getMember().hasPermission(e.getTextChannel(), Permission.MESSAGE_ATTACH_FILES)) {
+				if (!e.isFromGuild() || e.getGuild().getSelfMember().hasPermission(e.getTextChannel(), Permission.MESSAGE_ATTACH_FILES)) {
 					try {
 						byte[] data = Base64.getDecoder().decode(favicon.split(",")[1]);
 						e.getChannel().sendFile(data, "favicon.png").setEmbeds(eb.setDescription(m).setThumbnail("attachment://favicon.png").build()).queue();

--- a/src/com/tisawesomeness/minecord/util/DateUtils.java
+++ b/src/com/tisawesomeness/minecord/util/DateUtils.java
@@ -2,18 +2,8 @@ package com.tisawesomeness.minecord.util;
 
 import com.tisawesomeness.minecord.Bot;
 
-import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-
 public class DateUtils {
 
-	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy @ hh:mm:ss a z").withZone(ZoneId.systemDefault());
-	private static final DateTimeFormatter formatterShort = DateTimeFormatter.ofPattern("MM/dd/yyyy").withZone(ZoneId.systemDefault());
-	
 	public static String getUptime() {
 		long uptimeRaw = System.currentTimeMillis() - Bot.birth;
 		uptimeRaw = Math.floorDiv(uptimeRaw, 1000L);
@@ -49,42 +39,6 @@ public class DateUtils {
 	 */
 	public static String getBootTime() {
 		return (double) Bot.bootTime / 1000 + "s";
-	}
-
-	/**
-	 * Generates a string with the formatted date and the amount of days since that date
-	 * @param time The timestamp to measure, must be in the past
-	 * @return A string formatted to "%s (%d days ago)"
-	 */
-	public static String getDateAgo(long time) {
-		return getDateAgo(Instant.ofEpochMilli(time).atOffset(ZoneOffset.UTC));
-	}
-
-	/**
-	 * Generates a string with the formatted date and the amount of days since that date
-	 * @param time The date to measure, must be in the past
-	 * @return A string formatted to "%s (%d days ago)"
-	 */
-	public static String getDateAgo(OffsetDateTime time) {
-		return String.format("%s (**%d** days ago)", time.format(formatter), time.until(OffsetDateTime.now(), ChronoUnit.DAYS));
-	}
-
-	/**
-	 * Generates a string with the formatted date and the amount of days since that date
-	 * @param time The timestamp to measure, must be in the past
-	 * @return A string formatted to "%s (%d days ago)"
-	 */
-	public static String getDateAgoShort(long time) {
-		return getDateAgoShort(Instant.ofEpochMilli(time).atOffset(ZoneOffset.UTC));
-	}
-
-	/**
-	 * Generates a string with the formatted date and the amount of days since that date
-	 * @param time The date to measure, must be in the past
-	 * @return A string formatted to "%s (%d days ago)"
-	 */
-	public static String getDateAgoShort(OffsetDateTime time) {
-		return String.format("%s (**%d** days ago)", time.format(formatterShort), time.until(OffsetDateTime.now(), ChronoUnit.DAYS));
 	}
 
 }


### PR DESCRIPTION
- `&history`, `&profile`, `&guild`, `&role`, and `&user` now use Discord-formatted timestamps
- Added role icon, bot, boost, and integration info to `&role`
- `&perms` will check if the bot has permission to upload server icons
- Fix `&server` incorrectly checking for upload server icon permissions
- Improved exception formatting