### PR TITLE
Version 0.16.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A robust Discord bot using the JDA library for various Minecraft functions.
 - `@Minecord reload` - Reloads the bot. In dev mode, this hot reloads all code. Otherwise, this reloads the config, item/recipe files, and restarts the database and vote server.
 - `@Minecord shutdown` - Shuts down the bot.
 - `@Minecord deploy` - Deploys slash commands globally.
-- `@Minecord eval` - Evaluates javascript code with variables `jda`, `config`, `event`, `guild`, `channel`, and `user`.
+- `@Minecord eval` - Evaluates javascript code with variables `jda`, `config`, `event`, `guild`, `channel`, and `user`. Requires setting `evil: true` in the config since eval is a security risk.
 - `@Minecord test` - Test command. This may change depending on what features are being developed.
 
 ### Config

--- a/README.md
+++ b/README.md
@@ -83,17 +83,17 @@ A robust Discord bot using the JDA library for various Minecraft functions.
 - *Is Self Hosted:* Leave as `true` if you are self-hosting the bot.
 - *Author:* The name of the person hosting the bot.
 - *Author Tag:* The Discord tag of the person hosting the bot.
-- *Invite:* The invite link to use in `&invite`.
-- *Help Server:* The help server link to use in `&invite`.
-- *Website:* The website to display in `&info`.
+- *Invite:* The invite link to use in `/invite`.
+- *Help Server:* The help server link to use in `/invite`.
+- *Website:* The website to display in `/info`.
 - *Github:* A link to the source code currently running on the bot.
-- *Prefix:* The prefix of the bot. Use something else instead of `&` if you want to host your own bot alongside the main one.
+- *Prefix:* The prefix (optionally) used for admin commands.
 - *Game:* This is the game that the bot is playing, shown under the username. `{prefix}` and `{guilds}` are available variables.
-- *Dev Mode:* Turning this on will let you reload code using `&reload` on the fly. When hosting the bot, it's best to keep this off in order to decrease memory usage.
+- *Dev Mode:* Turning this on will let you reload code using `@Minecord reload` on the fly. When hosting the bot, it's best to keep this off in order to decrease memory usage.
 - *Debug Mode:* If true, exceptions during command execution will be sent to the user.
-- *Delete Commands:* If true, the commands sent by players (like `&help`) will be deleted to clean up chat. Requires permission to manage messages.
-- *Use Menus:* If true, the bot will use a reaction menu for `&recipe` and `&ingredient` if possible.
-- *Show Memory:* Whether to show the memory in `&info`.
+- *Delete Commands:* If true, the commands sent by players (like `/help`) will be deleted to clean up chat. Requires permission to manage messages.
+- *Use Menus:* If true, the bot will use a reaction menu for `/recipe` and `/ingredient` if possible.
+- *Show Memory:* Whether to show the memory in `/info`.
 - *Elevated Skip Cooldown:* Whether elevated users skip command cooldowns.
 - *Use Electroid API:* Whether to use the Electroid API to speed up player lookups. May cause slowdowns if the API is consistently down.
 - *Use Gapple API:* Whether to use the Gapple API to look up account types. May cause slowdowns if the API is consistently down.

--- a/data.json
+++ b/data.json
@@ -21,6 +21,7 @@
     "dark": 6,
     "pink": 6,
     "light_purple": 6,
+    "cherry": 6,
     "gray": 7,
     "grey": 7,
     "light_gray": 8,

--- a/items.json
+++ b/items.json
@@ -14898,17 +14898,6 @@
       "version": "1.17"
     }
   },
-  "minecraft.bundle": {
-    "lang": {
-      "en_US": {
-        "display_name": "Bundle"
-      }
-    },
-    "properties": {
-      "feature_flag": "bundle",
-      "version": "1.17"
-    }
-  },
   "minecraft.calcite": {
     "lang": {
       "en_US": {
@@ -17025,6 +17014,17 @@
       "version": "1.17"
     }
   },
+  "minecraft.bundle": {
+    "lang": {
+      "en_US": {
+        "display_name": "Bundle"
+      }
+    },
+    "properties": {
+      "feature_flag": "bundle",
+      "version": "1.17"
+    }
+  },
   "minecraft.music_disc_otherside": {
     "lang": {
       "en_US": {
@@ -18546,6 +18546,561 @@
       "image_key": "Warped Hanging Sign",
       "feature_flag": "1.20",
       "version": "1.19.3"
+    }
+  },
+  "minecraft.brush": {
+    "lang": {
+      "en_US": {
+        "display_name": "Brush"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_boat": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Boat"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_button": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Button"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_chest_boat": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Boat with Chest"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_door": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Door"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_fence": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Fence"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_fence_gate": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Fence Gate"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_hanging_sign": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Hanging Sign"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_leaves": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Leaves"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_log": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Log"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_planks": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Planks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_pressure_plate": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Pressure Plate"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_sapling": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Sapling"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_sign": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Sign"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_slab": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_stairs": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Stairs"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_trapdoor": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Trapdoor"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_wall_hanging_sign": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Wall Hanging Sign"
+      }
+    },
+    "properties": {
+      "image_key": "Cherry Hanging Sign",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_wall_sign": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Wall Sign"
+      }
+    },
+    "properties": {
+      "image_key": "Cherry Sign",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.cherry_wood": {
+    "lang": {
+      "en_US": {
+        "display_name": "Cherry Wood"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.coast_armor_trim_smithing_template": {
+    "lang": {
+      "en_US": {
+        "lore": "Coast Armor Trim",
+        "display_name": "Smithing Template",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Coast Armor Trim",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.decorated_pot": {
+    "lang": {
+      "en_US": {
+        "display_name": "Decorated Pot"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.dune_armor_trim_smithing_template": {
+    "lang": {
+      "en_US": {
+        "lore": "Dune Armor Trim",
+        "display_name": "Smithing Template",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Dune Armor Trim",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.eye_armor_trim_smithing_template": {
+    "lang": {
+      "en_US": {
+        "lore": "Eye Armor Trim",
+        "display_name": "Smithing Template",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Eye Armor Trim",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.netherite_upgrade_smithing_template": {
+    "lang": {
+      "en_US": {
+        "lore": "Netherite Upgrade",
+        "display_name": "Smithing Template",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Netherite Upgrade",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.pink_petals": {
+    "lang": {
+      "en_US": {
+        "display_name": "Pink Petals"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.potted_cherry_sapling": {
+    "lang": {
+      "en_US": {
+        "display_name": "Potted Cherry Sapling"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.potted_torchflower": {
+    "lang": {
+      "en_US": {
+        "display_name": "Potted Torchflower"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.pottery_shard_archer": {
+    "lang": {
+      "en_US": {
+        "display_name": "Archer Pottery Shard"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.pottery_shard_arms_up": {
+    "lang": {
+      "en_US": {
+        "display_name": "Arms Up Pottery Shard"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.pottery_shard_prize": {
+    "lang": {
+      "en_US": {
+        "display_name": "Prize Pottery Shard"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.pottery_shard_skull": {
+    "lang": {
+      "en_US": {
+        "display_name": "Skull Pottery Shard"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.rib_armor_trim_smithing_template": {
+    "lang": {
+      "en_US": {
+        "lore": "Rib Armor Trim",
+        "display_name": "Smithing Template",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Rib Armor Trim",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.sentry_armor_trim_smithing_template": {
+    "lang": {
+      "en_US": {
+        "lore": "Sentry Armor Trim",
+        "display_name": "Smithing Template",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Sentry Armor Trim",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.sniffer_spawn_egg": {
+    "lang": {
+      "en_US": {
+        "display_name": "Sniffer Spawn Egg"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.snout_armor_trim_smithing_template": {
+    "lang": {
+      "en_US": {
+        "lore": "Snout Armor Trim",
+        "display_name": "Smithing Template",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Snout Armor Trim",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.spire_armor_trim_smithing_template": {
+    "lang": {
+      "en_US": {
+        "lore": "Spire Armor Trim",
+        "display_name": "Smithing Template",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Spire Armor Trim",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.stripped_cherry_log": {
+    "lang": {
+      "en_US": {
+        "display_name": "Stripped Cherry Log"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.stripped_cherry_wood": {
+    "lang": {
+      "en_US": {
+        "display_name": "Stripped Cherry Wood"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.suspicious_sand": {
+    "lang": {
+      "en_US": {
+        "display_name": "Suspicious Sand"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.tide_armor_trim_smithing_template": {
+    "lang": {
+      "en_US": {
+        "lore": "Tide Armor Trim",
+        "display_name": "Smithing Template",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Tide Armor Trim",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.torchflower": {
+    "lang": {
+      "en_US": {
+        "display_name": "Torchflower"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.torchflower_crop": {
+    "lang": {
+      "en_US": {
+        "display_name": "Torchflower Crop"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.torchflower_seeds": {
+    "lang": {
+      "en_US": {
+        "display_name": "Torchflower Seeds"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.vex_armor_trim_smithing_template": {
+    "lang": {
+      "en_US": {
+        "lore": "Vex Armor Trim",
+        "display_name": "Smithing Template",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Vex Armor Trim",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.ward_armor_trim_smithing_template": {
+    "lang": {
+      "en_US": {
+        "lore": "Ward Armor Trim",
+        "display_name": "Smithing Template",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Ward Armor Trim",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "minecraft.wild_armor_trim_smithing_template": {
+    "lang": {
+      "en_US": {
+        "lore": "Wild Armor Trim",
+        "display_name": "Smithing Template",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Wild Armor Trim",
+      "feature_flag": "1.20",
+      "version": "1.19.4"
     }
   },
   "minecraft.lingering_potion.effect.awkward": {

--- a/items.json
+++ b/items.json
@@ -10236,7 +10236,6 @@
         "lore": "C418 - 13",
         "search_names": [
           "13 Disc",
-          "Music Disc 13",
           "Disc 13",
           "C418 - 13",
           "Thirteen Disc",
@@ -10246,7 +10245,8 @@
           "Thirteen"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc 13"
       }
     },
     "properties": {
@@ -10261,12 +10261,12 @@
         "lore": "C418 - Cat",
         "search_names": [
           "Cat Disc",
-          "Music Disc Cat",
           "Disc Cat",
           "C418 - Cat"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc Cat"
       }
     },
     "properties": {
@@ -10281,12 +10281,12 @@
         "lore": "C418 - Blocks",
         "search_names": [
           "Blocks Disc",
-          "Music Disc Blocks",
           "Disc Blocks",
           "C418 - Blocks"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc Blocks"
       }
     },
     "properties": {
@@ -10301,12 +10301,12 @@
         "lore": "C418 - Chirp",
         "search_names": [
           "Chirp Disc",
-          "Music Disc Chirp",
           "Disc Chirp",
           "C418 - Chirp"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc Chirp"
       }
     },
     "properties": {
@@ -10321,12 +10321,12 @@
         "lore": "C418 - Far",
         "search_names": [
           "Far Disc",
-          "Music Disc Far",
           "Disc Far",
           "C418 - Far"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc Far"
       }
     },
     "properties": {
@@ -10341,12 +10341,12 @@
         "lore": "C418 - Mall",
         "search_names": [
           "Mall Disc",
-          "Music Disc Mall",
           "Disc Mall",
           "C418 - Mall"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc Mall"
       }
     },
     "properties": {
@@ -10361,12 +10361,12 @@
         "lore": "C418 - Mellohi",
         "search_names": [
           "Mellohi Disc",
-          "Music Disc Mellohi",
           "Disc Mellohi",
           "C418 - Mellohi"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc Mellohi"
       }
     },
     "properties": {
@@ -10381,13 +10381,13 @@
         "lore": "C418 - Stal",
         "search_names": [
           "Stal Disc",
-          "Music Disc Stal",
           "Disc Stal",
           "C418 - Stal",
           "Jschlatt"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc Stal"
       }
     },
     "properties": {
@@ -10402,12 +10402,12 @@
         "lore": "C418 - Strad",
         "search_names": [
           "Strad Disc",
-          "Music Disc Strad",
           "Disc Strad",
           "C418 - Strad"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc Strad"
       }
     },
     "properties": {
@@ -10422,13 +10422,13 @@
         "lore": "C418 - Ward",
         "search_names": [
           "Ward Disc",
-          "Music Disc Ward",
           "Disc Ward",
           "C418 - Ward",
           "Herobrine"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc Ward"
       }
     },
     "properties": {
@@ -10447,13 +10447,13 @@
           "Disc 11",
           "C418 - 11",
           "Eleven Disc",
-          "Music Disc Eleven",
           "Disc Eleven",
           "C418 - Eleven",
           "Eleven"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc Eleven"
       }
     },
     "properties": {
@@ -10468,12 +10468,12 @@
         "lore": "C418 - Wait",
         "search_names": [
           "Wait Disc",
-          "Music Disc Wait",
           "Disc Wait",
           "C418 - Wait"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc Wait"
       }
     },
     "properties": {
@@ -12327,13 +12327,13 @@
       "en_US": {
         "lore": "Creeper Charge",
         "search_names": [
-          "Creeper Banner Pattern",
           "Creeper Charge Banner Pattern",
           "Creeper Pattern",
           "Creeper Charge Pattern"
         ],
         "display_name": "Banner Pattern",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Creeper Banner Pattern"
       }
     },
     "properties": {
@@ -12472,13 +12472,13 @@
       "en_US": {
         "lore": "Flower Charge",
         "search_names": [
-          "Flower Banner Pattern",
           "Flower Charge Banner Pattern",
           "Flower Pattern",
           "Flower Charge Pattern"
         ],
         "display_name": "Banner Pattern",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Flower Banner Pattern"
       }
     },
     "properties": {
@@ -12504,13 +12504,13 @@
       "en_US": {
         "lore": "Globe",
         "search_names": [
-          "Globe Banner Pattern",
           "Globe Pattern",
           "Earth Banner Pattern",
           "Earth Pattern"
         ],
         "display_name": "Banner Pattern",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Globe Banner Pattern"
       }
     },
     "properties": {
@@ -12665,13 +12665,13 @@
       "en_US": {
         "lore": "Thing",
         "search_names": [
-          "Thing Banner Pattern",
           "Thing Pattern",
           "Mojang Banner Pattern",
           "Mojang Pattern"
         ],
         "display_name": "Banner Pattern",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Thing Banner Pattern"
       }
     },
     "properties": {
@@ -13004,13 +13004,13 @@
       "en_US": {
         "lore": "Skull Charge",
         "search_names": [
-          "Skull Charge Banner Pattern",
           "Skull Banner Pattern",
           "Skull Charge Pattern",
           "Skull Pattern"
         ],
         "display_name": "Banner Pattern",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Skull Charge Banner Pattern"
       }
     },
     "properties": {
@@ -13787,13 +13787,13 @@
         "lore": "Lena Raine - Pigstep",
         "search_names": [
           "Pigstep Disc",
-          "Music Disc Pigstep",
           "Disc Pigstep",
           "Lena Raine - Pigstep",
           "Pigstep"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc Pigstep"
       }
     },
     "properties": {
@@ -13958,13 +13958,13 @@
       "en_US": {
         "lore": "Snout",
         "search_names": [
-          "Snout Banner Pattern",
           "Piglin Banner Pattern",
           "Snout Pattern",
           "Piglin Pattern"
         ],
         "display_name": "Banner Pattern",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Snout Banner Pattern"
       }
     },
     "properties": {
@@ -17031,13 +17031,13 @@
         "lore": "Lena Raine - otherside",
         "search_names": [
           "Otherside Disc",
-          "Music Disc Otherside",
           "Disc Otherside",
           "Lena Raine - otherside",
           "otherside"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc otherside"
       }
     },
     "properties": {
@@ -17517,7 +17517,6 @@
         "lore": "C418 - 5",
         "search_names": [
           "5 Disc",
-          "Music Disc 5",
           "Disc 5",
           "C418 - 5",
           "Five Disc",
@@ -17527,7 +17526,8 @@
           "Five"
         ],
         "display_name": "Music Disc",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Music Disc 5"
       }
     },
     "properties": {
@@ -18775,7 +18775,8 @@
       "en_US": {
         "lore": "Coast Armor Trim",
         "display_name": "Smithing Template",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Coast Smithing Template"
       }
     },
     "properties": {
@@ -18800,7 +18801,8 @@
       "en_US": {
         "lore": "Dune Armor Trim",
         "display_name": "Smithing Template",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Dune Smithing Template"
       }
     },
     "properties": {
@@ -18814,7 +18816,8 @@
       "en_US": {
         "lore": "Eye Armor Trim",
         "display_name": "Smithing Template",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Eye Smithing Template"
       }
     },
     "properties": {
@@ -18828,7 +18831,8 @@
       "en_US": {
         "lore": "Netherite Upgrade",
         "display_name": "Smithing Template",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Netherite Upgrade Smithing Template"
       }
     },
     "properties": {
@@ -18919,7 +18923,8 @@
       "en_US": {
         "lore": "Rib Armor Trim",
         "display_name": "Smithing Template",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Rib Smithing Template"
       }
     },
     "properties": {
@@ -18933,7 +18938,8 @@
       "en_US": {
         "lore": "Sentry Armor Trim",
         "display_name": "Smithing Template",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Sentry Smithing Template"
       }
     },
     "properties": {
@@ -18958,7 +18964,8 @@
       "en_US": {
         "lore": "Snout Armor Trim",
         "display_name": "Smithing Template",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Snout Smithing Template"
       }
     },
     "properties": {
@@ -18972,7 +18979,8 @@
       "en_US": {
         "lore": "Spire Armor Trim",
         "display_name": "Smithing Template",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Spire Smithing Template"
       }
     },
     "properties": {
@@ -19019,7 +19027,8 @@
       "en_US": {
         "lore": "Tide Armor Trim",
         "display_name": "Smithing Template",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Tide Smithing Template"
       }
     },
     "properties": {
@@ -19066,7 +19075,8 @@
       "en_US": {
         "lore": "Vex Armor Trim",
         "display_name": "Smithing Template",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Vex Smithing Template"
       }
     },
     "properties": {
@@ -19080,7 +19090,8 @@
       "en_US": {
         "lore": "Ward Armor Trim",
         "display_name": "Smithing Template",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Ward Smithing Template"
       }
     },
     "properties": {
@@ -19094,7 +19105,8 @@
       "en_US": {
         "lore": "Wild Armor Trim",
         "display_name": "Smithing Template",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Wild Smithing Template"
       }
     },
     "properties": {
@@ -23189,12 +23201,12 @@
       "en_US": {
         "lore": "No effects",
         "search_names": [
-          "Awkward Tipped Arrow",
           "Tipped Awkward Arrow",
           "Awkward Arrow"
         ],
         "display_name": "Tipped Arrow",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Awkward Tipped Arrow"
       }
     },
     "properties": {
@@ -23713,12 +23725,12 @@
       "en_US": {
         "lore": "No effects",
         "search_names": [
-          "Mundane Tipped Arrow",
           "Mundane Arrow",
           "Tipped Mundane Arrow"
         ],
         "display_name": "Tipped Arrow",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Mundane Tipped Arrow"
       }
     },
     "properties": {
@@ -24495,12 +24507,12 @@
           "Thicc Tipped Arrow",
           "Thicc Arrow",
           "Tipped Thicc Arrow",
-          "Thick Tipped Arrow",
           "Thick Arrow",
           "Tipped Thick Arrow"
         ],
         "display_name": "Tipped Arrow",
-        "name_conflict": true
+        "name_conflict": true,
+        "distinct_display_name": "Thick Tipped Arrow"
       }
     },
     "properties": {

--- a/items.json
+++ b/items.json
@@ -10236,9 +10236,11 @@
         "lore": "C418 - 13",
         "search_names": [
           "13 Disc",
+          "13 Music Disc",
           "Disc 13",
           "C418 - 13",
           "Thirteen Disc",
+          "Thirteen Music Disc",
           "Music Disc Thirteen",
           "Disc Thirteen",
           "C418 - Thirteen",
@@ -10261,6 +10263,7 @@
         "lore": "C418 - Cat",
         "search_names": [
           "Cat Disc",
+          "Cat Music Disc",
           "Disc Cat",
           "C418 - Cat"
         ],
@@ -10281,6 +10284,7 @@
         "lore": "C418 - Blocks",
         "search_names": [
           "Blocks Disc",
+          "Blocks Music Disc",
           "Disc Blocks",
           "C418 - Blocks"
         ],
@@ -10301,6 +10305,7 @@
         "lore": "C418 - Chirp",
         "search_names": [
           "Chirp Disc",
+          "Chirp Music Disc",
           "Disc Chirp",
           "C418 - Chirp"
         ],
@@ -10321,6 +10326,7 @@
         "lore": "C418 - Far",
         "search_names": [
           "Far Disc",
+          "Far Music Disc",
           "Disc Far",
           "C418 - Far"
         ],
@@ -10341,6 +10347,7 @@
         "lore": "C418 - Mall",
         "search_names": [
           "Mall Disc",
+          "Mall Music Disc",
           "Disc Mall",
           "C418 - Mall"
         ],
@@ -10361,6 +10368,7 @@
         "lore": "C418 - Mellohi",
         "search_names": [
           "Mellohi Disc",
+          "Mellohi Music Disc",
           "Disc Mellohi",
           "C418 - Mellohi"
         ],
@@ -10381,6 +10389,7 @@
         "lore": "C418 - Stal",
         "search_names": [
           "Stal Disc",
+          "Stal Music Disc",
           "Disc Stal",
           "C418 - Stal",
           "Jschlatt"
@@ -10402,6 +10411,7 @@
         "lore": "C418 - Strad",
         "search_names": [
           "Strad Disc",
+          "Strad Music Disc",
           "Disc Strad",
           "C418 - Strad"
         ],
@@ -10422,6 +10432,7 @@
         "lore": "C418 - Ward",
         "search_names": [
           "Ward Disc",
+          "Ward Music Disc",
           "Disc Ward",
           "C418 - Ward",
           "Herobrine"
@@ -10443,10 +10454,12 @@
         "lore": "C418 - 11",
         "search_names": [
           "11 Disc",
+          "11 Music Disc",
           "Music Disc 11",
           "Disc 11",
           "C418 - 11",
           "Eleven Disc",
+          "Eleven Music Disc",
           "Disc Eleven",
           "C418 - Eleven",
           "Eleven"
@@ -10468,6 +10481,7 @@
         "lore": "C418 - Wait",
         "search_names": [
           "Wait Disc",
+          "Wait Music Disc",
           "Disc Wait",
           "C418 - Wait"
         ],
@@ -13787,6 +13801,7 @@
         "lore": "Lena Raine - Pigstep",
         "search_names": [
           "Pigstep Disc",
+          "Pigstep Music Disc",
           "Disc Pigstep",
           "Lena Raine - Pigstep",
           "Pigstep"
@@ -17031,6 +17046,7 @@
         "lore": "Lena Raine - otherside",
         "search_names": [
           "Otherside Disc",
+          "Otherside Music Disc",
           "Disc Otherside",
           "Lena Raine - otherside",
           "otherside"
@@ -17517,10 +17533,12 @@
         "lore": "Samuel Åberg - 5",
         "search_names": [
           "5 Disc",
+          "5 Music Disc",
           "Disc 5",
           "Samuel Aberg - 5",
           "Samuel Åberg - 5",
           "Five Disc",
+          "Five Music Disc",
           "Music Disc Five",
           "Disc Five",
           "Samuel Aberg - Five",

--- a/items.json
+++ b/items.json
@@ -18582,6 +18582,11 @@
   "minecraft.cherry_boat": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Boat",
+          "Pink Boat",
+          "Pink Wood Boat"
+        ],
         "display_name": "Cherry Boat"
       }
     },
@@ -18593,6 +18598,11 @@
   "minecraft.cherry_button": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Button",
+          "Pink Button",
+          "Pink Wood Button"
+        ],
         "display_name": "Cherry Button"
       }
     },
@@ -18604,6 +18614,15 @@
   "minecraft.cherry_chest_boat": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Chest Boat",
+          "Cherry Wood Boat with Chest",
+          "Cherry Wood Chest Boat",
+          "Pink Boat with Chest",
+          "Pink Chest Boat",
+          "Pink Wood Boat with Chest",
+          "Pink Wood CHest Boat"
+        ],
         "display_name": "Cherry Boat with Chest"
       }
     },
@@ -18615,6 +18634,11 @@
   "minecraft.cherry_door": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Door",
+          "Pink Door",
+          "Pink Wood Door"
+        ],
         "display_name": "Cherry Door"
       }
     },
@@ -18626,6 +18650,11 @@
   "minecraft.cherry_fence": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Fence",
+          "Pink Fence",
+          "Pink Wood Fence"
+        ],
         "display_name": "Cherry Fence"
       }
     },
@@ -18637,6 +18666,15 @@
   "minecraft.cherry_fence_gate": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Fence Gate",
+          "Cherry Wood Gate",
+          "Cherry Gate",
+          "Pink Fence Gate",
+          "Pink Wood Fence Gate",
+          "Pink Wood Gate",
+          "Pink Gate"
+        ],
         "display_name": "Cherry Fence Gate"
       }
     },
@@ -18648,6 +18686,15 @@
   "minecraft.cherry_hanging_sign": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Hanging Sign",
+          "Hanging Cherry Sign",
+          "Hanging Cherry Wood Sign",
+          "Pink Hanging Sign",
+          "Pink Wood Hanging Sign",
+          "Hanging Pink Sign",
+          "Hanging Pink Wood Sign"
+        ],
         "display_name": "Cherry Hanging Sign"
       }
     },
@@ -18659,6 +18706,9 @@
   "minecraft.cherry_leaves": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Pink Leaves"
+        ],
         "display_name": "Cherry Leaves"
       }
     },
@@ -18670,6 +18720,9 @@
   "minecraft.cherry_log": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Pink Log"
+        ],
         "display_name": "Cherry Log"
       }
     },
@@ -18681,6 +18734,15 @@
   "minecraft.cherry_planks": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Planks",
+          "Cherry Wood Plank",
+          "Cherry Plank",
+          "Pink Planks",
+          "Pink Wood Planks",
+          "Pink Wood Plank",
+          "Pink Plank"
+        ],
         "display_name": "Cherry Planks"
       }
     },
@@ -18692,6 +18754,15 @@
   "minecraft.cherry_pressure_plate": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Pressure Plate",
+          "Cherry Wood Plate",
+          "Cherry Plate",
+          "Pink Pressure Plate",
+          "Pink Wood Pressure Plate",
+          "Pink Wood Plate",
+          "Pink Plate"
+        ],
         "display_name": "Cherry Pressure Plate"
       }
     },
@@ -18703,6 +18774,9 @@
   "minecraft.cherry_sapling": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Pink Sapling"
+        ],
         "display_name": "Cherry Sapling"
       }
     },
@@ -18714,6 +18788,11 @@
   "minecraft.cherry_sign": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Sign",
+          "Pink Sign",
+          "Pink Wood Sign"
+        ],
         "display_name": "Cherry Sign"
       }
     },
@@ -18725,6 +18804,11 @@
   "minecraft.cherry_slab": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Slab",
+          "Pink Slab",
+          "Pink Wood Slab"
+        ],
         "display_name": "Cherry Slab"
       }
     },
@@ -18736,6 +18820,15 @@
   "minecraft.cherry_stairs": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Stairs",
+          "Cherry Wood Stair",
+          "Cherry Stair",
+          "Pink Stairs",
+          "Pink Wood Stairs",
+          "Pink Wood Stair",
+          "Pink Stair"
+        ],
         "display_name": "Cherry Stairs"
       }
     },
@@ -18747,6 +18840,15 @@
   "minecraft.cherry_trapdoor": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Trapdoor",
+          "Cherry Wood Trap Door",
+          "Cherry Trap Door",
+          "Pink Trapdoor",
+          "Pink Wood Trapdoor",
+          "Pink Wood Trap Door",
+          "Pink Trap Door"
+        ],
         "display_name": "Cherry Trapdoor"
       }
     },
@@ -18758,6 +18860,23 @@
   "minecraft.cherry_wall_hanging_sign": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Wall Hanging Sign",
+          "Wall Hanging Cherry Sign",
+          "Wall Hanging Cherry Wood Sign",
+          "Cherry Hanging Wall Sign",
+          "Cherry Wood Hanging Wall Sign",
+          "Hanging Cherry Wall Sign",
+          "Hanging Cherry Wood Wall Sign",
+          "Pink Wall Hanging Sign",
+          "Pink Wood Wall Hanging Sign",
+          "Wall Hanging Pink Sign",
+          "Wall Hanging Pink Wood Sign",
+          "Pink Hanging Wall Sign",
+          "Pink Wood Hanging Wall Sign",
+          "Hanging Pink Wall Sign",
+          "Hanging Pink Wood Wall Sign"
+        ],
         "display_name": "Cherry Wall Hanging Sign"
       }
     },
@@ -18770,6 +18889,11 @@
   "minecraft.cherry_wall_sign": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cherry Wood Wall Sign",
+          "Pink Wall Sign",
+          "Pink Wood Wall Sign"
+        ],
         "display_name": "Cherry Wall Sign"
       }
     },
@@ -18782,6 +18906,9 @@
   "minecraft.cherry_wood": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Pink Wood"
+        ],
         "display_name": "Cherry Wood"
       }
     },
@@ -18793,6 +18920,23 @@
   "minecraft.coast_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Coast Armor Trim Smithing Template",
+          "Coast Armor Trim Template",
+          "Coast Armor Trim",
+          "Coast Trim Smithing Template",
+          "Coast Trim Template",
+          "Coast Trim",
+          "Coast Template",
+          "Shipwreck Armor Trim Smithing Template",
+          "Shipwreck Armor Trim Template",
+          "Shipwreck Armor Trim",
+          "Shipwreck Trim Smithing Template",
+          "Shipwreck Trim Template",
+          "Shipwreck Trim",
+          "Shipwreck Smithing Template",
+          "Shipwreck Template"
+        ],
         "lore": "Coast Armor Trim",
         "display_name": "Smithing Template",
         "name_conflict": true,
@@ -18808,6 +18952,10 @@
   "minecraft.decorated_pot": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Undecorated Pot",
+          "Undecorated Decorated Pot"
+        ],
         "display_name": "Decorated Pot"
       }
     },
@@ -18819,6 +18967,39 @@
   "minecraft.dune_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Dune Armor Trim Smithing Template",
+          "Dune Armor Trim Template",
+          "Dune Armor Trim",
+          "Dune Trim Smithing Template",
+          "Dune Trim Template",
+          "Dune Trim",
+          "Dune Template",
+          "Desert Pyramid Armor Trim Smithing Template",
+          "Desert Pyramid Armor Trim Template",
+          "Desert Pyramid Armor Trim",
+          "Desert Pyramid Trim Smithing Template",
+          "Desert Pyramid Trim Template",
+          "Desert Pyramid Trim",
+          "Desert Pyramid Smithing Template",
+          "Desert Pyramid Template",
+          "Pyramid Armor Trim Smithing Template",
+          "Pyramid Armor Trim Template",
+          "Pyramid Armor Trim",
+          "Pyramid Trim Smithing Template",
+          "Pyramid Trim Template",
+          "Pyramid Trim",
+          "Pyramid Smithing Template",
+          "Pyramid Template",
+          "Desert Temple Armor Trim Smithing Template",
+          "Desert Temple Armor Trim Template",
+          "Desert Temple Armor Trim",
+          "Desert Temple Trim Smithing Template",
+          "Desert Temple Trim Template",
+          "Desert Temple Trim",
+          "Desert Temple Smithing Template",
+          "Desert Temple Template"
+        ],
         "lore": "Dune Armor Trim",
         "display_name": "Smithing Template",
         "name_conflict": true,
@@ -18834,6 +19015,23 @@
   "minecraft.eye_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Eye Armor Trim Smithing Template",
+          "Eye Armor Trim Template",
+          "Eye Armor Trim",
+          "Eye Trim Smithing Template",
+          "Eye Trim Template",
+          "Eye Trim",
+          "Eye Template",
+          "Stronghold Armor Trim Smithing Template",
+          "Stronghold Armor Trim Template",
+          "Stronghold Armor Trim",
+          "Stronghold Trim Smithing Template",
+          "Stronghold Trim Template",
+          "Stronghold Trim",
+          "Stronghold Smithing Template",
+          "Stronghold Template"
+        ],
         "lore": "Eye Armor Trim",
         "display_name": "Smithing Template",
         "name_conflict": true,
@@ -18849,6 +19047,12 @@
   "minecraft.netherite_upgrade_smithing_template": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Netherite Upgrade Template",
+          "Netherite Smithing Template",
+          "Netherite Template",
+          "Netherite Upgrade"
+        ],
         "lore": "Netherite Upgrade",
         "display_name": "Smithing Template",
         "name_conflict": true,
@@ -18864,6 +19068,11 @@
   "minecraft.pink_petals": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Pink Flowers",
+          "Cherry Petals",
+          "Cherry Flowers"
+        ],
         "display_name": "Pink Petals"
       }
     },
@@ -18875,6 +19084,9 @@
   "minecraft.potted_cherry_sapling": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Potted Pink Sapling"
+        ],
         "display_name": "Potted Cherry Sapling"
       }
     },
@@ -18886,6 +19098,9 @@
   "minecraft.potted_torchflower": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Potted Torch Flower"
+        ],
         "display_name": "Potted Torchflower"
       }
     },
@@ -18897,6 +19112,12 @@
   "minecraft.pottery_shard_archer": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Archer Shard",
+          "Bow Pottery Shard",
+          "Pottery Shard Bow",
+          "Bow Shard"
+        ],
         "display_name": "Archer Pottery Shard"
       }
     },
@@ -18908,6 +19129,9 @@
   "minecraft.pottery_shard_arms_up": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Arms Up Shard"
+        ],
         "display_name": "Arms Up Pottery Shard"
       }
     },
@@ -18919,6 +19143,12 @@
   "minecraft.pottery_shard_prize": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Prize Shard",
+          "Diamond Pottery Shard",
+          "Pottery Shard Diamond",
+          "Diamond Shard"
+        ],
         "display_name": "Prize Pottery Shard"
       }
     },
@@ -18930,6 +19160,9 @@
   "minecraft.pottery_shard_skull": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Skull Shard"
+        ],
         "display_name": "Skull Pottery Shard"
       }
     },
@@ -18941,6 +19174,31 @@
   "minecraft.rib_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Rib Armor Trim Smithing Template",
+          "Rib Armor Trim Template",
+          "Rib Armor Trim",
+          "Rib Trim Smithing Template",
+          "Rib Trim Template",
+          "Rib Trim",
+          "Rib Template",
+          "Nether Fortress Armor Trim Smithing Template",
+          "Nether Fortress Armor Trim Template",
+          "Nether Fortress Armor Trim",
+          "Nether Fortress Trim Smithing Template",
+          "Nether Fortress Trim Template",
+          "Nether Fortress Trim",
+          "Nether Fortress Smithing Template",
+          "Nether Fortress Template",
+          "Fortress Armor Trim Smithing Template",
+          "Fortress Armor Trim Template",
+          "Fortress Armor Trim",
+          "Fortress Trim Smithing Template",
+          "Fortress Trim Template",
+          "Fortress Trim",
+          "Fortress Smithing Template",
+          "Fortress Template"
+        ],
         "lore": "Rib Armor Trim",
         "display_name": "Smithing Template",
         "name_conflict": true,
@@ -18956,6 +19214,39 @@
   "minecraft.sentry_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Sentry Armor Trim Smithing Template",
+          "Sentry Armor Trim Template",
+          "Sentry Armor Trim",
+          "Sentry Trim Smithing Template",
+          "Sentry Trim Template",
+          "Sentry Trim",
+          "Sentry Template",
+          "Pillager Outpost Armor Trim Smithing Template",
+          "Pillager Outpost Armor Trim Template",
+          "Pillager Outpost Armor Trim",
+          "Pillager Outpost Trim Smithing Template",
+          "Pillager Outpost Trim Template",
+          "Pillager Outpost Trim",
+          "Pillager Outpost Smithing Template",
+          "Pillager Outpost Template",
+          "Pillager Armor Trim Smithing Template",
+          "Pillager Armor Trim Template",
+          "Pillager Armor Trim",
+          "Pillager Trim Smithing Template",
+          "Pillager Trim Template",
+          "Pillager Trim",
+          "Pillager Smithing Template",
+          "Pillager Template",
+          "Outpost Armor Trim Smithing Template",
+          "Outpost Armor Trim Template",
+          "Outpost Armor Trim",
+          "Outpost Trim Smithing Template",
+          "Outpost Trim Template",
+          "Outpost Trim",
+          "Outpost Smithing Template",
+          "Outpost Template"
+        ],
         "lore": "Sentry Armor Trim",
         "display_name": "Smithing Template",
         "name_conflict": true,
@@ -18971,6 +19262,10 @@
   "minecraft.sniffer_spawn_egg": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Spawn Sniffer",
+          "Sniffer Egg"
+        ],
         "display_name": "Sniffer Spawn Egg"
       }
     },
@@ -18982,6 +19277,47 @@
   "minecraft.snout_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Snout Armor Trim Smithing Template",
+          "Snout Armor Trim Template",
+          "Snout Armor Trim",
+          "Snout Trim Smithing Template",
+          "Snout Trim Template",
+          "Snout Trim",
+          "Snout Template",
+          "Bastion Remnant Armor Trim Smithing Template",
+          "Bastion Remnant Armor Trim Template",
+          "Bastion Remnant Armor Trim",
+          "Bastion Remnant Trim Smithing Template",
+          "Bastion Remnant Trim Template",
+          "Bastion Remnant Trim",
+          "Bastion Remnant Smithing Template",
+          "Bastion Remnant Template",
+          "Bastion Armor Trim Smithing Template",
+          "Bastion Armor Trim Template",
+          "Bastion Armor Trim",
+          "Bastion Trim Smithing Template",
+          "Bastion Trim Template",
+          "Bastion Trim",
+          "Bastion Smithing Template",
+          "Bastion Template",
+          "Remnant Armor Trim Smithing Template",
+          "Remnant Armor Trim Template",
+          "Remnant Armor Trim",
+          "Remnant Trim Smithing Template",
+          "Remnant Trim Template",
+          "Remnant Trim",
+          "Remnant Smithing Template",
+          "Remnant Template",
+          "Piglin Armor Trim Smithing Template",
+          "Piglin Armor Trim Template",
+          "Piglin Armor Trim",
+          "Piglin Trim Smithing Template",
+          "Piglin Trim Template",
+          "Piglin Trim",
+          "Piglin Smithing Template",
+          "Piglin Template"
+        ],
         "lore": "Snout Armor Trim",
         "display_name": "Smithing Template",
         "name_conflict": true,
@@ -18997,6 +19333,31 @@
   "minecraft.spire_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Spire Armor Trim Smithing Template",
+          "Spire Armor Trim Template",
+          "Spire Armor Trim",
+          "Spire Trim Smithing Template",
+          "Spire Trim Template",
+          "Spire Trim",
+          "Spire Template",
+          "End City Armor Trim Smithing Template",
+          "End City Armor Trim Template",
+          "End City Armor Trim",
+          "End City Trim Smithing Template",
+          "End City Trim Template",
+          "End City Trim",
+          "End City Smithing Template",
+          "End City Template",
+          "End Armor Trim Smithing Template",
+          "End Armor Trim Template",
+          "End Armor Trim",
+          "End Trim Smithing Template",
+          "End Trim Template",
+          "End Trim",
+          "End Smithing Template",
+          "End Template"
+        ],
         "lore": "Spire Armor Trim",
         "display_name": "Smithing Template",
         "name_conflict": true,
@@ -19012,6 +19373,9 @@
   "minecraft.stripped_cherry_log": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Stripped Pink Log"
+        ],
         "display_name": "Stripped Cherry Log"
       }
     },
@@ -19023,6 +19387,9 @@
   "minecraft.stripped_cherry_wood": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Stripped Pink Wood"
+        ],
         "display_name": "Stripped Cherry Wood"
       }
     },
@@ -19034,6 +19401,9 @@
   "minecraft.suspicious_sand": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Sus Sand"
+        ],
         "display_name": "Suspicious Sand"
       }
     },
@@ -19045,6 +19415,47 @@
   "minecraft.tide_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Tide Armor Trim Smithing Template",
+          "Tide Armor Trim Template",
+          "Tide Armor Trim",
+          "Tide Trim Smithing Template",
+          "Tide Trim Template",
+          "Tide Trim",
+          "Tide Template",
+          "Elder Guardian Armor Trim Smithing Template",
+          "Elder Guardian Armor Trim Template",
+          "Elder Guardian Armor Trim",
+          "Elder Guardian Trim Smithing Template",
+          "Elder Guardian Trim Template",
+          "Elder Guardian Trim",
+          "Elder Guardian Smithing Template",
+          "Elder Guardian Template",
+          "Guardian Armor Trim Smithing Template",
+          "Guardian Armor Trim Template",
+          "Guardian Armor Trim",
+          "Guardian Trim Smithing Template",
+          "Guardian Trim Template",
+          "Guardian Trim",
+          "Guardian Smithing Template",
+          "Guardian Template",
+          "Ocean Monument Armor Trim Smithing Template",
+          "Ocean Monument Armor Trim Template",
+          "Ocean Monument Armor Trim",
+          "Ocean Monument Trim Smithing Template",
+          "Ocean Monument Trim Template",
+          "Ocean Monument Trim",
+          "Ocean Monument Smithing Template",
+          "Ocean Monument Template",
+          "Monument Armor Trim Smithing Template",
+          "Monument Armor Trim Template",
+          "Monument Armor Trim",
+          "Monument Trim Smithing Template",
+          "Monument Trim Template",
+          "Monument Trim",
+          "Monument Smithing Template",
+          "Monument Template"
+        ],
         "lore": "Tide Armor Trim",
         "display_name": "Smithing Template",
         "name_conflict": true,
@@ -19060,6 +19471,9 @@
   "minecraft.torchflower": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Torch Flower"
+        ],
         "display_name": "Torchflower"
       }
     },
@@ -19071,6 +19485,11 @@
   "minecraft.torchflower_crop": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Torch Flower Crop",
+          "Torchflower Crops",
+          "Torch Flower Crops"
+        ],
         "display_name": "Torchflower Crop"
       }
     },
@@ -19082,6 +19501,9 @@
   "minecraft.torchflower_seeds": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Torch Flower Seeds"
+        ],
         "display_name": "Torchflower Seeds"
       }
     },
@@ -19093,6 +19515,31 @@
   "minecraft.vex_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Vex Armor Trim Smithing Template",
+          "Vex Armor Trim Template",
+          "Vex Armor Trim",
+          "Vex Trim Smithing Template",
+          "Vex Trim Template",
+          "Vex Trim",
+          "Vex Template",
+          "Woodland Mansion Armor Trim Smithing Template",
+          "Woodland Mansion Armor Trim Template",
+          "Woodland Mansion Armor Trim",
+          "Woodland Mansion Trim Smithing Template",
+          "Woodland Mansion Trim Template",
+          "Woodland Mansion Trim",
+          "Woodland Mansion Smithing Template",
+          "Woodland Mansion Template",
+          "Mansion Armor Trim Smithing Template",
+          "Mansion Armor Trim Template",
+          "Mansion Armor Trim",
+          "Mansion Trim Smithing Template",
+          "Mansion Trim Template",
+          "Mansion Trim",
+          "Mansion Smithing Template",
+          "Mansion Template"
+        ],
         "lore": "Vex Armor Trim",
         "display_name": "Smithing Template",
         "name_conflict": true,
@@ -19108,6 +19555,39 @@
   "minecraft.ward_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Ward Armor Trim Smithing Template",
+          "Ward Armor Trim Template",
+          "Ward Armor Trim",
+          "Ward Trim Smithing Template",
+          "Ward Trim Template",
+          "Ward Trim",
+          "Ward Template",
+          "Warden Armor Trim Smithing Template",
+          "Warden Armor Trim Template",
+          "Warden Armor Trim",
+          "Warden Trim Smithing Template",
+          "Warden Trim Template",
+          "Warden Trim",
+          "Warden Smithing Template",
+          "Warden Template",
+          "Ancient City Armor Trim Smithing Template",
+          "Ancient City Armor Trim Template",
+          "Ancient City Armor Trim",
+          "Ancient City Trim Smithing Template",
+          "Ancient City Trim Template",
+          "Ancient City Trim",
+          "Ancient City Smithing Template",
+          "Ancient City Template",
+          "Deep Dark Armor Trim Smithing Template",
+          "Deep Dark Armor Trim Template",
+          "Deep Dark Armor Trim",
+          "Deep Dark Trim Smithing Template",
+          "Deep Dark Trim Template",
+          "Deep Dark Trim",
+          "Deep Dark Smithing Template",
+          "Deep Dark Template"
+        ],
         "lore": "Ward Armor Trim",
         "display_name": "Smithing Template",
         "name_conflict": true,
@@ -19123,6 +19603,31 @@
   "minecraft.wild_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Wild Armor Trim Smithing Template",
+          "Wild Armor Trim Template",
+          "Wild Armor Trim",
+          "Wild Trim Smithing Template",
+          "Wild Trim Template",
+          "Wild Trim",
+          "Wild Template",
+          "Jungle Temple Armor Trim Smithing Template",
+          "Jungle Temple Armor Trim Template",
+          "Jungle Temple Armor Trim",
+          "Jungle Temple Trim Smithing Template",
+          "Jungle Temple Trim Template",
+          "Jungle Temple Trim",
+          "Jungle Temple Smithing Template",
+          "Jungle Temple Template",
+          "Jungle Armor Trim Smithing Template",
+          "Jungle Armor Trim Template",
+          "Jungle Armor Trim",
+          "Jungle Trim Smithing Template",
+          "Jungle Trim Template",
+          "Jungle Trim",
+          "Jungle Smithing Template",
+          "Jungle Template"
+        ],
         "lore": "Wild Armor Trim",
         "display_name": "Smithing Template",
         "name_conflict": true,

--- a/items.json
+++ b/items.json
@@ -17514,15 +17514,17 @@
   "minecraft.music_disc_5": {
     "lang": {
       "en_US": {
-        "lore": "C418 - 5",
+        "lore": "Samuel Åberg - 5",
         "search_names": [
           "5 Disc",
           "Disc 5",
-          "C418 - 5",
+          "Samuel Aberg - 5",
+          "Samuel Åberg - 5",
           "Five Disc",
           "Music Disc Five",
           "Disc Five",
-          "C418 - Five",
+          "Samuel Aberg - Five",
+          "Samuel Åberg - Five",
           "Five"
         ],
         "display_name": "Music Disc",

--- a/items.json
+++ b/items.json
@@ -1478,7 +1478,6 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Brick",
           "Brown Bricks"
         ],
         "display_name": "Bricks"

--- a/pom.xml
+++ b/pom.xml
@@ -15,18 +15,13 @@
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>5.0.0-beta.2</version>
+      <version>5.0.0-beta.5</version>
       <exclusions>
         <exclusion>
           <groupId>club.minnced</groupId>
           <artifactId>opus-java</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
-      <version>4.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
@@ -39,9 +34,14 @@
       <version>2.1.2</version>
     </dependency>
     <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20230227</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10</version>
+      <version>2.10.1</version>
     </dependency>
     <dependency>
       <groupId>club.minnced</groupId>
@@ -49,24 +49,19 @@
       <version>0.8.2</version>
     </dependency>
     <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20220924</version>
-    </dependency>
-    <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.31</version>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>8.0.32</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.21.10</version>
+      <version>3.22.2</version>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.40.0.0</version>
+      <version>3.41.0.0</version>
     </dependency>
     <dependency>
       <groupId>dnsjava</groupId>
@@ -76,7 +71,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.24</version>
+      <version>1.18.26</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -92,7 +87,7 @@
     <dependency>
       <groupId>dev.failsafe</groupId>
       <artifactId>failsafe</artifactId>
-      <version>3.2.4</version>
+      <version>3.3.0</version>
     </dependency>
     <!-- Part of the ColorMine Java library is included, licensed under the MIT license
     https://github.com/colormine/colormine -->

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.16.7</version>
+  <version>0.16.8</version>
 
   <repositories>
     <repository>

--- a/recipes.json
+++ b/recipes.json
@@ -3619,6 +3619,33 @@
     },
     "group": "wool"
   },
+  "brush": {
+    "result": {
+      "item": "minecraft:brush"
+    },
+    "pattern": [
+      "X",
+      "#",
+      "I"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "equipment",
+    "key": {
+      "#": {
+        "item": "minecraft:copper_ingot"
+      },
+      "X": {
+        "item": "minecraft:feather"
+      },
+      "I": {
+        "item": "minecraft:stick"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
   "bucket": {
     "result": {
       "item": "minecraft:bucket"
@@ -3908,6 +3935,315 @@
       "animated": true
     },
     "cookingtime": 200
+  },
+  "cherry_boat": {
+    "result": {
+      "item": "minecraft:cherry_boat"
+    },
+    "pattern": [
+      "# #",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:cherry_planks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "boat"
+  },
+  "cherry_button": {
+    "result": {
+      "item": "minecraft:cherry_button"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:cherry_planks"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "category": "redstone",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "wooden_button"
+  },
+  "cherry_chest_boat": {
+    "result": {
+      "item": "minecraft:cherry_chest_boat"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:chest"
+      },
+      {
+        "item": "minecraft:cherry_boat"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "category": "misc",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "chest_boat"
+  },
+  "cherry_door": {
+    "result": {
+      "item": "minecraft:cherry_door",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "redstone",
+    "key": {
+      "#": {
+        "item": "minecraft:cherry_planks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "wooden_door"
+  },
+  "cherry_fence": {
+    "result": {
+      "item": "minecraft:cherry_fence",
+      "count": 3
+    },
+    "pattern": [
+      "W#W",
+      "W#W"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:stick"
+      },
+      "W": {
+        "item": "minecraft:cherry_planks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "wooden_fence"
+  },
+  "cherry_fence_gate": {
+    "result": {
+      "item": "minecraft:cherry_fence_gate"
+    },
+    "pattern": [
+      "#W#",
+      "#W#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "redstone",
+    "key": {
+      "#": {
+        "item": "minecraft:stick"
+      },
+      "W": {
+        "item": "minecraft:cherry_planks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "wooden_fence_gate"
+  },
+  "cherry_hanging_sign": {
+    "result": {
+      "item": "minecraft:cherry_hanging_sign",
+      "count": 6
+    },
+    "pattern": [
+      "X X",
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:stripped_cherry_log"
+      },
+      "X": {
+        "item": "minecraft:chain"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "hanging_sign"
+  },
+  "cherry_planks": {
+    "result": {
+      "item": "minecraft:cherry_planks",
+      "count": 4
+    },
+    "ingredients": [
+      {
+        "tag": "minecraft:cherry_logs"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "category": "building",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "group": "planks"
+  },
+  "cherry_pressure_plate": {
+    "result": {
+      "item": "minecraft:cherry_pressure_plate"
+    },
+    "pattern": [
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "redstone",
+    "key": {
+      "#": {
+        "item": "minecraft:cherry_planks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "wooden_pressure_plate"
+  },
+  "cherry_sign": {
+    "result": {
+      "item": "minecraft:cherry_sign",
+      "count": 3
+    },
+    "pattern": [
+      "###",
+      "###",
+      " X "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:cherry_planks"
+      },
+      "X": {
+        "item": "minecraft:stick"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "wooden_sign"
+  },
+  "cherry_slab": {
+    "result": {
+      "item": "minecraft:cherry_slab",
+      "count": 6
+    },
+    "pattern": [
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "building",
+    "key": {
+      "#": {
+        "item": "minecraft:cherry_planks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "wooden_slab"
+  },
+  "cherry_stairs": {
+    "result": {
+      "item": "minecraft:cherry_stairs",
+      "count": 4
+    },
+    "pattern": [
+      "#  ",
+      "## ",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "building",
+    "key": {
+      "#": {
+        "item": "minecraft:cherry_planks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "wooden_stairs"
+  },
+  "cherry_trapdoor": {
+    "result": {
+      "item": "minecraft:cherry_trapdoor",
+      "count": 2
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "redstone",
+    "key": {
+      "#": {
+        "item": "minecraft:cherry_planks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "wooden_trapdoor"
+  },
+  "cherry_wood": {
+    "result": {
+      "item": "minecraft:cherry_wood",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "building",
+    "key": {
+      "#": {
+        "item": "minecraft:cherry_log"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "bark"
   },
   "chest": {
     "result": {
@@ -4337,6 +4673,34 @@
     },
     "properties": {
       "version": "1.8"
+    }
+  },
+  "coast_armor_trim_smithing_template": {
+    "result": {
+      "item": "minecraft:coast_armor_trim_smithing_template",
+      "count": 2
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:cobblestone"
+      },
+      "S": {
+        "item": "minecraft:coast_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
     }
   },
   "cobbled_deepslate_slab": {
@@ -6438,6 +6802,28 @@
       "animated": true
     }
   },
+  "decorated_pot": {
+    "result": {
+      "item": "minecraft:decorated_pot"
+    },
+    "pattern": [
+      " # ",
+      "# #",
+      " # "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "tag": "minecraft:decorated_pot_shards"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    }
+  },
   "deepslate": {
     "result": "minecraft:deepslate",
     "ingredient": {
@@ -7418,6 +7804,34 @@
       "#": {
         "item": "minecraft:cobblestone"
       }
+    }
+  },
+  "dune_armor_trim_smithing_template": {
+    "result": {
+      "item": "minecraft:dune_armor_trim_smithing_template",
+      "count": 2
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:sandstone"
+      },
+      "S": {
+        "item": "minecraft:dune_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
     }
   },
   "emerald": {
@@ -8484,6 +8898,34 @@
       "item": "minecraft.potion.effect.weakness.extended"
     }
   },
+  "eye_armor_trim_smithing_template": {
+    "result": {
+      "item": "minecraft:eye_armor_trim_smithing_template",
+      "count": 2
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:end_stone"
+      },
+      "S": {
+        "item": "minecraft:eye_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
   "fermented_spider_eye": {
     "result": {
       "item": "minecraft:fermented_spider_eye"
@@ -9076,7 +9518,7 @@
   "glass": {
     "result": "minecraft:glass",
     "ingredient": {
-      "tag": "minecraft:sand"
+      "tag": "minecraft:smelts_to_glass"
     },
     "type": "minecraft:smelting",
     "category": "blocks",
@@ -15253,8 +15695,29 @@
     "result": {
       "item": "minecraft:netherite_axe"
     },
+    "template": {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    "type": "minecraft:smithing_transform",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_axe"
+    }
+  },
+  "netherite_axe_smithing_legacy": {
+    "result": {
+      "item": "minecraft:netherite_axe"
+    },
     "type": "minecraft:smithing",
     "properties": {
+      "flag_removed_version": "1.19.4",
+      "removed_in_flag": "1.20",
       "version": "1.16"
     },
     "addition": {
@@ -15288,8 +15751,29 @@
     "result": {
       "item": "minecraft:netherite_boots"
     },
+    "template": {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    "type": "minecraft:smithing_transform",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_boots"
+    }
+  },
+  "netherite_boots_smithing_legacy": {
+    "result": {
+      "item": "minecraft:netherite_boots"
+    },
     "type": "minecraft:smithing",
     "properties": {
+      "flag_removed_version": "1.19.4",
+      "removed_in_flag": "1.20",
       "version": "1.16"
     },
     "addition": {
@@ -15303,8 +15787,29 @@
     "result": {
       "item": "minecraft:netherite_chestplate"
     },
+    "template": {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    "type": "minecraft:smithing_transform",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_chestplate"
+    }
+  },
+  "netherite_chestplate_smithing_legacy": {
+    "result": {
+      "item": "minecraft:netherite_chestplate"
+    },
     "type": "minecraft:smithing",
     "properties": {
+      "flag_removed_version": "1.19.4",
+      "removed_in_flag": "1.20",
       "version": "1.16"
     },
     "addition": {
@@ -15318,8 +15823,29 @@
     "result": {
       "item": "minecraft:netherite_helmet"
     },
+    "template": {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    "type": "minecraft:smithing_transform",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_helmet"
+    }
+  },
+  "netherite_helmet_smithing_legacy": {
+    "result": {
+      "item": "minecraft:netherite_helmet"
+    },
     "type": "minecraft:smithing",
     "properties": {
+      "flag_removed_version": "1.19.4",
+      "removed_in_flag": "1.20",
       "version": "1.16"
     },
     "addition": {
@@ -15333,8 +15859,29 @@
     "result": {
       "item": "minecraft:netherite_hoe"
     },
+    "template": {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    "type": "minecraft:smithing_transform",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_hoe"
+    }
+  },
+  "netherite_hoe_smithing_legacy": {
+    "result": {
+      "item": "minecraft:netherite_hoe"
+    },
     "type": "minecraft:smithing",
     "properties": {
+      "flag_removed_version": "1.19.4",
+      "removed_in_flag": "1.20",
       "version": "1.16"
     },
     "addition": {
@@ -15402,8 +15949,29 @@
     "result": {
       "item": "minecraft:netherite_leggings"
     },
+    "template": {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    "type": "minecraft:smithing_transform",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_leggings"
+    }
+  },
+  "netherite_leggings_smithing_legacy": {
+    "result": {
+      "item": "minecraft:netherite_leggings"
+    },
     "type": "minecraft:smithing",
     "properties": {
+      "flag_removed_version": "1.19.4",
+      "removed_in_flag": "1.20",
       "version": "1.16"
     },
     "addition": {
@@ -15417,8 +15985,29 @@
     "result": {
       "item": "minecraft:netherite_pickaxe"
     },
+    "template": {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    "type": "minecraft:smithing_transform",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_pickaxe"
+    }
+  },
+  "netherite_pickaxe_smithing_legacy": {
+    "result": {
+      "item": "minecraft:netherite_pickaxe"
+    },
     "type": "minecraft:smithing",
     "properties": {
+      "flag_removed_version": "1.19.4",
+      "removed_in_flag": "1.20",
       "version": "1.16"
     },
     "addition": {
@@ -15458,8 +16047,29 @@
     "result": {
       "item": "minecraft:netherite_shovel"
     },
+    "template": {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    "type": "minecraft:smithing_transform",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_shovel"
+    }
+  },
+  "netherite_shovel_smithing_legacy": {
+    "result": {
+      "item": "minecraft:netherite_shovel"
+    },
     "type": "minecraft:smithing",
     "properties": {
+      "flag_removed_version": "1.19.4",
+      "removed_in_flag": "1.20",
       "version": "1.16"
     },
     "addition": {
@@ -15473,8 +16083,29 @@
     "result": {
       "item": "minecraft:netherite_sword"
     },
+    "template": {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    "type": "minecraft:smithing_transform",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "addition": {
+      "item": "minecraft:netherite_ingot"
+    },
+    "base": {
+      "item": "minecraft:diamond_sword"
+    }
+  },
+  "netherite_sword_smithing_legacy": {
+    "result": {
+      "item": "minecraft:netherite_sword"
+    },
     "type": "minecraft:smithing",
     "properties": {
+      "flag_removed_version": "1.19.4",
+      "removed_in_flag": "1.20",
       "version": "1.16"
     },
     "addition": {
@@ -15482,6 +16113,34 @@
     },
     "base": {
       "item": "minecraft:diamond_sword"
+    }
+  },
+  "netherite_upgrade_smithing_template": {
+    "result": {
+      "item": "minecraft:netherite_upgrade_smithing_template",
+      "count": 2
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:netherrack"
+      },
+      "S": {
+        "item": "minecraft:netherite_upgrade_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
     }
   },
   "night_vision_lingering_potion": {
@@ -16052,6 +16711,23 @@
     "category": "misc",
     "group": "orange_dye"
   },
+  "orange_dye_from_torchflower": {
+    "result": {
+      "item": "minecraft:orange_dye"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:torchflower"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "category": "misc",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "orange_dye"
+  },
   "orange_glazed_terracotta": {
     "result": "minecraft:orange_glazed_terracotta",
     "ingredient": {
@@ -16569,6 +17245,23 @@
     ],
     "type": "minecraft:crafting_shapeless",
     "category": "misc",
+    "group": "pink_dye"
+  },
+  "pink_dye_from_pink_petals": {
+    "result": {
+      "item": "minecraft:pink_dye"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:pink_petals"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "category": "misc",
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
     "group": "pink_dye"
   },
   "pink_dye_from_pink_tulip": {
@@ -19624,6 +20317,34 @@
       "version": "1.16"
     }
   },
+  "rib_armor_trim_smithing_template": {
+    "result": {
+      "item": "minecraft:rib_armor_trim_smithing_template",
+      "count": 2
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:netherrack"
+      },
+      "S": {
+        "item": "minecraft:rib_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
   "sandstone": {
     "result": {
       "item": "minecraft:sandstone"
@@ -19791,6 +20512,34 @@
     },
     "properties": {
       "version": "1.8"
+    }
+  },
+  "sentry_armor_trim_smithing_template": {
+    "result": {
+      "item": "minecraft:sentry_armor_trim_smithing_template",
+      "count": 2
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:cobblestone"
+      },
+      "S": {
+        "item": "minecraft:sentry_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
     }
   },
   "shears": {
@@ -21331,6 +22080,506 @@
       "version": "1.14"
     }
   },
+  "smithing_template_smithing_trim_chainmail_boots": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:chainmail_boots"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:chainmail_boots"
+    }
+  },
+  "smithing_template_smithing_trim_chainmail_chestplate": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:chainmail_chestplate"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:chainmail_chestplate"
+    }
+  },
+  "smithing_template_smithing_trim_chainmail_helmet": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:chainmail_helmet"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:chainmail_helmet"
+    }
+  },
+  "smithing_template_smithing_trim_chainmail_leggings": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:chainmail_leggings"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:chainmail_leggings"
+    }
+  },
+  "smithing_template_smithing_trim_diamond_boots": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:diamond_boots"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:diamond_boots"
+    }
+  },
+  "smithing_template_smithing_trim_diamond_chestplate": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:diamond_chestplate"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:diamond_chestplate"
+    }
+  },
+  "smithing_template_smithing_trim_diamond_helmet": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:diamond_helmet"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:diamond_helmet"
+    }
+  },
+  "smithing_template_smithing_trim_diamond_leggings": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:diamond_leggings"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:diamond_leggings"
+    }
+  },
+  "smithing_template_smithing_trim_golden_boots": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:golden_boots"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:golden_boots"
+    }
+  },
+  "smithing_template_smithing_trim_golden_chestplate": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:golden_chestplate"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:golden_chestplate"
+    }
+  },
+  "smithing_template_smithing_trim_golden_helmet": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:golden_helmet"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:golden_helmet"
+    }
+  },
+  "smithing_template_smithing_trim_golden_leggings": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:golden_leggings"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:golden_leggings"
+    }
+  },
+  "smithing_template_smithing_trim_iron_boots": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:iron_boots"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:iron_boots"
+    }
+  },
+  "smithing_template_smithing_trim_iron_chestplate": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:iron_chestplate"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:iron_chestplate"
+    }
+  },
+  "smithing_template_smithing_trim_iron_helmet": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:iron_helmet"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:iron_helmet"
+    }
+  },
+  "smithing_template_smithing_trim_iron_leggings": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:iron_leggings"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:iron_leggings"
+    }
+  },
+  "smithing_template_smithing_trim_leather_boots": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:leather_boots"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:leather_boots"
+    }
+  },
+  "smithing_template_smithing_trim_leather_chestplate": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:leather_chestplate"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:leather_chestplate"
+    }
+  },
+  "smithing_template_smithing_trim_leather_helmet": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:leather_helmet"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:leather_helmet"
+    }
+  },
+  "smithing_template_smithing_trim_leather_leggings": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:leather_leggings"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:leather_leggings"
+    }
+  },
+  "smithing_template_smithing_trim_netherite_boots": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:netherite_boots"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:netherite_boots"
+    }
+  },
+  "smithing_template_smithing_trim_netherite_chestplate": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:netherite_chestplate"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:netherite_chestplate"
+    }
+  },
+  "smithing_template_smithing_trim_netherite_helmet": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:netherite_helmet"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:netherite_helmet"
+    }
+  },
+  "smithing_template_smithing_trim_netherite_leggings": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:netherite_leggings"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:netherite_leggings"
+    }
+  },
+  "smithing_template_smithing_trim_turtle_helmet": {
+    "template": {
+      "tag": "minecraft:trim_templates"
+    },
+    "result": {
+      "item": "minecraft:turtle_helmet"
+    },
+    "type": "minecraft:smithing_trim",
+    "properties": {
+      "feature_flag": "1.20",
+      "animated": true,
+      "version": "1.19.4"
+    },
+    "addition": {
+      "tag": "minecraft:trim_materials"
+    },
+    "base": {
+      "item": "minecraft:turtle_helmet"
+    }
+  },
   "smoker": {
     "result": {
       "item": "minecraft:smoker"
@@ -21630,6 +22879,34 @@
       "version": "1.14"
     }
   },
+  "snout_armor_trim_smithing_template": {
+    "result": {
+      "item": "minecraft:snout_armor_trim_smithing_template",
+      "count": 2
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:blackstone"
+      },
+      "S": {
+        "item": "minecraft:snout_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
   "snow": {
     "result": {
       "item": "minecraft:snow",
@@ -21767,6 +23044,34 @@
     },
     "properties": {
       "version": "1.9"
+    }
+  },
+  "spire_armor_trim_smithing_template": {
+    "result": {
+      "item": "minecraft:spire_armor_trim_smithing_template",
+      "count": 2
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:purpur_block"
+      },
+      "S": {
+        "item": "minecraft:spire_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
     }
   },
   "splash_amplified_harming_potion": {
@@ -23258,6 +24563,28 @@
     },
     "group": "bark"
   },
+  "stripped_cherry_wood": {
+    "result": {
+      "item": "minecraft:stripped_cherry_wood",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "building",
+    "key": {
+      "#": {
+        "item": "minecraft:stripped_cherry_log"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    },
+    "group": "bark"
+  },
   "stripped_crimson_hyphae": {
     "result": {
       "item": "minecraft:stripped_crimson_hyphae",
@@ -23599,6 +24926,34 @@
     },
     "base": {
       "item": "minecraft.potion.effect.thick"
+    }
+  },
+  "tide_armor_trim_smithing_template": {
+    "result": {
+      "item": "minecraft:tide_armor_trim_smithing_template",
+      "count": 2
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:prismarine"
+      },
+      "S": {
+        "item": "minecraft:tide_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
     }
   },
   "tinted_glass": {
@@ -24790,6 +26145,62 @@
     },
     "base": {
       "item": "minecraft.potion.effect.turtle_master"
+    }
+  },
+  "vex_armor_trim_smithing_template": {
+    "result": {
+      "item": "minecraft:vex_armor_trim_smithing_template",
+      "count": 2
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:cobblestone"
+      },
+      "S": {
+        "item": "minecraft:vex_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
+    }
+  },
+  "ward_armor_trim_smithing_template": {
+    "result": {
+      "item": "minecraft:ward_armor_trim_smithing_template",
+      "count": 2
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      "S": {
+        "item": "minecraft:ward_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
     }
   },
   "warped_button": {
@@ -26561,6 +27972,34 @@
       "#": {
         "item": "minecraft:string"
       }
+    }
+  },
+  "wild_armor_trim_smithing_template": {
+    "result": {
+      "item": "minecraft:wild_armor_trim_smithing_template",
+      "count": 2
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:mossy_cobblestone"
+      },
+      "S": {
+        "item": "minecraft:wild_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.20",
+      "version": "1.19.4"
     }
   },
   "wooden_axe": {

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -46,7 +46,7 @@ public class Bot {
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
     private static final String version = "0.16.7";
-    public static final String jdaVersion = "5.0.0-beta.2";
+    public static final String jdaVersion = "5.0.0-beta.5";
     public static final Color color = Color.GREEN;
 
     public static ShardManager shardManager;

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -45,7 +45,7 @@ public class Bot {
     public static final String github = "https://github.com/Tisawesomeness/Minecord";
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
-    private static final String version = "0.16.7";
+    private static final String version = "0.16.8";
     public static final String jdaVersion = "5.0.0-beta.5";
     public static final Color color = Color.GREEN;
 

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -46,7 +46,6 @@ public class Bot {
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
     private static final String version = "0.16.7";
-    public static final String javaVersion = "1.8";
     public static final String jdaVersion = "5.0.0-beta.2";
     public static final Color color = Color.GREEN;
 

--- a/src/com/tisawesomeness/minecord/Config.java
+++ b/src/com/tisawesomeness/minecord/Config.java
@@ -31,6 +31,7 @@ public class Config {
     private static String github;
     private static String prefix;
     private static String game;
+    private static boolean evil;
     private static boolean devMode;
     private static boolean debugMode;
     private static boolean deleteCommands;
@@ -131,6 +132,10 @@ public class Config {
             }
             prefix = settings.getString("prefix");
             game = settings.getString("game");
+            evil = settings.optBoolean("evil", false);
+            if (evil) {
+                System.err.println("WARNING: Eval is enabled!");
+            }
             devMode = settings.getBoolean("devMode");
             debugMode = settings.getBoolean("debugMode");
             deleteCommands = settings.getBoolean("deleteCommands");
@@ -188,6 +193,7 @@ public class Config {
     public static String getGithub() { return github; }
     public static String getPrefix() { return prefix; }
     public static String getGame() { return game; }
+    public static boolean getEvil() { return evil; }
     public static boolean getDevMode() { return devMode; }
     public static boolean getDebugMode() { return debugMode; }
     public static boolean getDeleteCommands() { return deleteCommands; }

--- a/src/com/tisawesomeness/minecord/GuildListener.java
+++ b/src/com/tisawesomeness/minecord/GuildListener.java
@@ -12,8 +12,6 @@ import net.dv8tion.jda.api.events.guild.GuildLeaveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 
-import java.util.ArrayList;
-
 public class GuildListener extends ListenerAdapter {
 
     @Override
@@ -35,12 +33,6 @@ public class GuildListener extends ListenerAdapter {
                 eb.addField("Owner", owner.getEffectiveName(), true);
                 eb.addField("Owner ID", owner.getUser().getId(), true);
             }
-            eb.addField("Users", String.valueOf(guild.getMembers().size()), true);
-            ArrayList<Member> users = new ArrayList<>(guild.getMembers());
-            users.removeIf(u -> u.getUser().isBot());
-            eb.addField("Humans", String.valueOf(users.size()), true);
-            eb.addField("Bots", String.valueOf(guild.getMembers().size() - users.size()), true);
-            eb.addField("Channels", String.valueOf(guild.getTextChannels().size()), true);
 
         } else if (e instanceof GuildLeaveEvent) {
             if (owner != null) {

--- a/src/com/tisawesomeness/minecord/ReactMenu.java
+++ b/src/com/tisawesomeness/minecord/ReactMenu.java
@@ -1,6 +1,7 @@
 package com.tisawesomeness.minecord;
 
 import com.tisawesomeness.minecord.database.Database;
+import com.tisawesomeness.minecord.util.MessageUtils;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
@@ -88,7 +89,7 @@ public abstract class ReactMenu {
         if (delete) {
             message.delete().queue();
         } else {
-            message = message.editMessageEmbeds( new EmbedBuilder(emb).setFooter(emb.getFooter().getText() + " (expired)").build()).complete();
+            message = message.editMessageEmbeds(new EmbedBuilder(emb).setTitle("(expired) " + emb.getTitle()).build()).complete();
             if (hasPerms(Permission.MESSAGE_MANAGE)) {
                 message.getReactions().stream()
                         .filter(MessageReaction::isSelf)
@@ -126,12 +127,19 @@ public abstract class ReactMenu {
     /**
      * Adds a page display to the footer
      * @param page The current page number
-     * @param error True if the bot does not have correct permissoins
+     * @param error True if the bot does not have correct permissions
      * @return The built MessageEmbed
      */
     private MessageEmbed getEmbed(int page, boolean error) {
-        String err = error ? " | Give the bot manage messages and add reactions permissions to use an interactive menu!" : " | Requested by " + ownerName;
-        return getContent(page).setFooter(String.format("**Page %d/%d**%s", page + 1, getLength(), err)).build();
+        EmbedBuilder eb = getContent(page);
+        String title = String.format("(%d/%d) %s", page + 1, getLength(), eb.build().getTitle());
+        eb.setTitle(title);
+        if (error) {
+            eb.setFooter("Give the bot manage messages and add reactions permissions to use an interactive menu!");
+        } else {
+            eb = MessageUtils.addFooter(eb);
+        }
+        return eb.build();
     }
     /**
      * Resets the expiration timer

--- a/src/com/tisawesomeness/minecord/command/Registry.java
+++ b/src/com/tisawesomeness/minecord/command/Registry.java
@@ -16,7 +16,10 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -96,7 +99,8 @@ public class Registry {
             )
     };
     // Map from name or alias user enters to either command or name of slash command to migrate to
-    private static final Map<String, Either<String, Command<?>>> commandMap = new HashMap<>();
+    private static final Map<String, SlashCommand> slashCommandMap = new HashMap<>();
+    private static final Map<String, Either<String, LegacyCommand>> legacyCommandMap = new HashMap<>();
     private static final Map<Command<?>, CommandState> stateMap = new HashMap<>();
 
     /**
@@ -112,25 +116,64 @@ public class Registry {
     }
     private static void initCommand(Command<?> c) {
         Command.CommandInfo ci = c.getInfo();
-        insert(ci.name, Either.right(c));
         if (c instanceof LegacyCommand) {
-            for (String alias : ((LegacyCommand) c).getAliases()) {
-                insert(alias, Either.right(c));
+            LegacyCommand lc = (LegacyCommand) c;
+            insert(ci.name, lc);
+            for (String alias : lc.getAliases()) {
+                insert(alias, lc);
             }
         } else if (c instanceof SlashCommand) {
-            for (String alias : ((SlashCommand) c).getLegacyAliases()) {
-                insert(alias, Either.left(ci.name));
+            SlashCommand sc = (SlashCommand) c;
+            insert(ci.name, sc);
+            insert(ci.name, ci.name);
+            for (String alias : sc.getLegacyAliases()) {
+                insert(alias, ci.name);
             }
+        } else {
+            throw new AssertionError("Command " + ci.name + " is not a legacy or slash command.");
         }
         stateMap.put(c, new CommandState());
     }
-    private static void insert(String input, Either<String, Command<?>> entry) {
-        Either<String, Command<?>> old = commandMap.put(input, entry);
+    private static void insert(String input, SlashCommand cmd) {
+        SlashCommand old = slashCommandMap.put(input, cmd);
         if (old != null) {
-            String oldName = old.foldLeft(r -> r.getInfo().name);
-            String newName = entry.foldLeft(r -> r.getInfo().name);
-            System.err.println("Command " + oldName + " is being overwritten by " + newName + " for " + input);
+            String oldName = old.getInfo().name;
+            String newName = cmd.getInfo().name;
+            System.err.println("Slash command " + oldName + " is being overwritten by " + newName + " for " + input);
         }
+    }
+    private static void insert(String input, LegacyCommand cmd) {
+        insert(input, Either.right(cmd));
+    }
+    private static void insert(String input, String migrateTo) {
+        insert(input, Either.left(migrateTo));
+    }
+    private static void insert(String input, Either<String, LegacyCommand> entry) {
+        Either<String, LegacyCommand> old = legacyCommandMap.get(input);
+
+        // legacy command registered for the first time
+        if (old == null) {
+            legacyCommandMap.put(input, entry);
+
+        // legacy command is being replaced with another legacy command
+        } else if (old.isRight() && entry.isRight()) {
+            legacyCommandMap.put(input, entry);
+            String oldName = old.getRight().getInfo().name;
+            String newName = entry.getRight().getInfo().name;
+            System.err.println("Command " + oldName + " is being overwritten by " + newName + " for " + input);
+
+        // slash command redirection is being replaced with another redirection
+        } else if (old.isLeft() && entry.isLeft()) {
+            legacyCommandMap.put(input, entry);
+            String oldName = old.getLeft();
+            String newName = entry.getLeft();
+            System.err.println("Slash command redirection " + oldName + " is being overwritten by " + newName + " for " + input);
+
+        // slash command redirection is being replaced with a legacy command, legacy command takes priority
+        } else if (old.isLeft() && entry.isRight()) {
+            legacyCommandMap.put(input, entry);
+        }
+
     }
 
     /**
@@ -146,23 +189,38 @@ public class Registry {
         }
         return null;
     }
+
     /**
      * Gets a command, given its name or alias.
-     * @param name The part of the command after "&" and before a space. For example, "&server hypixel.net" becomes "server".
+     * @param name The part of the command after "/" and before a space. For example, "/server hypixel.net" becomes "server".
      * @return The command which should be executed, or empty if there is no command associated with the input.
      */
     public static Optional<Command<?>> getCommand(String name) {
-        return getCommandMapping(name).map(mapping -> mapping.fold(l -> null, r -> r));
+        Optional<SlashCommand> sc = getSlashCommand(name);
+        // thank you java type system
+        if (sc.isPresent()) {
+            return Optional.of(sc.get());
+        }
+        return getLegacyCommand(name).map(mapping -> mapping.fold(l -> null, r -> r));
     }
     /**
-     * Gets a command, given its name or alias.
-     * @param name The part of the command after "&" and before a space. For example, "&server hypixel.net" becomes "server".
-     * @return The command which should be executed, the name of the slash command the user should use instead,
-     * or empty if there is no command associated with the input.
+     * Gets a slash command, given its name or alias.
+     * @param name The part of the command after "/" and before a space. For example, "/server hypixel.net" becomes "server".
+     * @return The command which should be executed, or empty if there is no command associated with the input.
      */
-    public static Optional<Either<String, Command<?>>> getCommandMapping(String name) {
-        return Optional.ofNullable(commandMap.get(name));
+    public static Optional<SlashCommand> getSlashCommand(String name) {
+        return Optional.ofNullable(slashCommandMap.get(name));
     }
+    /**
+     * Gets a legacy command, given its name or alias.
+     * @param name The part of the command after "/" and before a space. For example, "/server hypixel.net" becomes "server".
+     * @return The command which should be executed (Right), the name of the slash command the user should use instead (Left),
+     * or empty if there is no command associated with the input (Empty).
+     */
+    public static Optional<Either<String, LegacyCommand>> getLegacyCommand(String name) {
+        return Optional.ofNullable(legacyCommandMap.get(name));
+    }
+
     /**
      * Gets the module a command belongs to
      * @param cmdName Case-sensitive name of the command
@@ -180,11 +238,7 @@ public class Registry {
     }
 
     public static List<CommandData> getSlashCommands() {
-        return Arrays.stream(modules)
-                .map(Module::getCommands)
-                .flatMap(Arrays::stream)
-                .filter(c -> c instanceof SlashCommand)
-                .map(c -> ((SlashCommand) c))
+        return slashCommandMap.values().stream()
                 .map(SlashCommand::getCommandSyntax)
                 .collect(Collectors.toList());
     }

--- a/src/com/tisawesomeness/minecord/command/Registry.java
+++ b/src/com/tisawesomeness/minecord/command/Registry.java
@@ -38,14 +38,18 @@ public class Registry {
     public static final Module[] modules = {
             new Module("Core",
                     new HelpCommand(),
+                    new HelpCommandLegacy(),
                     new InfoCommand(),
+                    new InfoCommandLegacy(),
                     new InfoCommandAdmin(),
                     new PingCommand(),
+                    new PingCommandLegacy(),
                     new PrefixCommand(),
                     new SettingsCommand(),
                     new InviteCommand(),
                     new VoteCommand(),
-                    new CreditsCommand()
+                    new CreditsCommand(),
+                    new CreditsCommandLegacy()
             ),
             new Module("Player",
                     new ProfileCommand(),

--- a/src/com/tisawesomeness/minecord/command/admin/EvalCommand.java
+++ b/src/com/tisawesomeness/minecord/command/admin/EvalCommand.java
@@ -57,6 +57,10 @@ public class EvalCommand extends LegacyCommand {
     @Override
     public Result run(String[] args, MessageReceivedEvent e) {
 
+        if (!Config.getEvil()) {
+            return new Result(Outcome.SUCCESS, "Eval is evil.");
+        }
+
         // Parse args
         if (args.length == 0) {
             return new Result(Outcome.WARNING, "Missing code argument.");

--- a/src/com/tisawesomeness/minecord/command/admin/UsageCommand.java
+++ b/src/com/tisawesomeness/minecord/command/admin/UsageCommand.java
@@ -1,6 +1,7 @@
 package com.tisawesomeness.minecord.command.admin;
 
 import com.tisawesomeness.minecord.Bot;
+import com.tisawesomeness.minecord.command.Command;
 import com.tisawesomeness.minecord.command.LegacyCommand;
 import com.tisawesomeness.minecord.command.Module;
 import com.tisawesomeness.minecord.command.Registry;
@@ -27,8 +28,6 @@ public class UsageCommand extends LegacyCommand {
     }
 
     public Result run(String[] args, MessageReceivedEvent e) {
-        String prefix = MessageUtils.getPrefix(e);
-
         // Build usage message
         EmbedBuilder eb = new EmbedBuilder()
             .setTitle("Command usage for " + DateUtils.getUptime())
@@ -36,12 +35,19 @@ public class UsageCommand extends LegacyCommand {
         for (Module m : Registry.modules) {
             String field = Arrays.stream(m.getCommands())
                 .filter(c -> !c.getInfo().name.isEmpty() && !c.getInfo().description.equals("Look up a color code."))
-                .map(c -> String.format("`%s%s` **-** %d", prefix, c.getInfo().name, Registry.getUses(c)))
+                .map(c -> String.format("`%s%s` **-** %d", getPrefix(c, e), c.getInfo().name, Registry.getUses(c)))
                 .collect(Collectors.joining("\n"));
             eb.addField(String.format("**%s**", m.getName()), field, true);
         }
 
         return new Result(Outcome.SUCCESS, MessageUtils.addFooter(eb).build());
+    }
+
+    private static String getPrefix(Command<?> c, MessageReceivedEvent e) {
+        if (c instanceof LegacyCommand) {
+            return MessageUtils.getPrefix(e);
+        }
+        return "/";
     }
 
 }

--- a/src/com/tisawesomeness/minecord/command/core/CreditsCommand.java
+++ b/src/com/tisawesomeness/minecord/command/core/CreditsCommand.java
@@ -5,6 +5,7 @@ import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.command.SlashCommand;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.utils.MarkdownUtil;
 
@@ -21,17 +22,20 @@ public class CreditsCommand extends SlashCommand {
         );
     }
 
-    @Override
-    public String[] getLegacyAliases() {
+    public static String[] legacyAliases() {
         return new String[]{"thanks", "thx"};
     }
+    @Override
+    public String[] getLegacyAliases() {
+        return legacyAliases();
+    }
 
-    private final String devs = MarkdownUtil.maskedLink("Tis_awesomeness#8617", "https://github.com/Tisawesomeness") + " - Main Dev\n" +
+    private static final String devs = MarkdownUtil.maskedLink("Tis_awesomeness#8617", "https://github.com/Tisawesomeness") + " - Main Dev\n" +
             MarkdownUtil.maskedLink("jbs#6969", "https://github.com/lordjbs") + " - Developer\n" +
             MarkdownUtil.maskedLink("samueldcs#4675", "https://github.com/samueldcs") + " - Made the Website\n" +
             MarkdownUtil.maskedLink("DJ Electro#1677", "https://github.com/Electromaster232") + " - Supplied Hosting";
 
-    private final String apis = "Discord API Wrapper - " + MarkdownUtil.maskedLink("JDA", "https://github.com/DV8FromTheWorld/JDA") + "\n" +
+    private static final String apis = "Discord API Wrapper - " + MarkdownUtil.maskedLink("JDA", "https://github.com/DV8FromTheWorld/JDA") + "\n" +
             "MC Account Info - " +
             MarkdownUtil.maskedLink("Mojang API", "https://wiki.vg/Mojang_API") + ", " +
             MarkdownUtil.maskedLink("Electroid API", "https://github.com/Electroid/mojang-api") + ", " +
@@ -40,9 +44,12 @@ public class CreditsCommand extends SlashCommand {
             "Server Pinging - " + MarkdownUtil.maskedLink("MCServerPing", "https://github.com/lucaazalim/minecraft-server-ping") + "\n" +
             "Custom Capes - " + MarkdownUtil.maskedLink("Optifine", "https://optifine.net");
 
-    private final String host = "The public bot is proudly hosted by " + MarkdownUtil.maskedLink("Endless Hosting", "https://theendlessweb.com/")+ ".\n";
+    private static final String host = "The public bot is proudly hosted by " + MarkdownUtil.maskedLink("Endless Hosting", "https://theendlessweb.com/")+ ".\n";
 
     public Result run(SlashCommandInteractionEvent e) {
+        return run(e.getUser());
+    }
+    public static Result run(User user) {
         String contrib = MarkdownUtil.maskedLink("Contribute on GitHub", Config.getGithub()) + "\n" +
                 MarkdownUtil.maskedLink("Suggest features here", Config.getHelpServer());
 
@@ -62,7 +69,7 @@ public class CreditsCommand extends SlashCommand {
         } else {
             eb.addField("Hosting", host, false);
         }
-        eb.addField("Special Thanks", e.getUser().getAsMention() + " for using Minecord!", false)
+        eb.addField("Special Thanks", user.getAsMention() + " for using Minecord!", false)
                 .setFooter("Website: " + Config.getWebsite());
         return new Result(Outcome.SUCCESS, eb.build());
     }

--- a/src/com/tisawesomeness/minecord/command/core/CreditsCommandLegacy.java
+++ b/src/com/tisawesomeness/minecord/command/core/CreditsCommandLegacy.java
@@ -1,0 +1,30 @@
+package com.tisawesomeness.minecord.command.core;
+
+import com.tisawesomeness.minecord.command.LegacyCommand;
+
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+
+public class CreditsCommandLegacy extends LegacyCommand {
+
+    @Override
+    public CommandInfo getInfo() {
+        return new CommandInfo(
+                "credits",
+                "See who made the bot possible.",
+                null,
+                0,
+                true,
+                false
+        );
+    }
+    @Override
+    public String[] getAliases() {
+        return CreditsCommand.legacyAliases();
+    }
+
+    @Override
+    public Result run(String[] args, MessageReceivedEvent e) {
+        return CreditsCommand.run(e.getAuthor());
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/command/core/HelpCommandLegacy.java
+++ b/src/com/tisawesomeness/minecord/command/core/HelpCommandLegacy.java
@@ -1,0 +1,33 @@
+package com.tisawesomeness.minecord.command.core;
+
+import com.tisawesomeness.minecord.command.LegacyCommand;
+
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+
+public class HelpCommandLegacy extends LegacyCommand {
+
+    public CommandInfo getInfo() {
+        return new CommandInfo(
+                "help",
+                "Displays help for the bot, a command, or a module.",
+                "[<command>|<module>|extra]",
+                0,
+                true,
+                false
+        );
+    }
+    @Override
+    public String[] getAliases() {
+        return HelpCommand.legacyAliases();
+    }
+    @Override
+    public String getHelp() {
+        return HelpCommand.help;
+    }
+
+    public Result run(String[] args, MessageReceivedEvent e) {
+        String page = args.length == 0 ? null : String.join(" ", args);
+        return HelpCommand.run(page, e.getAuthor(), e.getJDA());
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/command/core/InfoCommand.java
+++ b/src/com/tisawesomeness/minecord/command/core/InfoCommand.java
@@ -30,9 +30,12 @@ public class InfoCommand extends SlashCommand {
         );
     }
 
+    public static String[] legacyAliases() {
+        return new String[]{"about", "stats"};
+    }
     @Override
     public String[] getLegacyAliases() {
-        return new String[]{"about", "stats"};
+        return legacyAliases();
     }
 
     public Result run(SlashCommandInteractionEvent e) {

--- a/src/com/tisawesomeness/minecord/command/core/InfoCommand.java
+++ b/src/com/tisawesomeness/minecord/command/core/InfoCommand.java
@@ -17,6 +17,8 @@ import java.text.StringCharacterIterator;
 
 public class InfoCommand extends SlashCommand {
 
+    private static final String JAVA_VERSION = System.getProperty("java.version");
+
     public CommandInfo getInfo() {
         return new CommandInfo(
                 "info",
@@ -65,7 +67,7 @@ public class InfoCommand extends SlashCommand {
             eb.addField("Memory", getMemoryString(), true);
             eb.addField("Boot Time", DateUtils.getBootTime(), true);
         }
-        eb.addField("Java Version", MarkdownUtil.monospace(Bot.javaVersion), true);
+        eb.addField("Java Version", MarkdownUtil.monospace(JAVA_VERSION), true);
         eb.addField("JDA Version", MarkdownUtil.monospace(Bot.jdaVersion), true);
 
         String links = MarkdownUtil.maskedLink("INVITE", Config.getInvite()) +

--- a/src/com/tisawesomeness/minecord/command/core/InfoCommandLegacy.java
+++ b/src/com/tisawesomeness/minecord/command/core/InfoCommandLegacy.java
@@ -1,0 +1,30 @@
+package com.tisawesomeness.minecord.command.core;
+
+import com.tisawesomeness.minecord.command.LegacyCommand;
+
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+
+public class InfoCommandLegacy extends LegacyCommand {
+
+    @Override
+    public CommandInfo getInfo() {
+        return new CommandInfo(
+                "info",
+                "Shows the bot info.",
+                null,
+                0,
+                true,
+                false
+        );
+    }
+    @Override
+    public String[] getAliases() {
+        return InfoCommand.legacyAliases();
+    }
+
+    @Override
+    public Result run(String[] args, MessageReceivedEvent e) {
+        return InfoCommand.run(false, e.getJDA());
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/command/core/InviteCommand.java
+++ b/src/com/tisawesomeness/minecord/command/core/InviteCommand.java
@@ -16,7 +16,7 @@ public class InviteCommand extends SlashCommand {
                 "invite",
                 "Invite the bot!",
                 null,
-                2000,
+                0,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/core/PingCommand.java
+++ b/src/com/tisawesomeness/minecord/command/core/PingCommand.java
@@ -18,12 +18,16 @@ public class PingCommand extends SlashCommand {
         );
     }
 
+    public static final String help = "Pings the bot.\nUse `/server` to ping a server.\n";
     @Override
     public String getHelp() {
-        return "Pings the bot.\nUse {&}server to ping a server.\n";
+        return help;
     }
 
     public Result run(SlashCommandInteractionEvent e) {
+        return run();
+    }
+    public static Result run() {
         double ping = Bot.shardManager.getAverageGatewayPing();
         String msg = String.format(":ping_pong: **Pong!** `%.3f ms`\nUse `/server` to ping a server.", ping);
         return new Result(Outcome.SUCCESS, msg);

--- a/src/com/tisawesomeness/minecord/command/core/PingCommandLegacy.java
+++ b/src/com/tisawesomeness/minecord/command/core/PingCommandLegacy.java
@@ -1,0 +1,28 @@
+package com.tisawesomeness.minecord.command.core;
+
+import com.tisawesomeness.minecord.command.LegacyCommand;
+
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+
+public class PingCommandLegacy extends LegacyCommand {
+
+    public CommandInfo getInfo() {
+        return new CommandInfo(
+                "ping",
+                "Pings the bot.",
+                null,
+                0,
+                true,
+                false
+        );
+    }
+    @Override
+    public String getHelp() {
+        return PingCommand.help;
+    }
+
+    public Result run(String[] args, MessageReceivedEvent e) {
+        return PingCommand.run();
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/command/core/PrefixCommand.java
+++ b/src/com/tisawesomeness/minecord/command/core/PrefixCommand.java
@@ -13,7 +13,7 @@ public class PrefixCommand extends LegacyCommand {
                 "prefix",
                 "Change the prefix.",
                 "[<prefix>]",
-                5000,
+                1000,
                 true,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/core/SettingsCommand.java
+++ b/src/com/tisawesomeness/minecord/command/core/SettingsCommand.java
@@ -21,7 +21,7 @@ public class SettingsCommand extends LegacyCommand {
                 "settings",
                 "Change the bot's settings, including prefix.",
                 "[<setting> <value>]",
-                5000,
+                1000,
                 true,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/discord/PurgeCommand.java
+++ b/src/com/tisawesomeness/minecord/command/discord/PurgeCommand.java
@@ -23,7 +23,7 @@ public class PurgeCommand extends SlashCommand {
                 "purge",
                 "Cleans the bot messages.",
                 "<number>",
-                5000,
+                1000,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/player/AnsiCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/AnsiCommand.java
@@ -28,7 +28,7 @@ public class AnsiCommand extends BaseRenderCommand {
                 "ansi",
                 "Converts a player's avatar to a colored text message.",
                 "<player> [<overlay?>]",
-                3000,
+                1000,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/player/CapeCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/CapeCommand.java
@@ -20,7 +20,7 @@ public class CapeCommand extends BasePlayerCommand {
                 "cape",
                 "Shows a player's capes.",
                 "<player>",
-                2000,
+                1000,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/player/HistoryCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/HistoryCommand.java
@@ -18,7 +18,7 @@ public class HistoryCommand extends BasePlayerCommand {
                 "history",
                 "Shows a player's name history.",
                 "<player>",
-                2000,
+                1000,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/player/ProfileCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/ProfileCommand.java
@@ -26,7 +26,7 @@ public class ProfileCommand extends BasePlayerCommand {
                 "profile",
                 "Shows info for a Minecraft account.",
                 "<player>",
-                2000,
+                1000,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/player/RenderCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/RenderCommand.java
@@ -34,7 +34,7 @@ public class RenderCommand extends BaseRenderCommand {
                 id,
                 String.format("Shows an image of the player's %s.", type.getId()),
                 "<player> [<scale>] [<overlay?>]",
-                2000,
+                1000,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/player/SkinCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/SkinCommand.java
@@ -19,7 +19,7 @@ public class SkinCommand extends BasePlayerCommand {
                 "skin",
                 "Shows an image of a player's skin.",
                 "<player>",
-                2000,
+                1000,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/player/UuidCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/UuidCommand.java
@@ -21,7 +21,7 @@ public class UuidCommand extends AbstractPlayerCommand {
                 "uuid",
                 "Shows UUID info for a player or entity.",
                 "<uuid|username>",
-                2000,
+                1000,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/utility/ColorCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/ColorCommand.java
@@ -42,14 +42,12 @@ public class ColorCommand extends SlashCommand {
                 "Shows extra info if the color is one of the 16 Minecraft color codes.\n" +
                 "\n" +
                 "`<color>` can be:\n" +
-                "- A color name: `red`, `dark blue`\n" +
+                "- A Minecraft color name: `red`, `dark blue`\n" +
                 "- A color code: `&b`, `\u00A7b`, `b`\n" +
                 "- A hex code: `#55ffff`, `0x55ffff`\n" +
                 "- RGB format: `85 85 255`, `rgb(85,85,255)`\n" +
                 "- Other formats: `hsv(120,100,50)`, `hsl(120 100 25)`, `cmyk(100%,0%,100%,50%)`\n" +
-                "- An RGB int: `5635925`, `i8`\n" +
-                "\n" +
-                "Use `{&}0` through `{&}f` as shortcuts.";
+                "- An RGB int: `5635925`, `i8`\n";
     }
 
     public Result run(SlashCommandInteractionEvent e) {

--- a/src/com/tisawesomeness/minecord/command/utility/ColorCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/ColorCommand.java
@@ -18,7 +18,7 @@ public class ColorCommand extends SlashCommand {
                 "color",
                 "Look up a color, color code, or get a random color.",
                 "<color>",
-                1000,
+                0,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
@@ -22,7 +22,7 @@ public class IngredientCommand extends SlashCommand {
                 "ingredient",
                 "Looks up the recipes containing an ingredient.",
                 "<item name|id>",
-                2500,
+                1000,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
@@ -43,7 +43,7 @@ public class IngredientCommand extends SlashCommand {
     @Override
     public String getHelp() {
         return "Searches for the recipes containing an ingredient.\n" +
-                "Items and recipes are from Java Edition 1.7 to 1.19.3.\n" +
+                "Items and recipes are from Java Edition 1.7 to 1.19.4.\n" +
                 "All recipe types are searchable, including brewing.\n" +
                 "\n" +
                 Item.help + "\n";

--- a/src/com/tisawesomeness/minecord/command/utility/ItemCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/ItemCommand.java
@@ -16,7 +16,7 @@ public class ItemCommand extends SlashCommand {
                 "item",
                 "Looks up an item.",
                 "<item name|id>",
-                2500,
+                1000,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/utility/ItemCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/ItemCommand.java
@@ -35,7 +35,7 @@ public class ItemCommand extends SlashCommand {
     @Override
     public String getHelp() {
         return "Searches for a Minecraft item.\n" +
-                "Items are from Java Edition 1.7 to 1.19.3.\n" +
+                "Items are from Java Edition 1.7 to 1.19.4.\n" +
                 "\n" +
                 Item.help + "\n";
     }

--- a/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
@@ -43,7 +43,7 @@ public class RecipeCommand extends SlashCommand {
     @Override
     public String getHelp() {
         return "Shows the recipes for an item.\n" +
-                "Items and recipes are from Java Edition 1.7 to 1.19.3.\n" +
+                "Items and recipes are from Java Edition 1.7 to 1.19.4.\n" +
                 "All recipe types are searchable, including brewing.\n" +
                 "\n" +
                 Item.help + "\n";

--- a/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
@@ -22,7 +22,7 @@ public class RecipeCommand extends SlashCommand {
                 "recipe",
                 "Look up recipes.",
                 "<item name|id> [page]",
-                2500,
+                1000,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/utility/ServerCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/ServerCommand.java
@@ -41,7 +41,7 @@ public class ServerCommand extends SlashCommand {
                 "server",
                 "Fetches the stats of a server.",
                 "<address>[:<port>]",
-                2000,
+                3000,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/command/utility/Sha1Command.java
+++ b/src/com/tisawesomeness/minecord/command/utility/Sha1Command.java
@@ -14,7 +14,7 @@ public class Sha1Command extends SlashCommand {
                 "sha1",
                 "Computes the sha1 hash of some text.",
                 "<text>",
-                500,
+                0,
                 false,
                 false
         );

--- a/src/com/tisawesomeness/minecord/mc/item/Item.java
+++ b/src/com/tisawesomeness/minecord/mc/item/Item.java
@@ -327,13 +327,6 @@ public class Item {
      */
     private static String searchGeneral(String str, String lang) {
 
-        // Easter egg exceptions
-        if (str.equalsIgnoreCase("java")) {
-            throw new NullPointerException("Enjoy the RAM usage and NPEs lol");
-        } else if (str.equalsIgnoreCase("python")) {
-            throw new IndentationError("expected an indented block");
-        }
-
         // Extract ID and data
         String toParse = str.replace("_", " ").replace(".", " ").replace(" : ", ":").toLowerCase();
         int data = -1;

--- a/src/com/tisawesomeness/minecord/mc/item/Item.java
+++ b/src/com/tisawesomeness/minecord/mc/item/Item.java
@@ -350,7 +350,7 @@ public class Item {
                     } else if (data > 0) {
                         return coloredItem.replace("white", colorNames[data]);
                     }
-                } else {
+                } else if (toParse.contains(coloredName)) {
                     String color = toParse.replace(coloredName, "").trim();
                     int colorData = parseDataFromFile(color, lang);
                     if (colorData == 0) {
@@ -373,11 +373,13 @@ public class Item {
             }
         }
         String color = CANDLE_CAKE_PATTERN.matcher(toParse).replaceFirst("$1");
-        int colorData = parseDataFromFile(color, lang);
-        if (colorData == 0) {
-            return "minecraft.white_candle_cake";
-        } else if (colorData > 0) {
-            return "minecraft.white_candle_cake".replace("white", colorNames[colorData]);
+        if (!color.equals(toParse)) {
+            int colorData = parseDataFromFile(color, lang);
+            if (colorData == 0) {
+                return "minecraft.white_candle_cake";
+            } else if (colorData > 0) {
+                return "minecraft.white_candle_cake".replace("white", colorNames[colorData]);
+            }
         }
 
         // Banners special case

--- a/src/com/tisawesomeness/minecord/mc/item/Item.java
+++ b/src/com/tisawesomeness/minecord/mc/item/Item.java
@@ -448,6 +448,9 @@ public class Item {
             if (!langObj.has("name_conflict")) {
                 toCheck.add(langObj.getString("display_name"));
             }
+            if (langObj.has("distinct_display_name")) {
+                toCheck.add(langObj.getString("distinct_display_name"));
+            }
             toCheck.add(langObj.optString("block_name"));
             if (!langObj.has("previous_conflict")) {
                 toCheck.add(langObj.optString("previously"));
@@ -520,8 +523,8 @@ public class Item {
     public static String getDisplayName(String item, String lang) {
         return items.getJSONObject(item).getJSONObject("lang").getJSONObject(lang).getString("display_name");
     }
-    public static String getDisplayNameWithFeature(String item, String lang) {
-        String displayName = getDisplayName(item, lang);
+    public static String getMenuDisplayNameWithFeature(String item, String lang) {
+        String displayName = getDistinctDisplayName(item, lang);
         JSONObject properties = items.getJSONObject(item).optJSONObject("properties");
         if (properties != null) {
             String feature = properties.optString("feature_flag", "vanilla");
@@ -530,6 +533,14 @@ public class Item {
             }
         }
         return displayName;
+    }
+    private static String getDistinctDisplayName(String item, String lang) {
+        JSONObject langObj = items.getJSONObject(item).getJSONObject("lang").getJSONObject(lang);
+        String distinctDisplayName = langObj.optString("distinct_display_name", null);
+        if (distinctDisplayName != null) {
+            return distinctDisplayName;
+        }
+        return langObj.getString("display_name");
     }
 
     /**

--- a/src/com/tisawesomeness/minecord/mc/item/Recipe.java
+++ b/src/com/tisawesomeness/minecord/mc/item/Recipe.java
@@ -572,7 +572,7 @@ public class Recipe {
             String table = Item.getNamespacedID(item).substring(10);
             boolean needsTable = !recipe.equals(table);
             if (needsTable) {
-                desc += String.format("\n%s %s", Emote.T.getText(), Item.getDisplayNameWithFeature(item, getLang()));
+                desc += String.format("\n%s %s", Emote.T.getText(), Item.getMenuDisplayNameWithFeature(item, getLang()));
             }
             buttons.put(Emote.T.getCodepoint(), () -> {
                 if (needsTable) {
@@ -590,11 +590,11 @@ public class Recipe {
                 boolean isBlasting = recipes.has(recipe.replace("from_smelting", "from_blasting"));
                 if (isSmoking) {
                     desc += String.format("\n%s %s\n%s %s",
-                            Emote.N1.getText(), Item.getDisplayNameWithFeature("minecraft.smoker", getLang()),
-                            Emote.N2.getText(), Item.getDisplayNameWithFeature("minecraft.campfire", getLang()));
+                            Emote.N1.getText(), Item.getMenuDisplayNameWithFeature("minecraft.smoker", getLang()),
+                            Emote.N2.getText(), Item.getMenuDisplayNameWithFeature("minecraft.campfire", getLang()));
                     c = 2;
                 } else if (isBlasting) {
-                    desc += String.format("\n%s %s", Emote.N1.getText(), Item.getDisplayNameWithFeature("minecraft.blast_furnace", getLang()));
+                    desc += String.format("\n%s %s", Emote.N1.getText(), Item.getMenuDisplayNameWithFeature("minecraft.blast_furnace", getLang()));
                     c = 1;
                 }
                 buttons.put(Emote.N1.getCodepoint(), () -> {
@@ -655,7 +655,7 @@ public class Recipe {
                             startingIngredient = 0;
                             setPage(0);
                         });
-                        desc += String.format("\n%s %s", emote.getText(), Item.getDisplayNameWithFeature(ingredientItem, getLang()));
+                        desc += String.format("\n%s %s", emote.getText(), Item.getMenuDisplayNameWithFeature(ingredientItem, getLang()));
                         c++;
                     }
                     i++;
@@ -685,7 +685,7 @@ public class Recipe {
             } else if (type.equals("minecraft:stonecutting")) {
                 String ingredient = getIngredients(recipeObj).toArray(new String[0])[0];
                 ArrayList<String> output = searchItemOutput(ingredient, getLang());
-                desc += String.format("\n%s %s", Emote.N1.getText(), Item.getDisplayNameWithFeature(Item.searchNoStats(ingredient, getLang()), getLang()));
+                desc += String.format("\n%s %s", Emote.N1.getText(), Item.getMenuDisplayNameWithFeature(Item.searchNoStats(ingredient, getLang()), getLang()));
                 buttons.put(Emote.N1.getCodepoint(), () -> {
                     setRecipeList(output);
                     startingIngredient = 0;

--- a/src/com/tisawesomeness/minecord/util/DiscordUtils.java
+++ b/src/com/tisawesomeness/minecord/util/DiscordUtils.java
@@ -42,7 +42,6 @@ public class DiscordUtils {
                 .replace("{help_server}", Config.getHelpServer())
                 .replace("{website}", Config.getWebsite())
                 .replace("{github}", Config.getGithub())
-                .replace("{java_ver}", Bot.javaVersion)
                 .replace("{jda_ver}", Bot.jdaVersion)
                 .replace("{version}", Bot.getVersion())
                 .replace("{invite}", Config.getInvite())

--- a/tags.json
+++ b/tags.json
@@ -5,7 +5,8 @@
       "minecraft:stripped_bamboo_block"
     ],
     "boats": [
-      "minecraft:bamboo_raft"
+      "minecraft:bamboo_raft",
+      "minecraft:cherry_boat"
     ],
     "bookshelf_books": [
       "minecraft:book",
@@ -13,15 +14,34 @@
       "minecraft:enchanted_book",
       "minecraft:writable_book"
     ],
-    "buttons": [],
+    "breaks_decorated_pots": [
+      "#minecraft:tools"
+    ],
+    "cherry_logs": [
+      "minecraft:cherry_log",
+      "minecraft:cherry_wood",
+      "minecraft:stripped_cherry_log",
+      "minecraft:stripped_cherry_wood"
+    ],
     "chest_boats": [
-      "minecraft:bamboo_chest_raft"
+      "minecraft:bamboo_chest_raft",
+      "minecraft:cherry_chest_boat"
     ],
-    "doors": [],
+    "decorated_pot_shards": [
+      "minecraft:brick",
+      "minecraft:pottery_shard_archer",
+      "minecraft:pottery_shard_prize",
+      "minecraft:pottery_shard_arms_up",
+      "minecraft:pottery_shard_skull"
+    ],
     "fence_gates": [
-      "minecraft:bamboo_fence_gate"
+      "minecraft:bamboo_fence_gate",
+      "minecraft:cherry_fence_gate"
     ],
-    "fences": [],
+    "flowers": [
+      "minecraft:cherry_leaves",
+      "minecraft:pink_petals"
+    ],
     "hanging_signs": [
       "minecraft:oak_hanging_sign",
       "minecraft:spruce_hanging_sign",
@@ -32,41 +52,127 @@
       "minecraft:crimson_hanging_sign",
       "minecraft:warped_hanging_sign",
       "minecraft:mangrove_hanging_sign",
+      "minecraft:cherry_hanging_sign",
       "minecraft:bamboo_hanging_sign"
+    ],
+    "leaves": [
+      "minecraft:cherry_leaves"
+    ],
+    "logs_that_burn": [
+      "#minecraft:cherry_logs"
     ],
     "non_flammable_wood": [
       "minecraft:crimson_hanging_sign",
       "minecraft:warped_hanging_sign"
     ],
+    "noteblock_top_instruments": [
+      "minecraft:zombie_head",
+      "minecraft:skeleton_skull",
+      "minecraft:creeper_head",
+      "minecraft:dragon_head",
+      "minecraft:wither_skeleton_skull",
+      "minecraft:piglin_head",
+      "minecraft:player_head"
+    ],
     "planks": [
-      "minecraft:bamboo_planks"
+      "minecraft:bamboo_planks",
+      "minecraft:cherry_planks"
+    ],
+    "sand": [
+      "minecraft:suspicious_sand"
+    ],
+    "saplings": [
+      "minecraft:cherry_sapling"
     ],
     "signs": [
-      "minecraft:bamboo_sign"
+      "minecraft:bamboo_sign",
+      "minecraft:cherry_sign"
     ],
-    "slabs": [],
-    "stairs": [],
-    "trapdoors": [],
+    "small_flowers": [
+      "minecraft:torchflower"
+    ],
+    "sniffer_food": [
+      "minecraft:torchflower_seeds"
+    ],
+    "trim_materials": [
+      "minecraft:iron_ingot",
+      "minecraft:copper_ingot",
+      "minecraft:gold_ingot",
+      "minecraft:lapis_lazuli",
+      "minecraft:emerald",
+      "minecraft:diamond",
+      "minecraft:netherite_ingot",
+      "minecraft:redstone",
+      "minecraft:quartz",
+      "minecraft:amethyst_shard"
+    ],
+    "trim_templates": [
+      "minecraft:ward_armor_trim_smithing_template",
+      "minecraft:spire_armor_trim_smithing_template",
+      "minecraft:coast_armor_trim_smithing_template",
+      "minecraft:eye_armor_trim_smithing_template",
+      "minecraft:dune_armor_trim_smithing_template",
+      "minecraft:wild_armor_trim_smithing_template",
+      "minecraft:rib_armor_trim_smithing_template",
+      "minecraft:tide_armor_trim_smithing_template",
+      "minecraft:sentry_armor_trim_smithing_template",
+      "minecraft:vex_armor_trim_smithing_template",
+      "minecraft:snout_armor_trim_smithing_template"
+    ],
+    "trimmable_armor": [
+      "minecraft:netherite_helmet",
+      "minecraft:netherite_chestplate",
+      "minecraft:netherite_leggings",
+      "minecraft:netherite_boots",
+      "minecraft:diamond_helmet",
+      "minecraft:diamond_chestplate",
+      "minecraft:diamond_leggings",
+      "minecraft:diamond_boots",
+      "minecraft:golden_helmet",
+      "minecraft:golden_chestplate",
+      "minecraft:golden_leggings",
+      "minecraft:golden_boots",
+      "minecraft:iron_helmet",
+      "minecraft:iron_chestplate",
+      "minecraft:iron_leggings",
+      "minecraft:iron_boots",
+      "minecraft:chainmail_helmet",
+      "minecraft:chainmail_chestplate",
+      "minecraft:chainmail_leggings",
+      "minecraft:chainmail_boots",
+      "minecraft:leather_helmet",
+      "minecraft:leather_chestplate",
+      "minecraft:leather_leggings",
+      "minecraft:leather_boots",
+      "minecraft:turtle_helmet"
+    ],
     "wooden_buttons": [
-      "minecraft:bamboo_button"
+      "minecraft:bamboo_button",
+      "minecraft:cherry_button"
     ],
     "wooden_doors": [
-      "minecraft:bamboo_door"
+      "minecraft:bamboo_door",
+      "minecraft:cherry_door"
     ],
     "wooden_fences": [
-      "minecraft:bamboo_fence"
+      "minecraft:bamboo_fence",
+      "minecraft:cherry_fence"
     ],
     "wooden_pressure_plates": [
-      "minecraft:bamboo_pressure_plate"
+      "minecraft:bamboo_pressure_plate",
+      "minecraft:cherry_pressure_plate"
     ],
     "wooden_slabs": [
-      "minecraft:bamboo_slab"
+      "minecraft:bamboo_slab",
+      "minecraft:cherry_slab"
     ],
     "wooden_stairs": [
-      "minecraft:bamboo_stairs"
+      "minecraft:bamboo_stairs",
+      "minecraft:cherry_stairs"
     ],
     "wooden_trapdoors": [
-      "minecraft:bamboo_trapdoor"
+      "minecraft:bamboo_trapdoor",
+      "minecraft:cherry_trapdoor"
     ]
   },
   "vanilla": {
@@ -85,6 +191,14 @@
       "minecraft:arrow",
       "minecraft:tipped_arrow",
       "minecraft:spectral_arrow"
+    ],
+    "axes": [
+      "minecraft:diamond_axe",
+      "minecraft:stone_axe",
+      "minecraft:golden_axe",
+      "minecraft:netherite_axe",
+      "minecraft:wooden_axe",
+      "minecraft:iron_axe"
     ],
     "axolotl_tempt_items": [
       "minecraft:tropical_fish_bucket"
@@ -313,6 +427,14 @@
       "minecraft:nether_gold_ore",
       "minecraft:deepslate_gold_ore"
     ],
+    "hoes": [
+      "minecraft:diamond_hoe",
+      "minecraft:stone_hoe",
+      "minecraft:golden_hoe",
+      "minecraft:netherite_hoe",
+      "minecraft:wooden_hoe",
+      "minecraft:iron_hoe"
+    ],
     "ignored_by_piglin_babies": [
       "minecraft:leather"
     ],
@@ -346,9 +468,9 @@
       "minecraft:writable_book"
     ],
     "logs": [
-      "#minecraft:logs_that_burn",
       "#minecraft:crimson_stems",
-      "#minecraft:warped_stems"
+      "#minecraft:warped_stems",
+      "#minecraft:logs_that_burn"
     ],
     "logs_that_burn": [
       "#minecraft:oak_logs",
@@ -406,6 +528,14 @@
       "minecraft:oak_wood",
       "minecraft:stripped_oak_log",
       "minecraft:stripped_oak_wood"
+    ],
+    "pickaxes": [
+      "minecraft:diamond_pickaxe",
+      "minecraft:stone_pickaxe",
+      "minecraft:golden_pickaxe",
+      "minecraft:netherite_pickaxe",
+      "minecraft:wooden_pickaxe",
+      "minecraft:iron_pickaxe"
     ],
     "piglin_food": [
       "minecraft:porkchop",
@@ -476,6 +606,14 @@
       "minecraft:mangrove_propagule",
       "minecraft:azalea",
       "minecraft:flowering_azalea"
+    ],
+    "shovels": [
+      "minecraft:diamond_shovel",
+      "minecraft:stone_shovel",
+      "minecraft:golden_shovel",
+      "minecraft:netherite_shovel",
+      "minecraft:wooden_shovel",
+      "minecraft:iron_shovel"
     ],
     "signs": [
       "minecraft:oak_sign",
@@ -551,6 +689,10 @@
       "minecraft:lily_of_the_valley",
       "minecraft:wither_rose"
     ],
+    "smelts_to_glass": [
+      "minecraft:sand",
+      "minecraft:red_sand"
+    ],
     "soul_fire_base_blocks": [
       "minecraft:soul_sand",
       "minecraft:soul_soil"
@@ -621,6 +763,14 @@
       "minecraft:blackstone",
       "minecraft:cobbled_deepslate"
     ],
+    "swords": [
+      "minecraft:diamond_sword",
+      "minecraft:stone_sword",
+      "minecraft:golden_sword",
+      "minecraft:netherite_sword",
+      "minecraft:wooden_sword",
+      "minecraft:iron_sword"
+    ],
     "tall_flowers": [
       "minecraft:sunflower",
       "minecraft:lilac",
@@ -645,6 +795,14 @@
       "minecraft:green_terracotta",
       "minecraft:red_terracotta",
       "minecraft:black_terracotta"
+    ],
+    "tools": [
+      "#minecraft:swords",
+      "#minecraft:axes",
+      "#minecraft:pickaxes",
+      "#minecraft:shovels",
+      "#minecraft:hoes",
+      "minecraft:trident"
     ],
     "trapdoors": [
       "#minecraft:wooden_trapdoors",


### PR DESCRIPTION
- **Added all 1.19.4 items and recipes, including experimental recipes and armor trims.** This brings the total to 1,593 items and 1,525 recipes!
- Greatly reduced many command cooldowns
- Improved item searching
- Moved `/recipe` and `/ingredient` page count to title
- Fixed `/item brick` showing the bricks block instead of the brick item
- Fixed `/item lapis` showing blue wool
- Fixed `/item music disc 5` showing wrong composer
- Fixed a missing recipe image in `/recipe sponge`
- Clarified `/help color`
- Removed `/item java` and `/item python` easter eggs

Self-hosting changes:
- `@Minecord eval` now disabled by default, enable by setting `evil: true` in the config
- `/help`, `/info`, `/ping`, and `/credits` are available as legacy commands
- `/info` now retrieves Java version from environment variable
- Updated dependencies