### PR TITLE
Version 0.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ A robust Discord bot using the JDA library for various Minecraft functions.
 - *Elevated Skip Cooldown:* Whether or not elevated users skip command cooldowns.
 - *Use Electroid API:* Whether to use the Electroid API to speed up player lookups. May cause slowdowns if the API is consistently down.
 - *Use Gapple API:* Whether to use the Gapple API to look up account types. May cause slowdowns if the API is consistently down.
+- *Item Image Host:* The website hosting item images.
+- *Recipe Image Host:* The website hosting recipe images.
 
 - *Send Server Count:* Whether or not the bot should send the guild count to bot list websites.
 - *Pw Token:* The token to use on bots.discord.pw.
@@ -146,7 +148,9 @@ A robust Discord bot using the JDA library for various Minecraft functions.
         "showMemory": false,
         "elevatedSkipCooldown": true,
         "useElectroidAPI": true,
-        "useGappleAPI": true
+        "useGappleAPI": true,
+        "itemImageHost": "https://minecord.github.io/item/",
+        "recipeImageHost": "https://minecord.github.io/recipe/"
     },
     "botLists": {
         "sendServerCount": false,

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A robust Discord bot using the JDA library for various Minecraft functions.
 - `&avatar <player> [<scale>] [<overlay?>]` - Shows an image of the player's avatar.
 - `&head <player> [<scale>] [<overlay?>]` - Shows an image of the player's head.
 - `&body <player> [<scale>] [<overlay?>]` - Shows an image of the player's body.
+- `&ansi <player> [<overlay?>]` - Converts a player's avatar to a colored text message.
 
 #### Utility Commands
 - `&status` - Checks the status of Mojang servers.
@@ -47,6 +48,7 @@ A robust Discord bot using the JDA library for various Minecraft functions.
 - `&id <id>` - Gets the creation time of a Discord ID.
 - `&purge <number>` - Cleans the bot messages. Requires Manage Messages permissions.
 - `&perms [<channel>]` - Test the bot's permissions in a channel. Leave blank to test the current channel.
+- `&settings [setting] [value]` - Change the bot's settings, including prefix.
 
 #### Admin Commands
 - `&help <command> admin` - Displays admin help for a command.

--- a/config.json
+++ b/config.json
@@ -23,7 +23,9 @@
         "showMemory": false,
         "elevatedSkipCooldown": true,
         "useElectroidAPI": true,
-        "useGappleAPI": true
+        "useGappleAPI": true,
+        "itemImageHost": "https://minecord.github.io/item/",
+        "recipeImageHost": "https://minecord.github.io/recipe/"
     },
     "botLists": {
         "sendServerCount": false,

--- a/items.json
+++ b/items.json
@@ -1918,6 +1918,9 @@
   "minecraft.oak_fence": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Oak Wood Fence"
+        ],
         "display_name": "Oak Fence"
       }
     },
@@ -5472,17 +5475,17 @@
   "minecraft.dirt_path": {
     "lang": {
       "en_US": {
+        "previously": "Grass Path",
         "search_names": [
           "Path",
           "Path Block"
         ],
-        "previously": "Grass Path",
         "display_name": "Dirt Path"
       }
     },
     "properties": {
-      "id": 208,
       "previous_id": "minecraft.grass_path",
+      "id": 208,
       "version": "1.9"
     }
   },
@@ -7290,6 +7293,9 @@
     "lang": {
       "en_US": {
         "previously": "Sign",
+        "search_names": [
+          "Oak Wood Sign"
+        ],
         "display_name": "Oak Sign"
       }
     },
@@ -7303,6 +7309,9 @@
   "minecraft.oak_door": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Oak Wood Door"
+        ],
         "block_name": "Oak Door Block",
         "display_name": "Oak Door"
       }
@@ -7406,6 +7415,7 @@
     "lang": {
       "en_US": {
         "search_names": [
+          "Oak Wood Boat",
           "Discord Bot"
         ],
         "display_name": "Oak Boat"
@@ -8904,7 +8914,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Bottle of Enchanting"
+          "Bottle of Enchanting",
+          "Bottle o Enchanting"
         ],
         "display_name": "Bottle o' Enchanting"
       }
@@ -10227,7 +10238,12 @@
           "13 Disc",
           "Music Disc 13",
           "Disc 13",
-          "C418 - 13"
+          "C418 - 13",
+          "Thirteen Disc",
+          "Music Disc Thirteen",
+          "Disc Thirteen",
+          "C418 - Thirteen",
+          "Thirteen"
         ],
         "display_name": "Music Disc",
         "name_conflict": true
@@ -10429,7 +10445,12 @@
           "11 Disc",
           "Music Disc 11",
           "Disc 11",
-          "C418 - 11"
+          "C418 - 11",
+          "Eleven Disc",
+          "Music Disc Eleven",
+          "Disc Eleven",
+          "C418 - Eleven",
+          "Eleven"
         ],
         "display_name": "Music Disc",
         "name_conflict": true
@@ -10637,6 +10658,9 @@
   "minecraft.acacia_button": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Acacia Wood Button"
+        ],
         "display_name": "Acacia Button"
       }
     },
@@ -13766,7 +13790,7 @@
           "Music Disc Pigstep",
           "Disc Pigstep",
           "Lena Raine - Pigstep",
-          "Best Song"
+          "Pigstep"
         ],
         "display_name": "Music Disc",
         "name_conflict": true
@@ -15767,8 +15791,8 @@
       }
     },
     "properties": {
-      "version": "1.17",
-      "image_key": "Light Negative"
+      "image_key": "Light Negative",
+      "version": "1.17"
     }
   },
   "minecraft.light_blue_candle": {
@@ -16998,6 +17022,755 @@
     },
     "properties": {
       "version": "1.17"
+    }
+  },
+  "minecraft.music_disc_otherside": {
+    "lang": {
+      "en_US": {
+        "lore": "Lena Raine - otherside",
+        "search_names": [
+          "Otherside Disc",
+          "Music Disc Otherside",
+          "Disc Otherside",
+          "Lena Raine - otherside",
+          "otherside"
+        ],
+        "display_name": "Music Disc",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Music Disc Otherside",
+      "version": "1.18"
+    }
+  },
+  "minecraft.acacia_chest_boat": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Acacia Chest Boat"
+        ],
+        "display_name": "Acacia Boat with Chest"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.allay_spawn_egg": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Spawn Allay",
+          "Allay Egg"
+        ],
+        "display_name": "Allay Spawn Egg"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.birch_chest_boat": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Birch Chest Boat",
+          "Birch Wood Boat with Chest",
+          "Birch Wood Chest Boat"
+        ],
+        "display_name": "Birch Boat with Chest"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.dark_oak_chest_boat": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Dark Oak Chest Boat",
+          "Dark Oak Wood Boat with Chest",
+          "Dark Oak Wood Chest Boat",
+          "Dark Boat with Chest",
+          "Dark Chest Boat"
+        ],
+        "display_name": "Dark Oak Boat with Chest"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.disc_fragment_5": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Music Disc Fragment",
+          "Fragment 5",
+          "Disc Shard",
+          "Music Disc Shard",
+          "Shard 5",
+          "Fragment Five",
+          "Shard Five"
+        ],
+        "display_name": "Disc Fragment"
+      }
+    },
+    "properties": {
+      "image_key": "Disc Fragment 5",
+      "version": "1.19"
+    }
+  },
+  "minecraft.echo_shard": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Soul Shard",
+          "Sculk Shard"
+        ],
+        "display_name": "Echo Shard"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.frog_spawn_egg": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Frog Egg"
+        ],
+        "display_name": "Frog Spawn Egg"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.frogspawn": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Frog Spawn",
+          "Spawn Frog",
+          "Spawn Frogs",
+          "Spawn Tadpoles",
+          "Frog Eggs",
+          "Tadpole Eggs",
+          "Frog Spawn Eggs"
+        ],
+        "display_name": "Frogspawn"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.goat_horn": {
+    "lang": {
+      "en_US": {
+        "display_name": "Goat Horn"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.jungle_chest_boat": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Jungle Chest Boat",
+          "Jungle Wood Boat with Chest",
+          "Jungle Wood Chest Boat"
+        ],
+        "display_name": "Jungle Boat with Chest"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_boat": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Wood Boat"
+        ],
+        "display_name": "Mangrove Boat"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_button": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Wood Button"
+        ],
+        "display_name": "Mangrove Button"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_chest_boat": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Chest Boat",
+          "Mangrove Wood Boat with Chest",
+          "Mangrove Wood Chest Boat"
+        ],
+        "display_name": "Mangrove Boat with Chest"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_door": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Wood Door"
+        ],
+        "display_name": "Mangrove Door"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_fence": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Wood Fence"
+        ],
+        "display_name": "Mangrove Fence"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_fence_gate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Wood Fence Gate",
+          "Mangrove Wood Gate",
+          "Mangrove Gate"
+        ],
+        "display_name": "Mangrove Fence Gate"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_leaves": {
+    "lang": {
+      "en_US": {
+        "display_name": "Mangrove Leaves"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_log": {
+    "lang": {
+      "en_US": {
+        "display_name": "Mangrove Log"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_planks": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Wood Planks",
+          "Mangrove Wood Plank",
+          "Mangrove Plank"
+        ],
+        "display_name": "Mangrove Planks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_pressure_plate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Wood Pressure Plate",
+          "Mangrove Wood Plate",
+          "Mangrove Plate"
+        ],
+        "display_name": "Mangrove Pressure Plate"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_propagule": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Sapling",
+          "Propagule"
+        ],
+        "display_name": "Mangrove Propagule"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_roots": {
+    "lang": {
+      "en_US": {
+        "display_name": "Mangrove Roots"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_sign": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Wood Sign"
+        ],
+        "display_name": "Mangrove Sign"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_slab": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Wood Slab"
+        ],
+        "display_name": "Mangrove Slab"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_stairs": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Wood Stairs",
+          "Mangrove Wood Stair",
+          "Mangrove Stair"
+        ],
+        "display_name": "Mangrove Stairs"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_trapdoor": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Wood Trapdoor",
+          "Mangrove Wood Trap Door",
+          "Mangrove Trap Door"
+        ],
+        "display_name": "Mangrove Trapdoor"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_wall_sign": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mangrove Wood Wall Sign"
+        ],
+        "display_name": "Mangrove Wall Sign"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mangrove_wood": {
+    "lang": {
+      "en_US": {
+        "display_name": "Mangrove Wood"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mud": {
+    "lang": {
+      "en_US": {
+        "display_name": "Mud"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mud_brick_slab": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mud Bricks Slab"
+        ],
+        "display_name": "Mud Brick Slab"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mud_brick_stairs": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mud Bricks Stairs",
+          "Mud Bricks Stair",
+          "Mud Brick Stair"
+        ],
+        "display_name": "Mud Brick Stairs"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mud_brick_wall": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mud Bricks Wall"
+        ],
+        "display_name": "Mud Brick Wall"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.mud_bricks": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mud Bricks"
+        ],
+        "display_name": "Mud Bricks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.muddy_mangrove_roots": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Mud Mangrove Roots",
+          "Mangrove Mud Roots"
+        ],
+        "display_name": "Muddy Mangrove Roots"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.music_disc_5": {
+    "lang": {
+      "en_US": {
+        "lore": "C418 - 5",
+        "search_names": [
+          "5 Disc",
+          "Music Disc 5",
+          "Disc 5",
+          "C418 - 5",
+          "Five Disc",
+          "Music Disc Five",
+          "Disc Five",
+          "C418 - Five",
+          "Five"
+        ],
+        "display_name": "Music Disc",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Music Disc 5",
+      "version": "1.19"
+    }
+  },
+  "minecraft.oak_chest_boat": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Oak Chest Boat",
+          "Oak Wood Boat with Chest",
+          "Oak Wood Chest Boat"
+        ],
+        "display_name": "Oak Boat with Chest"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.ochre_froglight": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Ochre Frog Light",
+          "Yellow Froglight",
+          "Yellow Frog Light"
+        ],
+        "display_name": "Ochre Froglight"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.packed_mud": {
+    "lang": {
+      "en_US": {
+        "display_name": "Packed Mud"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.pearlescent_froglight": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Pearlescent Frog Light",
+          "Purple Froglight",
+          "Purple Frog Light"
+        ],
+        "display_name": "Pearlescent Froglight"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.potted_mangrove_propagule": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Potted Mangrove Sapling",
+          "Potted Propagule"
+        ],
+        "display_name": "Potted Mangrove Propagule"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.recovery_compass": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Death Compass",
+          "Echo Compass",
+          "Sculk Compass"
+        ],
+        "display_name": "Recovery Compass"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.reinforced_deepslate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Reinforced Grimstone",
+          "Reinforced Grim Stone"
+        ],
+        "display_name": "Reinforced Deepslate"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.sculk": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Sculk Block"
+        ],
+        "display_name": "Sculk"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.sculk_catalyst": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Sculk Spreader"
+        ],
+        "display_name": "Sculk Catalyst"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.sculk_shrieker": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Sculk Screamer"
+        ],
+        "display_name": "Sculk Shrieker"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.sculk_vein": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Sculk Vines"
+        ],
+        "display_name": "Sculk Vein"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.spruce_chest_boat": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Spruce Chest Boat",
+          "Spruce Wood Boat with Chest",
+          "Spruce Wood Chest Boat"
+        ],
+        "display_name": "Spruce Boat with Chest"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.stripped_mangrove_log": {
+    "lang": {
+      "en_US": {
+        "display_name": "Stripped Mangrove Log"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.stripped_mangrove_wood": {
+    "lang": {
+      "en_US": {
+        "display_name": "Stripped Mangrove Wood"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.tadpole_bucket": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Tadpole Bucket",
+          "Bucket of Tadpoles"
+        ],
+        "display_name": "Bucket of Tadpole"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.tadpole_spawn_egg": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Spawn Tadpole",
+          "Tadpole Egg"
+        ],
+        "display_name": "Tadpole Spawn Egg"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.verdant_froglight": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Verdant Frog Light",
+          "Green Froglight",
+          "Green Frog Light"
+        ],
+        "display_name": "Verdant Froglight"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "minecraft.warden_spawn_egg": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Spawn Warden",
+          "Warden Egg"
+        ],
+        "display_name": "Warden Spawn Egg"
+      }
+    },
+    "properties": {
+      "version": "1.19"
     }
   },
   "minecraft.lingering_potion.effect.awkward": {

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.15.0</version>
+  <version>0.15.1</version>
 
   <repositories>
     <repository>

--- a/recipes.json
+++ b/recipes.json
@@ -33,6 +33,24 @@
     },
     "group": "wooden_button"
   },
+  "acacia_chest_boat": {
+    "result": {
+      "item": "minecraft:acacia_chest_boat"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:chest"
+      },
+      {
+        "item": "minecraft:acacia_boat"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "chest_boat"
+  },
   "acacia_door": {
     "result": {
       "item": "minecraft:acacia_door",
@@ -1000,6 +1018,24 @@
       "version": "1.13"
     },
     "group": "wooden_button"
+  },
+  "birch_chest_boat": {
+    "result": {
+      "item": "minecraft:birch_chest_boat"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:chest"
+      },
+      {
+        "item": "minecraft:birch_boat"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "chest_boat"
   },
   "birch_door": {
     "result": {
@@ -3033,12 +3069,15 @@
     }
   },
   "bundle": {
-    "type": "minecraft:crafting_shaped",
+    "result": {
+      "item": "minecraft:bundle"
+    },
     "pattern": [
       "-#-",
       "# #",
       "###"
     ],
+    "type": "minecraft:crafting_shaped",
     "key": {
       "#": {
         "item": "minecraft:rabbit_hide"
@@ -3046,9 +3085,6 @@
       "-": {
         "item": "minecraft:string"
       }
-    },
-    "result": {
-      "item": "minecraft:bundle"
     },
     "properties": {
       "version": "1.17 Datapack"
@@ -3095,11 +3131,11 @@
     ],
     "type": "minecraft:crafting_shaped",
     "key": {
-      "S": {
-        "item": "minecraft:stick"
-      },
       "C": {
         "tag": "minecraft:coals"
+      },
+      "S": {
+        "item": "minecraft:stick"
       },
       "L": {
         "tag": "minecraft:logs"
@@ -3319,17 +3355,18 @@
     "result": {
       "item": "minecraft:chest_minecart"
     },
-    "pattern": [
-      "A",
-      "B"
-    ],
-    "type": "minecraft:crafting_shaped",
-    "key": {
-      "A": {
+    "ingredients": [
+      {
         "item": "minecraft:chest"
       },
-      "B": {
+      {
         "item": "minecraft:minecart"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.19, recipe is shaped."
       }
     }
   },
@@ -3621,8 +3658,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "coal",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "coal"
   },
   "coal_from_blasting_deepslate_coal_ore": {
     "result": "minecraft:coal",
@@ -3634,8 +3671,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "coal",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "coal"
   },
   "coal_from_smelting_coal_ore": {
     "result": "minecraft:coal",
@@ -3644,8 +3681,8 @@
     },
     "type": "minecraft:smelting",
     "experience": 0.1,
-    "group": "coal",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "coal"
   },
   "coal_from_smelting_deepslate_coal_ore": {
     "result": "minecraft:coal",
@@ -3657,8 +3694,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "coal",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "coal"
   },
   "coarse_dirt": {
     "result": {
@@ -3928,12 +3965,46 @@
     ],
     "type": "minecraft:crafting_shaped",
     "key": {
-      "#": {
-        "tag": "minecraft:planks"
-      },
-      "X": {
-        "tag": "minecraft:wooden_fences"
-      }
+      "#": [
+        {
+          "item": "minecraft:oak_planks"
+        },
+        {
+          "item": "minecraft:spruce_planks"
+        },
+        {
+          "item": "minecraft:birch_planks"
+        },
+        {
+          "item": "minecraft:jungle_planks"
+        },
+        {
+          "item": "minecraft:acacia_planks"
+        },
+        {
+          "item": "minecraft:dark_oak_planks"
+        }
+      ],
+      "X": [
+        {
+          "item": "minecraft:oak_fence"
+        },
+        {
+          "item": "minecraft:spruce_fence"
+        },
+        {
+          "item": "minecraft:birch_fence"
+        },
+        {
+          "item": "minecraft:jungle_fence"
+        },
+        {
+          "item": "minecraft:acacia_fence"
+        },
+        {
+          "item": "minecraft:dark_oak_fence"
+        }
+      ]
     },
     "properties": {
       "removed": "1.15",
@@ -4221,8 +4292,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "copper_ingot",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "copper_ingot"
   },
   "copper_ingot_from_blasting_deepslate_copper_ore": {
     "result": "minecraft:copper_ingot",
@@ -4234,8 +4305,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "copper_ingot",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "copper_ingot"
   },
   "copper_ingot_from_blasting_raw_copper": {
     "result": "minecraft:copper_ingot",
@@ -4247,8 +4318,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "copper_ingot",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "copper_ingot"
   },
   "copper_ingot_from_smelting_copper_ore": {
     "result": "minecraft:copper_ingot",
@@ -4260,8 +4331,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "copper_ingot",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "copper_ingot"
   },
   "copper_ingot_from_smelting_deepslate_copper_ore": {
     "result": "minecraft:copper_ingot",
@@ -4273,8 +4344,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "copper_ingot",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "copper_ingot"
   },
   "copper_ingot_from_smelting_raw_copper": {
     "result": "minecraft:copper_ingot",
@@ -4286,8 +4357,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "copper_ingot",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "copper_ingot"
   },
   "copper_ingot_from_waxed_copper_block": {
     "result": {
@@ -4672,8 +4743,13 @@
     "ingredient": {
       "item": "minecraft:copper_block"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -4701,8 +4777,13 @@
     "ingredient": {
       "item": "minecraft:copper_block"
     },
-    "count": 2,
+    "count": 8,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 2 blocks."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -4743,8 +4824,13 @@
     "ingredient": {
       "item": "minecraft:copper_block"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -5235,6 +5321,24 @@
       "version": "1.13"
     },
     "group": "wooden_button"
+  },
+  "dark_oak_chest_boat": {
+    "result": {
+      "item": "minecraft:dark_oak_chest_boat"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:chest"
+      },
+      {
+        "item": "minecraft:dark_oak_boat"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "chest_boat"
   },
   "dark_oak_door": {
     "result": {
@@ -6125,8 +6229,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "diamond",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "diamond"
   },
   "diamond_from_blasting_diamond_ore": {
     "result": "minecraft:diamond",
@@ -6135,8 +6239,8 @@
     },
     "type": "minecraft:blasting",
     "experience": 1,
-    "group": "diamond",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "diamond"
   },
   "diamond_from_smelting_deepslate_diamond_ore": {
     "result": "minecraft:diamond",
@@ -6148,8 +6252,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "diamond",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "diamond"
   },
   "diamond_from_smelting_diamond_ore": {
     "result": "minecraft:diamond",
@@ -6158,8 +6262,8 @@
     },
     "type": "minecraft:smelting",
     "experience": 1,
-    "group": "diamond",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "diamond"
   },
   "diamond_helmet": {
     "result": {
@@ -6548,8 +6652,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "emerald",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "emerald"
   },
   "emerald_from_blasting_emerald_ore": {
     "result": "minecraft:emerald",
@@ -6558,8 +6662,8 @@
     },
     "type": "minecraft:blasting",
     "experience": 1,
-    "group": "emerald",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "emerald"
   },
   "emerald_from_smelting_deepslate_emerald_ore": {
     "result": "minecraft:emerald",
@@ -6571,8 +6675,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "emerald",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "emerald"
   },
   "emerald_from_smelting_emerald_ore": {
     "result": "minecraft:emerald",
@@ -6581,8 +6685,8 @@
     },
     "type": "minecraft:smelting",
     "experience": 1,
-    "group": "emerald",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "emerald"
   },
   "empty_lingering_potion": {
     "result": "minecraft.lingering_potion.effect.empty",
@@ -6911,8 +7015,13 @@
     "ingredient": {
       "item": "minecraft:exposed_copper"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -6940,8 +7049,13 @@
     "ingredient": {
       "item": "minecraft:exposed_copper"
     },
-    "count": 2,
+    "count": 8,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 2 blocks."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -6982,8 +7096,13 @@
     "ingredient": {
       "item": "minecraft:exposed_copper"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -7635,7 +7754,7 @@
     "type": "minecraft:crafting_special_firework_rocket",
     "lang": {
       "en_US": {
-        "notes": "\nAdding gunpowder increases flight duration.\nUp to 7 firework stars can be used.\nGives 1 firework rocket before 1.10"
+        "notes": "\nAdding gunpowder increases flight duration.\nUp to 7 firework stars can be used.\nGives 1 firework rocket before 1.10."
       }
     },
     "properties": {
@@ -8103,17 +8222,18 @@
     "result": {
       "item": "minecraft:furnace_minecart"
     },
-    "pattern": [
-      "A",
-      "B"
-    ],
-    "type": "minecraft:crafting_shaped",
-    "key": {
-      "A": {
+    "ingredients": [
+      {
         "item": "minecraft:furnace"
       },
-      "B": {
+      {
         "item": "minecraft:minecart"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.19, recipe is shaped."
       }
     }
   },
@@ -8238,8 +8358,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "gold_ingot",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "gold_ingot"
   },
   "gold_ingot_from_blasting_gold_ore": {
     "result": "minecraft:gold_ingot",
@@ -8248,8 +8368,8 @@
     },
     "type": "minecraft:blasting",
     "experience": 1,
-    "group": "gold_ingot",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "gold_ingot"
   },
   "gold_ingot_from_blasting_nether_gold_ore": {
     "result": "minecraft:gold_ingot",
@@ -8261,8 +8381,8 @@
     "properties": {
       "version": "1.16"
     },
-    "group": "gold_ingot",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "gold_ingot"
   },
   "gold_ingot_from_blasting_raw_gold": {
     "result": "minecraft:gold_ingot",
@@ -8274,8 +8394,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "gold_ingot",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "gold_ingot"
   },
   "gold_ingot_from_gold_block": {
     "result": {
@@ -8317,8 +8437,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "gold_ingot",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "gold_ingot"
   },
   "gold_ingot_from_smelting_gold_ore": {
     "result": "minecraft:gold_ingot",
@@ -8327,8 +8447,8 @@
     },
     "type": "minecraft:smelting",
     "experience": 1,
-    "group": "gold_ingot",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "gold_ingot"
   },
   "gold_ingot_from_smelting_nether_gold_ore": {
     "result": "minecraft:gold_ingot",
@@ -8340,8 +8460,8 @@
     "properties": {
       "version": "1.16"
     },
-    "group": "gold_ingot",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "gold_ingot"
   },
   "gold_ingot_from_smelting_raw_gold": {
     "result": "minecraft:gold_ingot",
@@ -8353,8 +8473,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "gold_ingot",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "gold_ingot"
   },
   "gold_nugget": {
     "result": {
@@ -9557,17 +9677,18 @@
     "result": {
       "item": "minecraft:hopper_minecart"
     },
-    "pattern": [
-      "A",
-      "B"
-    ],
-    "type": "minecraft:crafting_shaped",
-    "key": {
-      "A": {
+    "ingredients": [
+      {
         "item": "minecraft:hopper"
       },
-      "B": {
+      {
         "item": "minecraft:minecart"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.19, recipe is shaped."
       }
     }
   },
@@ -9747,8 +9868,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "iron_ingot",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "iron_ingot"
   },
   "iron_ingot_from_blasting_iron_ore": {
     "result": "minecraft:iron_ingot",
@@ -9757,8 +9878,8 @@
     },
     "type": "minecraft:blasting",
     "experience": 0.7,
-    "group": "iron_ingot",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "iron_ingot"
   },
   "iron_ingot_from_blasting_raw_iron": {
     "result": "minecraft:iron_ingot",
@@ -9770,8 +9891,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "iron_ingot",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "iron_ingot"
   },
   "iron_ingot_from_iron_block": {
     "result": {
@@ -9816,8 +9937,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "iron_ingot",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "iron_ingot"
   },
   "iron_ingot_from_smelting_iron_ore": {
     "result": "minecraft:iron_ingot",
@@ -9826,8 +9947,8 @@
     },
     "type": "minecraft:smelting",
     "experience": 0.7,
-    "group": "iron_ingot",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "iron_ingot"
   },
   "iron_ingot_from_smelting_raw_iron": {
     "result": "minecraft:iron_ingot",
@@ -9839,8 +9960,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "iron_ingot",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "iron_ingot"
   },
   "iron_leggings": {
     "result": {
@@ -10148,6 +10269,24 @@
     },
     "group": "wooden_button"
   },
+  "jungle_chest_boat": {
+    "result": {
+      "item": "minecraft:jungle_chest_boat"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:chest"
+      },
+      {
+        "item": "minecraft:jungle_boat"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "chest_boat"
+  },
   "jungle_door": {
     "result": {
       "item": "minecraft:jungle_door",
@@ -10423,8 +10562,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "lapis_lazuli",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "lapis_lazuli"
   },
   "lapis_lazuli_from_blasting_lapis_ore": {
     "result": "minecraft:lapis_lazuli",
@@ -10433,8 +10572,8 @@
     },
     "type": "minecraft:blasting",
     "experience": 0.2,
-    "group": "lapis_lazuli",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "lapis_lazuli"
   },
   "lapis_lazuli_from_smelting_deepslate_lapis_ore": {
     "result": "minecraft:lapis_lazuli",
@@ -10446,8 +10585,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "lapis_lazuli",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "lapis_lazuli"
   },
   "lapis_lazuli_from_smelting_lapis_ore": {
     "result": "minecraft:lapis_lazuli",
@@ -10456,8 +10595,8 @@
     },
     "type": "minecraft:smelting",
     "experience": 0.2,
-    "group": "lapis_lazuli",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "lapis_lazuli"
   },
   "lead": {
     "result": {
@@ -12433,11 +12572,11 @@
     ],
     "type": "minecraft:crafting_shaped",
     "key": {
-      "S": {
-        "item": "minecraft:chiseled_stone_bricks"
-      },
       "#": {
         "item": "minecraft:netherite_ingot"
+      },
+      "S": {
+        "item": "minecraft:chiseled_stone_bricks"
       }
     },
     "properties": {
@@ -12899,6 +13038,263 @@
     ],
     "type": "minecraft:crafting_shapeless"
   },
+  "mangrove_boat": {
+    "result": {
+      "item": "minecraft:mangrove_boat"
+    },
+    "pattern": [
+      "# #",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:mangrove_planks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "boat"
+  },
+  "mangrove_button": {
+    "result": {
+      "item": "minecraft:mangrove_button"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:mangrove_planks"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "wooden_button"
+  },
+  "mangrove_chest_boat": {
+    "result": {
+      "item": "minecraft:mangrove_chest_boat"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:chest"
+      },
+      {
+        "item": "minecraft:mangrove_boat"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "chest_boat"
+  },
+  "mangrove_door": {
+    "result": {
+      "item": "minecraft:mangrove_door",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:mangrove_planks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "wooden_door"
+  },
+  "mangrove_fence": {
+    "result": {
+      "item": "minecraft:mangrove_fence",
+      "count": 3
+    },
+    "pattern": [
+      "W#W",
+      "W#W"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:stick"
+      },
+      "W": {
+        "item": "minecraft:mangrove_planks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "wooden_fence"
+  },
+  "mangrove_fence_gate": {
+    "result": {
+      "item": "minecraft:mangrove_fence_gate"
+    },
+    "pattern": [
+      "#W#",
+      "#W#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:stick"
+      },
+      "W": {
+        "item": "minecraft:mangrove_planks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "wooden_fence_gate"
+  },
+  "mangrove_planks": {
+    "result": {
+      "item": "minecraft:mangrove_planks",
+      "count": 4
+    },
+    "ingredients": [
+      {
+        "tag": "minecraft:mangrove_logs"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.19"
+    },
+    "group": "planks"
+  },
+  "mangrove_pressure_plate": {
+    "result": {
+      "item": "minecraft:mangrove_pressure_plate"
+    },
+    "pattern": [
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:mangrove_planks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "wooden_pressure_plate"
+  },
+  "mangrove_sign": {
+    "result": {
+      "item": "minecraft:mangrove_sign",
+      "count": 3
+    },
+    "pattern": [
+      "###",
+      "###",
+      " X "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:mangrove_planks"
+      },
+      "X": {
+        "item": "minecraft:stick"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "wooden_sign"
+  },
+  "mangrove_slab": {
+    "result": {
+      "item": "minecraft:mangrove_slab",
+      "count": 6
+    },
+    "pattern": [
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:mangrove_planks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "wooden_slab"
+  },
+  "mangrove_stairs": {
+    "result": {
+      "item": "minecraft:mangrove_stairs",
+      "count": 4
+    },
+    "pattern": [
+      "#  ",
+      "## ",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:mangrove_planks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "wooden_stairs"
+  },
+  "mangrove_trapdoor": {
+    "result": {
+      "item": "minecraft:mangrove_trapdoor",
+      "count": 2
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:mangrove_planks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "wooden_trapdoor"
+  },
+  "mangrove_wood": {
+    "result": {
+      "item": "minecraft:mangrove_wood",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:mangrove_log"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "bark"
+  },
   "map": {
     "result": {
       "item": "minecraft:map"
@@ -13254,6 +13650,132 @@
     },
     "group": "mossy_stone_bricks"
   },
+  "mud_brick_slab": {
+    "result": {
+      "item": "minecraft:mud_brick_slab",
+      "count": 6
+    },
+    "pattern": [
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:mud_bricks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "mud_brick_slab_from_mud_bricks_stonecutting": {
+    "result": "minecraft:mud_brick_slab",
+    "ingredient": {
+      "item": "minecraft:mud_bricks"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "mud_brick_stairs": {
+    "result": {
+      "item": "minecraft:mud_brick_stairs",
+      "count": 4
+    },
+    "pattern": [
+      "#  ",
+      "## ",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:mud_bricks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "mud_brick_stairs_from_mud_bricks_stonecutting": {
+    "result": "minecraft:mud_brick_stairs",
+    "ingredient": {
+      "item": "minecraft:mud_bricks"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "mud_brick_wall": {
+    "result": {
+      "item": "minecraft:mud_brick_wall",
+      "count": 6
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:mud_bricks"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "mud_brick_wall_from_mud_bricks_stonecutting": {
+    "result": "minecraft:mud_brick_wall",
+    "ingredient": {
+      "item": "minecraft:mud_bricks"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "mud_bricks": {
+    "result": {
+      "item": "minecraft:mud_bricks",
+      "count": 4
+    },
+    "pattern": [
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:packed_mud"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
+  "muddy_mangrove_roots": {
+    "result": {
+      "item": "minecraft:muddy_mangrove_roots"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:mud"
+      },
+      {
+        "item": "minecraft:mangrove_roots"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.19"
+    }
+  },
   "mundane_lingering_potion": {
     "result": "minecraft.lingering_potion.effect.mundane",
     "reagent": {
@@ -13332,6 +13854,25 @@
       }
     ],
     "type": "minecraft:crafting_shapeless"
+  },
+  "music_disc_5": {
+    "result": {
+      "item": "minecraft:music_disc_5"
+    },
+    "pattern": [
+      "SSS",
+      "SSS",
+      "SSS"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "S": {
+        "item": "minecraft:disc_fragment_5"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
   },
   "nether_brick": {
     "result": "minecraft:nether_brick",
@@ -13509,11 +14050,11 @@
     "properties": {
       "version": "1.16"
     },
-    "base": {
-      "item": "minecraft:diamond_axe"
-    },
     "addition": {
       "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_axe"
     }
   },
   "netherite_block": {
@@ -13543,11 +14084,11 @@
     "properties": {
       "version": "1.16"
     },
-    "base": {
-      "item": "minecraft:diamond_boots"
-    },
     "addition": {
       "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_boots"
     }
   },
   "netherite_chestplate_smithing": {
@@ -13558,11 +14099,11 @@
     "properties": {
       "version": "1.16"
     },
-    "base": {
-      "item": "minecraft:diamond_chestplate"
-    },
     "addition": {
       "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_chestplate"
     }
   },
   "netherite_helmet_smithing": {
@@ -13573,11 +14114,11 @@
     "properties": {
       "version": "1.16"
     },
-    "base": {
-      "item": "minecraft:diamond_helmet"
-    },
     "addition": {
       "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_helmet"
     }
   },
   "netherite_hoe_smithing": {
@@ -13588,11 +14129,11 @@
     "properties": {
       "version": "1.16"
     },
-    "base": {
-      "item": "minecraft:diamond_hoe"
-    },
     "addition": {
       "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_hoe"
     }
   },
   "netherite_ingot": {
@@ -13655,11 +14196,11 @@
     "properties": {
       "version": "1.16"
     },
-    "base": {
-      "item": "minecraft:diamond_leggings"
-    },
     "addition": {
       "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_leggings"
     }
   },
   "netherite_pickaxe_smithing": {
@@ -13670,11 +14211,11 @@
     "properties": {
       "version": "1.16"
     },
-    "base": {
-      "item": "minecraft:diamond_pickaxe"
-    },
     "addition": {
       "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_pickaxe"
     }
   },
   "netherite_scrap": {
@@ -13709,11 +14250,11 @@
     "properties": {
       "version": "1.16"
     },
-    "base": {
-      "item": "minecraft:diamond_shovel"
-    },
     "addition": {
       "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_shovel"
     }
   },
   "netherite_sword_smithing": {
@@ -13724,11 +14265,11 @@
     "properties": {
       "version": "1.16"
     },
-    "base": {
-      "item": "minecraft:diamond_sword"
-    },
     "addition": {
       "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_sword"
     }
   },
   "night_vision_lingering_potion": {
@@ -13813,6 +14354,24 @@
     ],
     "type": "minecraft:crafting_shapeless",
     "group": "wooden_button"
+  },
+  "oak_chest_boat": {
+    "result": {
+      "item": "minecraft:oak_chest_boat"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:chest"
+      },
+      {
+        "item": "minecraft:oak_boat"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "chest_boat"
   },
   "oak_door": {
     "result": {
@@ -14362,8 +14921,13 @@
     "ingredient": {
       "item": "minecraft:oxidized_copper"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -14391,8 +14955,13 @@
     "ingredient": {
       "item": "minecraft:oxidized_copper"
     },
-    "count": 2,
+    "count": 8,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 2 blocks."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -14433,8 +15002,13 @@
     "ingredient": {
       "item": "minecraft:oxidized_copper"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -14486,6 +15060,23 @@
     "type": "minecraft:crafting_shapeless",
     "properties": {
       "version": "1.13"
+    }
+  },
+  "packed_mud": {
+    "result": {
+      "item": "minecraft:packed_mud"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:mud"
+      },
+      {
+        "item": "minecraft:wheat"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.19"
     }
   },
   "painting": {
@@ -16855,6 +17446,28 @@
       "version": "1.17"
     }
   },
+  "recovery_compass": {
+    "result": {
+      "item": "minecraft:recovery_compass"
+    },
+    "pattern": [
+      "SSS",
+      "SCS",
+      "SSS"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "C": {
+        "item": "minecraft:compass"
+      },
+      "S": {
+        "item": "minecraft:echo_shard"
+      }
+    },
+    "properties": {
+      "version": "1.19"
+    }
+  },
   "red_banner": {
     "result": {
       "item": "minecraft:red_banner"
@@ -17443,8 +18056,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "redstone",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "redstone"
   },
   "redstone_from_blasting_redstone_ore": {
     "result": "minecraft:redstone",
@@ -17453,8 +18066,8 @@
     },
     "type": "minecraft:blasting",
     "experience": 0.7,
-    "group": "redstone",
-    "cookingtime": 100
+    "cookingtime": 100,
+    "group": "redstone"
   },
   "redstone_from_smelting_deepslate_redstone_ore": {
     "result": "minecraft:redstone",
@@ -17466,8 +18079,8 @@
     "properties": {
       "version": "1.17"
     },
-    "group": "redstone",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "redstone"
   },
   "redstone_from_smelting_redstone_ore": {
     "result": "minecraft:redstone",
@@ -17476,8 +18089,8 @@
     },
     "type": "minecraft:smelting",
     "experience": 0.7,
-    "group": "redstone",
-    "cookingtime": 200
+    "cookingtime": 200,
+    "group": "redstone"
   },
   "redstone_lamp": {
     "result": {
@@ -17747,11 +18360,11 @@
     ],
     "type": "minecraft:crafting_shaped",
     "key": {
-      "S": {
-        "item": "minecraft:prismarine_shard"
-      },
       "C": {
         "item": "minecraft:prismarine_crystals"
+      },
+      "S": {
+        "item": "minecraft:prismarine_shard"
       }
     },
     "properties": {
@@ -19616,11 +20229,11 @@
     ],
     "type": "minecraft:crafting_shaped",
     "key": {
-      "S": {
-        "item": "minecraft:stick"
-      },
       "#": {
         "tag": "minecraft:soul_fire_base_blocks"
+      },
+      "S": {
+        "item": "minecraft:stick"
       },
       "L": {
         "tag": "minecraft:logs"
@@ -20399,6 +21012,24 @@
     },
     "group": "wooden_button"
   },
+  "spruce_chest_boat": {
+    "result": {
+      "item": "minecraft:spruce_chest_boat"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:chest"
+      },
+      {
+        "item": "minecraft:spruce_boat"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "version": "1.19"
+    },
+    "group": "chest_boat"
+  },
   "spruce_door": {
     "result": {
       "item": "minecraft:spruce_door",
@@ -21175,6 +21806,26 @@
     },
     "properties": {
       "version": "1.15"
+    },
+    "group": "bark"
+  },
+  "stripped_mangrove_wood": {
+    "result": {
+      "item": "minecraft:stripped_mangrove_wood",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:stripped_mangrove_log"
+      }
+    },
+    "properties": {
+      "version": "1.19"
     },
     "group": "bark"
   },
@@ -22470,17 +23121,18 @@
     "result": {
       "item": "minecraft:tnt_minecart"
     },
-    "pattern": [
-      "A",
-      "B"
-    ],
-    "type": "minecraft:crafting_shaped",
-    "key": {
-      "A": {
+    "ingredients": [
+      {
         "item": "minecraft:tnt"
       },
-      "B": {
+      {
         "item": "minecraft:minecart"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.19, recipe is shaped."
       }
     }
   },
@@ -22974,8 +23626,13 @@
     "ingredient": {
       "item": "minecraft:waxed_copper_block"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23022,8 +23679,13 @@
     "ingredient": {
       "item": "minecraft:waxed_copper_block"
     },
-    "count": 2,
+    "count": 8,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 2 blocks."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23083,8 +23745,13 @@
     "ingredient": {
       "item": "minecraft:waxed_copper_block"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23161,8 +23828,13 @@
     "ingredient": {
       "item": "minecraft:waxed_exposed_copper"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23209,8 +23881,13 @@
     "ingredient": {
       "item": "minecraft:waxed_exposed_copper"
     },
-    "count": 2,
+    "count": 8,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 2 blocks."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23270,8 +23947,13 @@
     "ingredient": {
       "item": "minecraft:waxed_exposed_copper"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23348,8 +24030,13 @@
     "ingredient": {
       "item": "minecraft:waxed_oxidized_copper"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23396,8 +24083,13 @@
     "ingredient": {
       "item": "minecraft:waxed_oxidized_copper"
     },
-    "count": 2,
+    "count": 8,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 2 blocks."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23457,8 +24149,13 @@
     "ingredient": {
       "item": "minecraft:waxed_oxidized_copper"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23535,8 +24232,13 @@
     "ingredient": {
       "item": "minecraft:waxed_weathered_copper"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23583,8 +24285,13 @@
     "ingredient": {
       "item": "minecraft:waxed_weathered_copper"
     },
-    "count": 2,
+    "count": 8,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 2 blocks."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23644,8 +24351,13 @@
     "ingredient": {
       "item": "minecraft:waxed_weathered_copper"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23747,8 +24459,13 @@
     "ingredient": {
       "item": "minecraft:weathered_copper"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23776,8 +24493,13 @@
     "ingredient": {
       "item": "minecraft:weathered_copper"
     },
-    "count": 2,
+    "count": 8,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 2 blocks."
+      }
+    },
     "properties": {
       "version": "1.17"
     }
@@ -23818,8 +24540,13 @@
     "ingredient": {
       "item": "minecraft:weathered_copper"
     },
-    "count": 1,
+    "count": 4,
     "type": "minecraft:stonecutting",
+    "lang": {
+      "en_US": {
+        "notes": "Before 1.18, recipe gives 1 block."
+      }
+    },
     "properties": {
       "version": "1.17"
     }

--- a/src/com/tisawesomeness/minecord/Announcement.java
+++ b/src/com/tisawesomeness/minecord/Announcement.java
@@ -28,6 +28,7 @@ public class Announcement {
      */
     public static void init(String path) throws IOException {
         announcements = new ArrayList<>();
+        totalWeight = 0;
         JSONArray announceArr = RequestUtils.loadJSONArray(path + "/announce.json");
         for (int i = 0; i < announceArr.length(); i++) {
             JSONObject announceObj = announceArr.getJSONObject(i);
@@ -44,7 +45,7 @@ public class Announcement {
     public static String rollAnnouncement() {
         int rand = (int) (Math.random() * totalWeight);
         int i = -1;
-        while (rand > 0) {
+        while (rand >= 0) {
             i++;
             rand -= announcements.get(i).weight;
         }

--- a/src/com/tisawesomeness/minecord/Announcement.java
+++ b/src/com/tisawesomeness/minecord/Announcement.java
@@ -44,7 +44,7 @@ public class Announcement {
     public static String rollAnnouncement() {
         int rand = (int) (Math.random() * totalWeight);
         int i = -1;
-        while (rand >= 0) {
+        while (rand > 0) {
             i++;
             rand -= announcements.get(i).weight;
         }

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -39,7 +39,7 @@ public class Bot {
     public static final String helpServer = "https://minecord.github.io/support";
     public static final String website = "https://minecord.github.io";
     public static final String github = "https://github.com/Tisawesomeness/Minecord";
-    private static final String version = "0.15.0";
+    private static final String version = "0.15.1";
     public static final String javaVersion = "1.8";
     public static final String jdaVersion = "4.3.0_352";
     public static final Color color = Color.GREEN;

--- a/src/com/tisawesomeness/minecord/Config.java
+++ b/src/com/tisawesomeness/minecord/Config.java
@@ -35,6 +35,8 @@ public class Config {
     private static boolean elevatedSkipCooldown;
     private static boolean useElectroidAPI;
     private static boolean useGappleAPI;
+    private static String itemImageHost;
+    private static String recipeImageHost;
 
     private static boolean sendServerCount;
     private static String pwToken;
@@ -122,6 +124,8 @@ public class Config {
             elevatedSkipCooldown = settings.getBoolean("elevatedSkipCooldown");
             useElectroidAPI = settings.optBoolean("useElectroidAPI", true);
             useGappleAPI = settings.optBoolean("useGappleAPI", true);
+            itemImageHost = settings.optString("itemImageHost", "https://minecord.github.io/item/");
+            recipeImageHost = settings.optString("recipeImageHost", "https://minecord.github.io/recipe/");
 
             JSONObject botLists = config.getJSONObject("botLists");
             if (isSelfHosted) {
@@ -175,6 +179,8 @@ public class Config {
     public static boolean getElevatedSkipCooldown() { return elevatedSkipCooldown; }
     public static boolean getUseElectroidAPI() { return useElectroidAPI; }
     public static boolean getUseGappleAPI() { return useGappleAPI; }
+    public static String getItemImageHost() { return itemImageHost; }
+    public static String getRecipeImageHost() { return recipeImageHost; }
 
     public static boolean getSendServerCount() { return sendServerCount; }
     public static String getPwToken() { return pwToken; }

--- a/src/com/tisawesomeness/minecord/command/admin/ReloadCommand.java
+++ b/src/com/tisawesomeness/minecord/command/admin/ReloadCommand.java
@@ -8,6 +8,7 @@ import com.tisawesomeness.minecord.database.Database;
 import com.tisawesomeness.minecord.database.VoteHandler;
 import com.tisawesomeness.minecord.mc.item.Item;
 import com.tisawesomeness.minecord.mc.item.Recipe;
+import com.tisawesomeness.minecord.util.MessageUtils;
 
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -42,6 +43,7 @@ public class ReloadCommand extends Command {
 
     public Result run(String[] args, MessageReceivedEvent e) {
 
+        MessageUtils.log(":arrows_counterclockwise: **Bot reloaded by " + e.getAuthor().getAsTag() + "**");
         Message m = e.getChannel().sendMessage(":arrows_counterclockwise: Reloading...").complete();
         if (Config.getDevMode()) {
             Bot.shutdown(m, e.getAuthor());

--- a/src/com/tisawesomeness/minecord/command/admin/ShutdownCommand.java
+++ b/src/com/tisawesomeness/minecord/command/admin/ShutdownCommand.java
@@ -25,7 +25,7 @@ public class ShutdownCommand extends Command {
     }
 
     public Result run(String[] args, MessageReceivedEvent e) {
-        MessageUtils.log(":x: **Bot shut down by " + e.getAuthor().getName() + "**");
+        MessageUtils.log(":x: **Bot shut down by " + e.getAuthor().getAsTag() + "**");
         e.getChannel().sendMessage(":wave: Goodbye!").complete();
         e.getJDA().shutdown();
         System.exit(0);

--- a/src/com/tisawesomeness/minecord/command/player/AnsiCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/AnsiCommand.java
@@ -25,7 +25,7 @@ public class AnsiCommand extends BaseRenderCommand {
     public CommandInfo getInfo() {
         return new CommandInfo(
                 "ansi",
-                "Converts a player's avatar to a colored text message",
+                "Converts a player's avatar to a colored text message.",
                 "<player> [<overlay?>]",
                 null,
                 3000,

--- a/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
@@ -29,7 +29,7 @@ public class IngredientCommand extends Command {
 
     public String getHelp() {
         return "Searches for the recipes containing an ingredient.\n" +
-                "Items and recipes are from Java Edition 1.7 to 1.18.\n" +
+                "Items and recipes are from Java Edition 1.7 to 1.19.\n" +
                 "All recipe types are searchable, including brewing.\n" +
                 "\n" +
                 Item.help + "\n";

--- a/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
@@ -37,29 +37,34 @@ public class IngredientCommand extends Command {
 
     public Result run(String[] args, MessageReceivedEvent e) {
 
-        // Parse page number
-        int page = 0;
-        if (args.length > 1) {
-            try {
-                page = Integer.parseInt(args[args.length - 1]) - 1;
-                args = Arrays.copyOf(args, args.length - 1);
-            } catch (NumberFormatException ignored) {}
-        }
-
-        //Check for argument length
+        // Check for argument length
         if (args.length == 0) {
             return new Result(Outcome.WARNING, ":warning: You must specify an item!");
         }
 
-        // Search through the recipe database
+        // Search through the recipe database with full args first
         ArrayList<String> recipes = Recipe.searchIngredient(String.join(" ", args), "en_US");
+        int page = 0;
+        if (recipes == null) {
+            // Parse page number
+            if (args.length > 1) {
+                try {
+                    // Since full args failed, try searching without the page number
+                    page = Integer.parseInt(args[args.length - 1]) - 1;
+                    String[] args2 = Arrays.copyOf(args, args.length - 1);
+                    recipes = Recipe.searchIngredient(String.join(" ", args2), "en_US");
+                } catch (NumberFormatException ignored) {}
+            }
+        }
         if (recipes == null) {
             return new Result(Outcome.WARNING,
-                    ":warning: That item does not exist! " +
-                            "\n" + "Did you spell it correctly?");
+                    ":warning: That item does not exist! " + "\n" + "Did you spell it correctly?");
         }
         if (recipes.size() == 0) {
-            return new Result(Outcome.WARNING, ":warning: That item is not an ingredient for any recipes!");
+            return new Result(Outcome.WARNING, ":warning: That item does not have a recipe!");
+        }
+        if (page >= recipes.size()) {
+            return new Result(Outcome.WARNING, ":warning: That page does not exist!");
         }
 
         // Create menu

--- a/src/com/tisawesomeness/minecord/command/utility/ItemCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/ItemCommand.java
@@ -24,7 +24,7 @@ public class ItemCommand extends Command {
 
     public String getHelp() {
         return "Searches for a Minecraft item.\n" +
-                "Items are from Java Edition 1.7 to 1.18.\n" +
+                "Items are from Java Edition 1.7 to 1.19.\n" +
                 "\n" +
                 Item.help + "\n";
     }

--- a/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
@@ -31,7 +31,7 @@ public class RecipeCommand extends Command {
 
     public String getHelp() {
         return "Shows the recipes for an item.\n" +
-                "Items and recipes are from Java Edition 1.7 to 1.18.\n" +
+                "Items and recipes are from Java Edition 1.7 to 1.19.\n" +
                 "All recipe types are searchable, including brewing.\n" +
                 "\n" +
                 Item.help + "\n";

--- a/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
@@ -39,22 +39,25 @@ public class RecipeCommand extends Command {
 
     public Result run(String[] args, MessageReceivedEvent e) {
 
-        // Parse page number
-        int page = 0;
-        if (args.length > 1) {
-            try {
-                page = Integer.parseInt(args[args.length - 1]) - 1;
-                args = Arrays.copyOf(args, args.length - 1);
-            } catch (NumberFormatException ignored) {}
-        }
-
         // Check for argument length
         if (args.length == 0) {
             return new Result(Outcome.WARNING, ":warning: You must specify an item!");
         }
 
-        // Search through the recipe database
+        // Search through the recipe database with full args first
         ArrayList<String> recipes = Recipe.searchOutput(String.join(" ", args), "en_US");
+        int page = 0;
+        if (recipes == null) {
+            // Parse page number
+            if (args.length > 1) {
+                try {
+                    // Since full args failed, try searching without the page number
+                    page = Integer.parseInt(args[args.length - 1]) - 1;
+                    String[] args2 = Arrays.copyOf(args, args.length - 1);
+                    recipes = Recipe.searchOutput(String.join(" ", args2), "en_US");
+                } catch (NumberFormatException ignored) {}
+            }
+        }
         if (recipes == null) {
             return new Result(Outcome.WARNING,
                     ":warning: That item does not exist! " + "\n" + "Did you spell it correctly?");

--- a/src/com/tisawesomeness/minecord/mc/item/Item.java
+++ b/src/com/tisawesomeness/minecord/mc/item/Item.java
@@ -45,6 +45,7 @@ public class Item {
      */
     public static void init(String path) throws IOException {
         items = RequestUtils.loadJSON(path + "/items.json");
+        System.out.println("Loaded " + items.length() + " items");
         data = RequestUtils.loadJSON(path + "/data.json");
     }
 

--- a/src/com/tisawesomeness/minecord/mc/item/Item.java
+++ b/src/com/tisawesomeness/minecord/mc/item/Item.java
@@ -1,6 +1,7 @@
 package com.tisawesomeness.minecord.mc.item;
 
 import com.tisawesomeness.minecord.Bot;
+import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.util.RequestUtils;
 
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -8,8 +9,10 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Objects;
@@ -145,9 +148,12 @@ public class Item {
 
         // Sprite
         try {
-            eb.setThumbnail(new URI("https", "minecord.github.io", String.format("/item/%s.png", getImageKey(item)), null).toASCIIString());
-        } catch (URISyntaxException ex) {
-            ex.printStackTrace();
+            URL url = new URL(Config.getItemImageHost());
+            String path = url.getPath() + getImageKey(item) + ".png";
+            URI uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), path, url.getQuery(), url.getRef());
+            eb.setThumbnail(uri.toASCIIString());
+        } catch (URISyntaxException | MalformedURLException ex) {
+            throw new AssertionError(ex);
         }
 
         // Get rid of trailing newline

--- a/src/com/tisawesomeness/minecord/mc/item/Recipe.java
+++ b/src/com/tisawesomeness/minecord/mc/item/Recipe.java
@@ -27,6 +27,7 @@ public class Recipe {
      */
     public static void init(String path) throws IOException {
         recipes = RequestUtils.loadJSON(path + "/recipes.json");
+        System.out.println("Loaded " + recipes.length() + " recipes");
         tags = RequestUtils.loadJSON(path + "/tags.json");
     }
 

--- a/src/com/tisawesomeness/minecord/mc/item/Recipe.java
+++ b/src/com/tisawesomeness/minecord/mc/item/Recipe.java
@@ -10,9 +10,6 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/src/com/tisawesomeness/minecord/mc/item/Recipe.java
+++ b/src/com/tisawesomeness/minecord/mc/item/Recipe.java
@@ -1,6 +1,7 @@
 package com.tisawesomeness.minecord.mc.item;
 
 import com.tisawesomeness.minecord.Bot;
+import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.ReactMenu;
 import com.tisawesomeness.minecord.util.RequestUtils;
 
@@ -9,8 +10,9 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -42,11 +44,7 @@ public class Recipe {
         EmbedBuilder eb = new EmbedBuilder();
         String item = Item.search(getResult(recipe), lang);
         eb.setTitle(Item.getDisplayName(item, lang));
-        try {
-            eb.setImage(new URI("https", "minecord.github.io", String.format("/recipe/%s", getImage(recipe)), null).toASCIIString());
-        } catch (URISyntaxException ex) {
-            ex.printStackTrace();
-        }
+        eb.setImage(Config.getRecipeImageHost() + getImage(recipe));
         eb.setColor(Bot.color);
         return eb;
     }

--- a/src/com/tisawesomeness/minecord/mc/item/Recipe.java
+++ b/src/com/tisawesomeness/minecord/mc/item/Recipe.java
@@ -596,7 +596,7 @@ public class Recipe {
                     }
                     i++;
                 }
-                boolean hasMore = c == 9 || startingIngredient > 0;
+                boolean hasMore = ingredients.length > 9 || startingIngredient > 0;
                 while (c < 9) {
                     Emote emote = Emote.valueOf(c + 1);
                     buttons.put(emote.getCodepoint(), null);

--- a/tags.json
+++ b/tags.json
@@ -73,7 +73,9 @@
     "minecraft:birch_boat",
     "minecraft:jungle_boat",
     "minecraft:acacia_boat",
-    "minecraft:dark_oak_boat"
+    "minecraft:dark_oak_boat",
+    "minecraft:mangrove_boat",
+    "#minecraft:chest_boats"
   ],
   "buttons": [
     "#minecraft:wooden_buttons",
@@ -99,23 +101,14 @@
     "minecraft:red_candle",
     "minecraft:black_candle"
   ],
-  "carpets": [
-    "minecraft:white_carpet",
-    "minecraft:orange_carpet",
-    "minecraft:magenta_carpet",
-    "minecraft:light_blue_carpet",
-    "minecraft:yellow_carpet",
-    "minecraft:lime_carpet",
-    "minecraft:pink_carpet",
-    "minecraft:gray_carpet",
-    "minecraft:light_gray_carpet",
-    "minecraft:cyan_carpet",
-    "minecraft:purple_carpet",
-    "minecraft:blue_carpet",
-    "minecraft:brown_carpet",
-    "minecraft:green_carpet",
-    "minecraft:red_carpet",
-    "minecraft:black_carpet"
+  "chest_boats": [
+    "minecraft:oak_chest_boat",
+    "minecraft:spruce_chest_boat",
+    "minecraft:birch_chest_boat",
+    "minecraft:jungle_chest_boat",
+    "minecraft:acacia_chest_boat",
+    "minecraft:dark_oak_chest_boat",
+    "minecraft:mangrove_chest_boat"
   ],
   "cluster_max_harvestables": [
     "minecraft:diamond_pickaxe",
@@ -132,6 +125,15 @@
   "coals": [
     "minecraft:coal",
     "minecraft:charcoal"
+  ],
+  "compasses": [
+    "minecraft:compass",
+    "minecraft:recovery_compass"
+  ],
+  "completes_find_tree_tutorial": [
+    "#minecraft:logs",
+    "#minecraft:leaves",
+    "#minecraft:wart_blocks"
   ],
   "copper_ores": [
     "minecraft:copper_ore",
@@ -152,10 +154,14 @@
     "minecraft:music_disc_wait"
   ],
   "crimson_stems": [
-    "minecraft:crimson_stem",
-    "minecraft:stripped_crimson_stem",
     "minecraft:crimson_hyphae",
-    "minecraft:stripped_crimson_hyphae"
+    "minecraft:crimson_stem",
+    "minecraft:stripped_crimson_hyphae",
+    "minecraft:stripped_crimson_stem"
+  ],
+  "dampens_vibrations": [
+    "#minecraft:wool",
+    "#minecraft:wool_carpets"
   ],
   "dark_oak_logs": [
     "minecraft:dark_oak_log",
@@ -166,6 +172,17 @@
   "diamond_ores": [
     "minecraft:diamond_ore",
     "minecraft:deepslate_diamond_ore"
+  ],
+  "dirt": [
+    "minecraft:dirt",
+    "minecraft:grass_block",
+    "minecraft:podzol",
+    "minecraft:coarse_dirt",
+    "minecraft:mycelium",
+    "minecraft:rooted_dirt",
+    "minecraft:moss_block",
+    "minecraft:mud",
+    "minecraft:muddy_mangrove_roots"
   ],
   "doors": [
     "#minecraft:wooden_doors",
@@ -188,9 +205,10 @@
     "minecraft:tropical_fish"
   ],
   "flowers": [
+    "minecraft:mangrove_propagule",
     "#minecraft:small_flowers",
     "#minecraft:tall_flowers",
-    "minecraft:azalea_leaves_flowers",
+    "minecraft:flowering_azalea_leaves",
     "minecraft:flowering_azalea"
   ],
   "fox_food": [
@@ -233,8 +251,9 @@
     "minecraft:jungle_leaves",
     "minecraft:acacia_leaves",
     "minecraft:dark_oak_leaves",
+    "minecraft:mangrove_leaves",
     "minecraft:azalea_leaves",
-    "minecraft:azalea_leaves_flowers"
+    "minecraft:flowering_azalea_leaves"
   ],
   "lectern_books": [
     "minecraft:written_book",
@@ -251,41 +270,50 @@
     "#minecraft:birch_logs",
     "#minecraft:jungle_logs",
     "#minecraft:acacia_logs",
+    "#minecraft:mangrove_logs",
     "#minecraft:dark_oak_logs"
+  ],
+  "mangrove_logs": [
+    "minecraft:mangrove_log",
+    "minecraft:mangrove_wood",
+    "minecraft:stripped_mangrove_log",
+    "minecraft:stripped_mangrove_wood"
   ],
   "music_discs": [
     "#minecraft:creeper_drop_music_discs",
-    "minecraft:music_disc_pigstep"
+    "minecraft:music_disc_pigstep",
+    "minecraft:music_disc_otherside",
+    "minecraft:music_disc_5"
   ],
   "non_flammable_wood": [
-    "minecraft:warped_stem",
-    "minecraft:stripped_warped_stem",
-    "minecraft:warped_hyphae",
-    "minecraft:stripped_warped_hyphae",
-    "minecraft:crimson_stem",
-    "minecraft:stripped_crimson_stem",
-    "minecraft:crimson_hyphae",
-    "minecraft:stripped_crimson_hyphae",
-    "minecraft:crimson_planks",
-    "minecraft:warped_planks",
-    "minecraft:crimson_slab",
-    "minecraft:warped_slab",
-    "minecraft:crimson_pressure_plate",
-    "minecraft:warped_pressure_plate",
-    "minecraft:crimson_fence",
-    "minecraft:warped_fence",
-    "minecraft:crimson_trapdoor",
-    "minecraft:warped_trapdoor",
-    "minecraft:crimson_fence_gate",
-    "minecraft:warped_fence_gate",
-    "minecraft:crimson_stairs",
-    "minecraft:warped_stairs",
     "minecraft:crimson_button",
-    "minecraft:warped_button",
     "minecraft:crimson_door",
-    "minecraft:warped_door",
+    "minecraft:crimson_fence",
+    "minecraft:crimson_fence_gate",
+    "minecraft:crimson_hyphae",
+    "minecraft:crimson_planks",
+    "minecraft:crimson_pressure_plate",
     "minecraft:crimson_sign",
-    "minecraft:warped_sign"
+    "minecraft:crimson_slab",
+    "minecraft:crimson_stairs",
+    "minecraft:crimson_stem",
+    "minecraft:crimson_trapdoor",
+    "minecraft:stripped_crimson_hyphae",
+    "minecraft:stripped_crimson_stem",
+    "minecraft:warped_button",
+    "minecraft:warped_door",
+    "minecraft:warped_fence",
+    "minecraft:warped_fence_gate",
+    "minecraft:warped_hyphae",
+    "minecraft:warped_planks",
+    "minecraft:warped_pressure_plate",
+    "minecraft:warped_sign",
+    "minecraft:warped_slab",
+    "minecraft:warped_stairs",
+    "minecraft:warped_stem",
+    "minecraft:warped_trapdoor",
+    "minecraft:stripped_warped_hyphae",
+    "minecraft:stripped_warped_stem"
   ],
   "oak_logs": [
     "minecraft:oak_log",
@@ -293,8 +321,14 @@
     "minecraft:stripped_oak_log",
     "minecraft:stripped_oak_wood"
   ],
-  "occludes_vibration_signals": [
-    "#minecraft:wool"
+  "overworld_natural_logs": [
+    "minecraft:oak_log",
+    "minecraft:spruce_log",
+    "minecraft:birch_log",
+    "minecraft:jungle_log",
+    "minecraft:acacia_log",
+    "minecraft:dark_oak_log",
+    "minecraft:mangrove_log"
   ],
   "piglin_food": [
     "minecraft:porkchop",
@@ -338,7 +372,8 @@
     "minecraft:acacia_planks",
     "minecraft:dark_oak_planks",
     "minecraft:crimson_planks",
-    "minecraft:warped_planks"
+    "minecraft:warped_planks",
+    "minecraft:mangrove_planks"
   ],
   "rails": [
     "minecraft:rail",
@@ -361,6 +396,7 @@
     "minecraft:jungle_sapling",
     "minecraft:acacia_sapling",
     "minecraft:dark_oak_sapling",
+    "minecraft:mangrove_propagule",
     "minecraft:azalea",
     "minecraft:flowering_azalea"
   ],
@@ -368,11 +404,12 @@
     "minecraft:oak_sign",
     "minecraft:spruce_sign",
     "minecraft:birch_sign",
-    "minecraft:acacia_sign",
     "minecraft:jungle_sign",
+    "minecraft:acacia_sign",
     "minecraft:dark_oak_sign",
     "minecraft:crimson_sign",
-    "minecraft:warped_sign"
+    "minecraft:warped_sign",
+    "minecraft:mangrove_sign"
   ],
   "slabs": [
     "#minecraft:wooden_slabs",
@@ -419,7 +456,8 @@
     "minecraft:weathered_cut_copper_slab",
     "minecraft:exposed_cut_copper_slab",
     "minecraft:cut_copper_slab",
-    "minecraft:waxed_oxidized_cut_copper_slab"
+    "minecraft:waxed_oxidized_cut_copper_slab",
+    "minecraft:mud_brick_slab"
   ],
   "small_flowers": [
     "minecraft:dandelion",
@@ -487,7 +525,8 @@
     "minecraft:waxed_weathered_cut_copper_stairs",
     "minecraft:waxed_exposed_cut_copper_stairs",
     "minecraft:waxed_cut_copper_stairs",
-    "minecraft:waxed_oxidized_cut_copper_stairs"
+    "minecraft:waxed_oxidized_cut_copper_stairs",
+    "minecraft:mud_brick_stairs"
   ],
   "stone_bricks": [
     "minecraft:stone_bricks",
@@ -510,6 +549,25 @@
     "minecraft:lilac",
     "minecraft:peony",
     "minecraft:rose_bush"
+  ],
+  "terracotta": [
+    "minecraft:terracotta",
+    "minecraft:white_terracotta",
+    "minecraft:orange_terracotta",
+    "minecraft:magenta_terracotta",
+    "minecraft:light_blue_terracotta",
+    "minecraft:yellow_terracotta",
+    "minecraft:lime_terracotta",
+    "minecraft:pink_terracotta",
+    "minecraft:gray_terracotta",
+    "minecraft:light_gray_terracotta",
+    "minecraft:cyan_terracotta",
+    "minecraft:purple_terracotta",
+    "minecraft:blue_terracotta",
+    "minecraft:brown_terracotta",
+    "minecraft:green_terracotta",
+    "minecraft:red_terracotta",
+    "minecraft:black_terracotta"
   ],
   "trapdoors": [
     "#minecraft:wooden_trapdoors",
@@ -536,13 +594,18 @@
     "minecraft:cobbled_deepslate_wall",
     "minecraft:polished_deepslate_wall",
     "minecraft:deepslate_tile_wall",
-    "minecraft:deepslate_brick_wall"
+    "minecraft:deepslate_brick_wall",
+    "minecraft:mud_brick_wall"
   ],
   "warped_stems": [
-    "minecraft:warped_stem",
-    "minecraft:stripped_warped_stem",
     "minecraft:warped_hyphae",
-    "minecraft:stripped_warped_hyphae"
+    "minecraft:warped_stem",
+    "minecraft:stripped_warped_hyphae",
+    "minecraft:stripped_warped_stem"
+  ],
+  "wart_blocks": [
+    "minecraft:warped_wart_block",
+    "minecraft:nether_wart_block"
   ],
   "wooden_buttons": [
     "minecraft:oak_button",
@@ -552,7 +615,8 @@
     "minecraft:acacia_button",
     "minecraft:dark_oak_button",
     "minecraft:crimson_button",
-    "minecraft:warped_button"
+    "minecraft:warped_button",
+    "minecraft:mangrove_button"
   ],
   "wooden_doors": [
     "minecraft:oak_door",
@@ -562,7 +626,8 @@
     "minecraft:acacia_door",
     "minecraft:dark_oak_door",
     "minecraft:crimson_door",
-    "minecraft:warped_door"
+    "minecraft:warped_door",
+    "minecraft:mangrove_door"
   ],
   "wooden_fences": [
     "minecraft:oak_fence",
@@ -572,7 +637,8 @@
     "minecraft:acacia_fence",
     "minecraft:dark_oak_fence",
     "minecraft:crimson_fence",
-    "minecraft:warped_fence"
+    "minecraft:warped_fence",
+    "minecraft:mangrove_fence"
   ],
   "wooden_pressure_plates": [
     "minecraft:oak_pressure_plate",
@@ -582,7 +648,8 @@
     "minecraft:acacia_pressure_plate",
     "minecraft:dark_oak_pressure_plate",
     "minecraft:crimson_pressure_plate",
-    "minecraft:warped_pressure_plate"
+    "minecraft:warped_pressure_plate",
+    "minecraft:mangrove_pressure_plate"
   ],
   "wooden_slabs": [
     "minecraft:oak_slab",
@@ -592,7 +659,8 @@
     "minecraft:acacia_slab",
     "minecraft:dark_oak_slab",
     "minecraft:crimson_slab",
-    "minecraft:warped_slab"
+    "minecraft:warped_slab",
+    "minecraft:mangrove_slab"
   ],
   "wooden_stairs": [
     "minecraft:oak_stairs",
@@ -602,7 +670,8 @@
     "minecraft:acacia_stairs",
     "minecraft:dark_oak_stairs",
     "minecraft:crimson_stairs",
-    "minecraft:warped_stairs"
+    "minecraft:warped_stairs",
+    "minecraft:mangrove_stairs"
   ],
   "wooden_trapdoors": [
     "minecraft:oak_trapdoor",
@@ -612,7 +681,8 @@
     "minecraft:acacia_trapdoor",
     "minecraft:dark_oak_trapdoor",
     "minecraft:crimson_trapdoor",
-    "minecraft:warped_trapdoor"
+    "minecraft:warped_trapdoor",
+    "minecraft:mangrove_trapdoor"
   ],
   "wool": [
     "minecraft:white_wool",
@@ -631,5 +701,23 @@
     "minecraft:green_wool",
     "minecraft:red_wool",
     "minecraft:black_wool"
+  ],
+  "wool_carpets": [
+    "minecraft:white_carpet",
+    "minecraft:orange_carpet",
+    "minecraft:magenta_carpet",
+    "minecraft:light_blue_carpet",
+    "minecraft:yellow_carpet",
+    "minecraft:lime_carpet",
+    "minecraft:pink_carpet",
+    "minecraft:gray_carpet",
+    "minecraft:light_gray_carpet",
+    "minecraft:cyan_carpet",
+    "minecraft:purple_carpet",
+    "minecraft:blue_carpet",
+    "minecraft:brown_carpet",
+    "minecraft:green_carpet",
+    "minecraft:red_carpet",
+    "minecraft:black_carpet"
   ]
 }


### PR DESCRIPTION
- **Added all 1.19 items and recipes.** This brings the total to 1,500 items and 1,433 recipes!
- Added new item nicknames for existing items
- Fixed typo in firework rocket recipe notes
- Fixed old composter recipe including wood types unavailable to that version
- Fixed the cycle option appearing and doing nothing in recipe menus when there are exactly 9 ingredients
- (Self-hosting change) Add config options to change the image host for testing