### PR TITLE
Version 0.17.0

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,7 +24,7 @@
         "useMenus": true,
         "showMemory": false,
         "elevatedSkipCooldown": true,
-        "useElectroidAPI": true,
+        "useElectroidAPI": false,
         "useGappleAPI": true,
         "recordCacheStats": false,
         "itemImageHost": "https://minecord.github.io/item/",

--- a/items.json
+++ b/items.json
@@ -13190,7 +13190,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Sus Stew"
+          "Sus Stew",
+          "Sussy Stew"
         ],
         "display_name": "Suspicious Stew"
       }
@@ -19482,7 +19483,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Sus Sand"
+          "Sus Sand",
+          "Sussy Sand"
         ],
         "display_name": "Suspicious Sand"
       }
@@ -20303,7 +20305,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Sus Gravel"
+          "Sus Gravel",
+          "Sussy Gravel"
         ],
         "display_name": "Suspicious Gravel"
       }

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.16.10</version>
+  <version>0.16.11</version>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.16.12</version>
+  <version>0.17.0</version>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.16.11</version>
+  <version>0.16.12</version>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>5.0.0-beta.12</version>
+      <version>5.0.0-beta.13</version>
       <exclusions>
         <exclusion>
           <groupId>club.minnced</groupId>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>club.minnced</groupId>
       <artifactId>discord-webhooks</artifactId>
-      <version>0.8.2</version>
+      <version>0.8.4</version>
     </dependency>
     <dependency>
       <groupId>com.mysql</groupId>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.42.0.0</version>
+      <version>3.43.0.0</version>
     </dependency>
     <dependency>
       <groupId>dnsjava</groupId>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.28</version>
+      <version>1.18.30</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>dev.failsafe</groupId>
       <artifactId>failsafe</artifactId>
-      <version>3.3.1</version>
+      <version>3.3.2</version>
     </dependency>
     <!-- Part of the ColorMine Java library is included, licensed under the MIT license
     https://github.com/colormine/colormine -->

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>5.0.0-beta.10</version>
+      <version>5.0.0-beta.12</version>
       <exclusions>
         <exclusion>
           <groupId>club.minnced</groupId>
@@ -33,15 +33,16 @@
       <artifactId>java-sdk</artifactId>
       <version>2.1.2</version>
     </dependency>
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20230227</version>
-    </dependency>
+    <!-- Used in top-gg -->
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20230618</version>
     </dependency>
     <dependency>
       <groupId>club.minnced</groupId>
@@ -51,7 +52,7 @@
     <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
-      <version>8.0.33</version>
+      <version>8.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>

--- a/src/br/com/azalim/mcserverping/MCPing.java
+++ b/src/br/com/azalim/mcserverping/MCPing.java
@@ -159,7 +159,7 @@ public class MCPing {
 
         }
 
-        JsonObject jsonObject = new JsonParser().parse(json).getAsJsonObject();
+        JsonObject jsonObject = JsonParser.parseString(json).getAsJsonObject();
         // Modification from tis
         // Fix for NPE when description field is missing
         if (!jsonObject.has("description")) {

--- a/src/br/com/azalim/mcserverping/MCPingResponse.java
+++ b/src/br/com/azalim/mcserverping/MCPingResponse.java
@@ -62,10 +62,23 @@ public class MCPingResponse {
      */
     private String favicon;
 
-    // modification from tis
+    // below 3 are modifications from tis
     /**
-     * whether the server is announcing that it prevents chat reports
-     * shows an icon in the NoChatReports mod
+     * Whether the server is announcing that it requires players to send public keys to join.
+     * These servers enforce chat reports.
+     */
+    private boolean enforcesSecureChat;
+
+    /**
+     * Whether the server is announcing that it enables chat previews. Chat messages are sent to the server while
+     * typing so the server can send a formatted preview.
+     * Chat preview was added in 1.19 and removed in 1.19.3 due to privacy concerns.
+     */
+    private boolean previewsChat;
+
+    /**
+     * Whether the server is announcing that it prevents chat reports.
+     * This is a custom response used to show an icon in the NoChatReports mod.
      */
     private boolean preventsChatReports;
 

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -45,7 +45,7 @@ public class Bot {
     public static final String github = "https://github.com/Tisawesomeness/Minecord";
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
-    private static final String version = "0.16.11";
+    private static final String version = "0.16.12";
     public static final String jdaVersion = "5.0.0-beta.12";
     public static final String mcVersion = "1.20";
     public static final Color color = Color.GREEN;

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -45,7 +45,7 @@ public class Bot {
     public static final String github = "https://github.com/Tisawesomeness/Minecord";
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
-    private static final String version = "0.16.10";
+    private static final String version = "0.16.11";
     public static final String jdaVersion = "5.0.0-beta.10";
     public static final String mcVersion = "1.20";
     public static final Color color = Color.GREEN;

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -44,7 +44,7 @@ public class Bot {
     public static final String github = "https://github.com/Tisawesomeness/Minecord";
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
-    private static final String version = "0.16.12";
+    private static final String version = "0.17.0";
     public static final String jdaVersion = "5.0.0-beta.13";
     public static final String mcVersion = "1.20";
     public static final Color color = Color.GREEN;

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -13,7 +13,6 @@ import com.tisawesomeness.minecord.network.OkAPIClient;
 import com.tisawesomeness.minecord.util.*;
 import com.tisawesomeness.minecord.util.type.DelayedCountDownLatch;
 import com.tisawesomeness.minecord.util.type.Switch;
-
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Message;
@@ -25,7 +24,7 @@ import net.dv8tion.jda.api.sharding.ShardManager;
 import net.dv8tion.jda.api.utils.messages.MessageRequest;
 import org.discordbots.api.client.DiscordBotListAPI;
 
-import java.awt.Color;
+import java.awt.*;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.sql.SQLException;
@@ -46,7 +45,7 @@ public class Bot {
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
     private static final String version = "0.16.12";
-    public static final String jdaVersion = "5.0.0-beta.12";
+    public static final String jdaVersion = "5.0.0-beta.13";
     public static final String mcVersion = "1.20";
     public static final Color color = Color.GREEN;
 

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -46,7 +46,7 @@ public class Bot {
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
     private static final String version = "0.16.11";
-    public static final String jdaVersion = "5.0.0-beta.10";
+    public static final String jdaVersion = "5.0.0-beta.12";
     public static final String mcVersion = "1.20";
     public static final Color color = Color.GREEN;
 

--- a/src/com/tisawesomeness/minecord/Main.java
+++ b/src/com/tisawesomeness/minecord/Main.java
@@ -4,6 +4,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.sharding.ShardManager;
 
+@SuppressWarnings("unused")
 public class Main {
 
     protected static ClassLoader cl;

--- a/src/com/tisawesomeness/minecord/ReactMenu.java
+++ b/src/com/tisawesomeness/minecord/ReactMenu.java
@@ -2,7 +2,6 @@ package com.tisawesomeness.minecord;
 
 import com.tisawesomeness.minecord.database.Database;
 import com.tisawesomeness.minecord.util.MessageUtils;
-
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
@@ -167,7 +166,7 @@ public abstract class ReactMenu {
 
     /**
      * Checks if the bot is able to make a react menu in the specified channel
-     * @return True if the guild has menus enabled and the bot has manage message and add reaction permissions
+     * @return Whether menus are valid, disabled, or the bot has no permission
      */
     public static MenuStatus getMenuStatus(SlashCommandInteractionEvent e) {
         if (!Config.getUseMenus()) {
@@ -180,7 +179,7 @@ public abstract class ReactMenu {
         if (!Database.getUseMenu(g.getIdLong())) {
             return MenuStatus.DISABLED;
         }
-        if (!g.getSelfMember().hasPermission(e.getGuildChannel(), Permission.MESSAGE_ADD_REACTION)) {
+        if (!g.getSelfMember().hasPermission(e.getGuildChannel(), Permission.MESSAGE_ADD_REACTION) || !g.getSelfMember().hasPermission(e.getGuildChannel(), Permission.MESSAGE_HISTORY)) {
             return MenuStatus.NO_PERMISSION;
         }
         return MenuStatus.VALID;
@@ -304,7 +303,7 @@ public abstract class ReactMenu {
     public enum MenuStatus {
         VALID(),
         DISABLED(),
-        NO_PERMISSION("Give the bot manage messages permissions to use an interactive menu!");
+        NO_PERMISSION("Give the bot add reactions and message history permissions to use an interactive menu!");
 
         private final String reason;
         private boolean useSpacer;

--- a/src/com/tisawesomeness/minecord/command/Registry.java
+++ b/src/com/tisawesomeness/minecord/command/Registry.java
@@ -29,9 +29,9 @@ public class Registry {
 
     private static final String adminHelp = "**These commands require elevation to use.**\n\n" +
             "`{&}infoadmin` - Displays bot info, including used memory and boot time.\n" +
-            "`{&}settings <guild id> admin [setting] [value]` - Change the bot's settings for another guild.\n" +
+            "`{&}settingsadmin <guild id> [<setting> <value>]` - Change the bot's settings for another guild.\n" +
             "`{&}permsadmin <channel id>` - Test the bot's permissions in any channel.\n" +
-            "`{&}useradmin <user id> [mutual]` - Show info, ban status, and elevation for a user outside of the current guild. Include \"mutual\" to show mutual guilds.\n" +
+            "`{&}useradmin <user id> [mutual?]` - Show info, ban status, and elevation for a user outside of the current guild. Include \"mutual\" to show mutual guilds.\n" +
             "`{&}guildadmin <guild id>` - Show info and ban status for another guild.\n" +
             "`{&}roleadmin <role id>` - Shows the info of any role.\n";
 
@@ -46,6 +46,7 @@ public class Registry {
                     new PingCommandLegacy(),
                     new PrefixCommand(),
                     new SettingsCommand(),
+                    new SettingsCommandAdmin(),
                     new InviteCommand(),
                     new VoteCommand(),
                     new CreditsCommand(),
@@ -76,6 +77,7 @@ public class Registry {
             ),
             new Module("Discord",
                     new UserCommand(),
+                    new UserCommandAdmin(),
                     new GuildCommand(),
                     new GuildCommandAdmin(),
                     new RoleCommand(),

--- a/src/com/tisawesomeness/minecord/command/Registry.java
+++ b/src/com/tisawesomeness/minecord/command/Registry.java
@@ -69,6 +69,7 @@ public class Registry {
                        new RecipeCommand(),
                        new IngredientCommand(),
                        new StackCommand(),
+                       new CoordsCommand(),
                        new CodesCommand(),
                        new ColorCommand(),
                        new SeedCommand(),

--- a/src/com/tisawesomeness/minecord/command/Registry.java
+++ b/src/com/tisawesomeness/minecord/command/Registry.java
@@ -68,6 +68,7 @@ public class Registry {
                        new ItemCommand(),
                        new RecipeCommand(),
                        new IngredientCommand(),
+                       new StackCommand(),
                        new CodesCommand(),
                        new ColorCommand(),
                        new SeedCommand(),

--- a/src/com/tisawesomeness/minecord/command/Registry.java
+++ b/src/com/tisawesomeness/minecord/command/Registry.java
@@ -1,5 +1,8 @@
 package com.tisawesomeness.minecord.command;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.command.admin.*;
 import com.tisawesomeness.minecord.command.core.*;
@@ -8,10 +11,6 @@ import com.tisawesomeness.minecord.command.player.*;
 import com.tisawesomeness.minecord.command.utility.*;
 import com.tisawesomeness.minecord.mc.player.RenderType;
 import com.tisawesomeness.minecord.util.type.Either;
-
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 
@@ -37,71 +36,72 @@ public class Registry {
 
     public static final Module[] modules = {
             new Module("Core",
-                    new HelpCommand(),
-                    new HelpCommandLegacy(),
-                    new InfoCommand(),
-                    new InfoCommandLegacy(),
-                    new InfoCommandAdmin(),
-                    new PingCommand(),
-                    new PingCommandLegacy(),
-                    new PrefixCommand(),
-                    new SettingsCommand(),
-                    new SettingsCommandAdmin(),
-                    new InviteCommand(),
-                    new VoteCommand(),
-                    new CreditsCommand(),
-                    new CreditsCommandLegacy()
+                       new HelpCommand(),
+                       new HelpCommandLegacy(),
+                       new InfoCommand(),
+                       new InfoCommandLegacy(),
+                       new InfoCommandAdmin(),
+                       new PingCommand(),
+                       new PingCommandLegacy(),
+                       new PrefixCommand(),
+                       new SettingsCommand(),
+                       new SettingsCommandAdmin(),
+                       new InviteCommand(),
+                       new VoteCommand(),
+                       new CreditsCommand(),
+                       new CreditsCommandLegacy()
             ),
             new Module("Player",
-                    new ProfileCommand(),
-                    new HistoryCommand(),
-                    new UuidCommand(),
-                    new SkinCommand(),
-                    new CapeCommand(),
-                    new RenderCommand(RenderType.AVATAR),
-                    new RenderCommand(RenderType.HEAD),
-                    new RenderCommand(RenderType.BODY),
-                    new AnsiCommand()
+                       new ProfileCommand(),
+                       new HistoryCommand(),
+                       new UuidCommand(),
+                       new SkinCommand(),
+                       new CapeCommand(),
+                       new RenderCommand(RenderType.AVATAR),
+                       new RenderCommand(RenderType.HEAD),
+                       new RenderCommand(RenderType.BODY),
+                       new AnsiCommand()
             ),
             new Module("Utility",
-                    new StatusCommand(),
-                    new ServerCommand(),
-                    new ItemCommand(),
-                    new RecipeCommand(),
-                    new IngredientCommand(),
-                    new CodesCommand(),
-                    new ColorCommand(),
-                    new SeedCommand(),
-                    new ShadowCommand(),
-                    new Sha1Command()
+                       new StatusCommand(),
+                       new ServerCommand(),
+                       new ItemCommand(),
+                       new RecipeCommand(),
+                       new IngredientCommand(),
+                       new CodesCommand(),
+                       new ColorCommand(),
+                       new SeedCommand(),
+                       new ShadowCommand(),
+                       new Sha1Command(),
+                       new RandomCommand()
             ),
             new Module("Discord",
-                    new UserCommand(),
-                    new UserCommandAdmin(),
-                    new GuildCommand(),
-                    new GuildCommandAdmin(),
-                    new RoleCommand(),
-                    new RoleCommandAdmin(),
-                    new RolesCommand(),
-                    new IdCommand(),
-                    new PurgeCommand(),
-                    new PermsCommand(),
-                    new PermsCommandAdmin()
+                       new UserCommand(),
+                       new UserCommandAdmin(),
+                       new GuildCommand(),
+                       new GuildCommandAdmin(),
+                       new RoleCommand(),
+                       new RoleCommandAdmin(),
+                       new RolesCommand(),
+                       new IdCommand(),
+                       new PurgeCommand(),
+                       new PermsCommand(),
+                       new PermsCommandAdmin()
             ),
             new Module("Admin", true, adminHelp,
-                    new SayCommand(),
-                    new MsgCommand(),
-                    new NameCommand(),
-                    new UsageCommand(),
-                    new DebugCommand(),
-                    new PromoteCommand(),
-                    new DemoteCommand(),
-                    new BanCommand(),
-                    new ReloadCommand(),
-                    new ShutdownCommand(),
-                    new DeployCommand(),
-                    new EvalCommand(),
-                    new TestCommand()
+                       new SayCommand(),
+                       new MsgCommand(),
+                       new NameCommand(),
+                       new UsageCommand(),
+                       new DebugCommand(),
+                       new PromoteCommand(),
+                       new DemoteCommand(),
+                       new BanCommand(),
+                       new ReloadCommand(),
+                       new ShutdownCommand(),
+                       new DeployCommand(),
+                       new EvalCommand(),
+                       new TestCommand()
             )
     };
     // Map from name or alias user enters to either command or name of slash command to migrate to
@@ -161,21 +161,21 @@ public class Registry {
         if (old == null) {
             legacyCommandMap.put(input, entry);
 
-        // legacy command is being replaced with another legacy command
+            // legacy command is being replaced with another legacy command
         } else if (old.isRight() && entry.isRight()) {
             legacyCommandMap.put(input, entry);
             String oldName = old.getRight().getInfo().name;
             String newName = entry.getRight().getInfo().name;
             System.err.println("Command " + oldName + " is being overwritten by " + newName + " for " + input);
 
-        // slash command redirection is being replaced with another redirection
+            // slash command redirection is being replaced with another redirection
         } else if (old.isLeft() && entry.isLeft()) {
             legacyCommandMap.put(input, entry);
             String oldName = old.getLeft();
             String newName = entry.getLeft();
             System.err.println("Slash command redirection " + oldName + " is being overwritten by " + newName + " for " + input);
 
-        // slash command redirection is being replaced with a legacy command, legacy command takes priority
+            // slash command redirection is being replaced with a legacy command, legacy command takes priority
         } else if (old.isLeft() && entry.isRight()) {
             legacyCommandMap.put(input, entry);
         }
@@ -255,7 +255,7 @@ public class Registry {
 
         public CommandState() {
             Caffeine<Object, Object> builder = Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofMinutes(1));
+                    .expireAfterWrite(Duration.ofMinutes(1));
             if (Config.getRecordCacheStats()) {
                 builder.recordStats();
             }

--- a/src/com/tisawesomeness/minecord/command/core/CreditsCommand.java
+++ b/src/com/tisawesomeness/minecord/command/core/CreditsCommand.java
@@ -3,7 +3,6 @@ package com.tisawesomeness.minecord.command.core;
 import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.command.SlashCommand;
-
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -30,10 +29,10 @@ public class CreditsCommand extends SlashCommand {
         return legacyAliases();
     }
 
-    private static final String devs = MarkdownUtil.maskedLink("Tis_awesomeness#8617", "https://github.com/Tisawesomeness") + " - Main Dev\n" +
-            MarkdownUtil.maskedLink("jbs#6969", "https://github.com/lordjbs") + " - Developer\n" +
-            MarkdownUtil.maskedLink("samueldcs#4675", "https://github.com/samueldcs") + " - Made the Website\n" +
-            MarkdownUtil.maskedLink("DJ Electro#1677", "https://github.com/Electromaster232") + " - Supplied Hosting";
+    private static final String devs = MarkdownUtil.maskedLink("tis_awesomeness", "https://github.com/Tisawesomeness") + " - Main Dev\n" +
+            MarkdownUtil.maskedLink("jbs", "https://github.com/lordjbs") + " - Developer\n" +
+            MarkdownUtil.maskedLink("samueldcs", "https://github.com/samueldcs") + " - Made the Website\n" +
+            MarkdownUtil.maskedLink("DJ Electro", "https://github.com/Electromaster232") + " - Supplied Hosting";
 
     private static final String apis = "Discord API Wrapper - " + MarkdownUtil.maskedLink("JDA", "https://github.com/DV8FromTheWorld/JDA") + "\n" +
             "MC Account Info - " +

--- a/src/com/tisawesomeness/minecord/command/core/SettingsCommandAdmin.java
+++ b/src/com/tisawesomeness/minecord/command/core/SettingsCommandAdmin.java
@@ -1,0 +1,53 @@
+package com.tisawesomeness.minecord.command.core;
+
+import com.tisawesomeness.minecord.Bot;
+import com.tisawesomeness.minecord.command.LegacyCommand;
+import com.tisawesomeness.minecord.database.Database;
+import com.tisawesomeness.minecord.util.DiscordUtils;
+import com.tisawesomeness.minecord.util.MessageUtils;
+
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+
+import java.util.Arrays;
+
+public class SettingsCommandAdmin extends LegacyCommand {
+
+    @Override
+    public CommandInfo getInfo() {
+        return new CommandInfo(
+                "settingsadmin",
+                "Change the bot's settings for another guild.",
+                "<guild id> [<setting> <value>]",
+                0,
+                true,
+                true
+        );
+    }
+
+    @Override
+    public String getHelp() {
+        return "`{&}settings <guild id>` - View settings for another guild.\n" +
+                "`{&}settings <guild id> <setting> <value>` - Changes settings in another guild.\n" +
+                "\n" +
+                "Examples:\n" +
+                "- `{&}settings 347765748577468416`\n" +
+                "- `{&}settings 347765748577468416 prefix mc!`\n";
+    }
+
+    @Override
+    public Result run(String[] args, MessageReceivedEvent e) throws Exception {
+        // If the author used the admin keyword and is an elevated user
+        String sourcePrefix = MessageUtils.getPrefix(e);
+        if (!DiscordUtils.isDiscordId(args[0])) {
+            return new Result(Outcome.WARNING, ":warning: Not a valid ID!");
+        }
+        if (Bot.shardManager.getGuildById(args[0]) == null) {
+            return new Result(Outcome.WARNING, ":warning: Minecord does not know that guild ID!");
+        }
+        long gid = Long.parseLong(args[0]);
+        args = Arrays.copyOfRange(args, 1, args.length);
+        String targetPrefix = Database.getPrefix(gid);
+        return SettingsCommand.run(args, e, sourcePrefix, targetPrefix, gid, true);
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/command/discord/PermsCommand.java
+++ b/src/com/tisawesomeness/minecord/command/discord/PermsCommand.java
@@ -2,7 +2,6 @@ package com.tisawesomeness.minecord.command.discord;
 
 import com.tisawesomeness.minecord.command.SlashCommand;
 import com.tisawesomeness.minecord.util.DiscordUtils;
-
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -75,7 +74,7 @@ public class PermsCommand extends SlashCommand {
                 "\nAttach files: " + DiscordUtils.getBoolEmote(perms.contains(Permission.MESSAGE_ATTACH_FILES)) +
                 "\nAdd reactions: " + DiscordUtils.getBoolEmote(perms.contains(Permission.MESSAGE_ADD_REACTION)) +
                 "\nManage messages: " + DiscordUtils.getBoolEmote(perms.contains(Permission.MESSAGE_MANAGE)) +
-                "\nCan upload favicons: " + getFaviconEmote(perms) +
+                "\nCan upload server icons: " + getFaviconEmote(perms) +
                 "\nCan use reaction menus: " + getMenuEmote(perms);
 
         return new Result(Outcome.SUCCESS, m);
@@ -89,13 +88,13 @@ public class PermsCommand extends SlashCommand {
     }
 
     private static String getMenuEmote(EnumSet<Permission> perms) {
-        if (perms.contains(Permission.MESSAGE_EMBED_LINKS) && perms.contains(Permission.MESSAGE_ADD_REACTION)) {
+        if (perms.containsAll(EnumSet.of(Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_ADD_REACTION, Permission.MESSAGE_HISTORY))) {
             if (perms.contains(Permission.MESSAGE_MANAGE)) {
                 return ":white_check_mark:";
             }
             return ":warning: Partial, users must remove reactions manually, give manage messages permissions to fix";
         }
-        return ":x: Give embed links and add reactions permissions to fix";
+        return ":x: Give embed links, add reactions, and message history permissions to fix";
     }
 
 }

--- a/src/com/tisawesomeness/minecord/command/player/ProfileCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/ProfileCommand.java
@@ -4,16 +4,16 @@ import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.mc.external.PlayerProvider;
 import com.tisawesomeness.minecord.mc.player.AccountStatus;
 import com.tisawesomeness.minecord.mc.player.Player;
+import com.tisawesomeness.minecord.mc.player.ProfileAction;
 import com.tisawesomeness.minecord.mc.player.RenderType;
 import com.tisawesomeness.minecord.util.ColorUtils;
 import com.tisawesomeness.minecord.util.UuidUtils;
-
 import lombok.NonNull;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.utils.MarkdownUtil;
 
-import java.awt.Color;
+import java.awt.*;
 import java.net.URL;
 import java.util.Optional;
 import java.util.UUID;
@@ -110,18 +110,26 @@ public class ProfileCommand extends BasePlayerCommand {
         String descriptionStart = usernameLength + "\n" + shortUuid + "\n" + longUuid + "\n";
         String defaultModels = defaultModel + "\n" + newDefaultModel;
         if (player.isPHD()) {
-            return descriptionStart + defaultModels + "\n**This player is pseudo hard-deleted (PHD)!**";
-        } else {
-            String skinModel = "**Skin Model**: " + player.getSkinModel().getDescription();
-            return descriptionStart + skinModel + "\n" + defaultModels;
+            return "__This player is pseudo hard-deleted (PHD)!__\n\n" + descriptionStart + defaultModels;
         }
+        String skinModel = "**Skin Model**: " + player.getSkinModel().getDescription();
+        String description = descriptionStart + skinModel + "\n" + defaultModels;
+        if (player.getProfile().getProfileActions().contains(ProfileAction.FORCED_NAME_CHANGE)) {
+            return "__Cannot play multiplayer due to banned name.__\n\n" + description;
+        }
+        return description;
     }
 
     private static @NonNull String constructSkinInfo(Player player) {
         String skinLink = boldMaskedLink("View Skin", player.getSkinUrl());
         String custom = "**Custom**: " + displayBool(player.hasCustomSkin());
         String skinHistoryLink = boldMaskedLink("Skin History", player.getMCSkinHistoryUrl());
-        return skinLink + "\n" + custom + "\n" + skinHistoryLink;
+        String skinInfo = skinLink + "\n" + custom + "\n" + skinHistoryLink;
+        if (player.getProfile().getProfileActions().contains(ProfileAction.USING_BANNED_SKIN)) {
+            String banNotice = player.hasCustomSkin() ? "__Banned Skin__" : "__Banned Skin__ (reset)";
+            return banNotice + "\n" + skinInfo;
+        }
+        return skinInfo;
     }
     private static @NonNull String constructAccountInfo(Player player, Optional<AccountStatus> statusOpt) {
         String accountType = statusOpt

--- a/src/com/tisawesomeness/minecord/command/player/SkinCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/SkinCommand.java
@@ -2,15 +2,15 @@ package com.tisawesomeness.minecord.command.player;
 
 import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.mc.player.Player;
+import com.tisawesomeness.minecord.mc.player.ProfileAction;
 import com.tisawesomeness.minecord.mc.player.RenderType;
 import com.tisawesomeness.minecord.util.ColorUtils;
 import com.tisawesomeness.minecord.util.MessageUtils;
-
 import lombok.NonNull;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 
-import java.awt.Color;
+import java.awt.*;
 
 public class SkinCommand extends BasePlayerCommand {
 
@@ -57,7 +57,15 @@ public class SkinCommand extends BasePlayerCommand {
         String skinModel = "**Skin Model**: " + player.getSkinModel().getDescription();
         String defaultModel = "**Default Skin Model**: " + player.getDefaultSkinModel().getDescription();
         String newDefaultModel = "**1.19.3+ Default Skin**: " + player.getNewDefaultSkin();
-        return custom + "\n" + skinModel + "\n" + defaultModel + "\n" + newDefaultModel;
+
+        String description = custom + "\n" + skinModel + "\n" + defaultModel + "\n" + newDefaultModel;
+        if (player.getProfile().getProfileActions().contains(ProfileAction.USING_BANNED_SKIN)) {
+            String banNotice = player.hasCustomSkin() ?
+                    "__Cannot play multiplayer due to banned skin.__" :
+                    "__Cannot play multiplayer due to banned skin__ (skin has been reset).";
+            return banNotice + "\n\n" + description;
+        }
+        return description;
     }
 
 }

--- a/src/com/tisawesomeness/minecord/command/player/UuidCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/UuidCommand.java
@@ -3,7 +3,6 @@ package com.tisawesomeness.minecord.command.player;
 import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.mc.player.*;
 import com.tisawesomeness.minecord.util.UuidUtils;
-
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
@@ -99,7 +98,7 @@ public class UuidCommand extends AbstractPlayerCommand {
     private static void constructReply(SlashCommandInteractionEvent e, UUID uuid, String title) {
         String shortUuid = String.format("**Short**: `%s`", UuidUtils.toShortString(uuid));
         String longUuid = String.format("**Long**: `%s`", UuidUtils.toLongString(uuid));
-        String skinModel = String.format("**Default Skin Model**: `%s`", Player.getDefaultSkinModelFor(uuid).getDescription());
+        String skinModel = String.format("**Default Skin Model**: `%s`", SkinModel.defaultFor(uuid).getDescription());
         String newSkinModel = String.format("**1.19.3+ Skin**: `%s`", DefaultSkin.defaultFor(uuid));
         String intArray = String.format("**Post-1.16 NBT**: `%s`", UuidUtils.toIntArrayString(uuid));
         String mostLeast = String.format("**Pre-1.16 NBT**: `%s`", UuidUtils.toMostLeastString(uuid));

--- a/src/com/tisawesomeness/minecord/command/utility/CoordsCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/CoordsCommand.java
@@ -1,0 +1,90 @@
+package com.tisawesomeness.minecord.command.utility;
+
+import com.tisawesomeness.minecord.command.SlashCommand;
+import com.tisawesomeness.minecord.mc.pos.BlockPos;
+import com.tisawesomeness.minecord.mc.pos.SectionPos;
+import com.tisawesomeness.minecord.mc.pos.Vec3;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+
+import java.util.Optional;
+
+public class CoordsCommand extends SlashCommand {
+
+    @Override
+    public CommandInfo getInfo() {
+        return new CommandInfo(
+                "coords",
+                "Convert Overworld <-> Nether coordinates and compute chunk positions",
+                "<coordinate> [<dimension>]",
+                0,
+                false,
+                false
+        );
+    }
+
+    @Override
+    public SlashCommandData addCommandSyntax(SlashCommandData builder) {
+        return builder.addOptions(
+                new OptionData(OptionType.STRING, "coordinate", "A coordinate (example: `57, -12, 105`)", true),
+                new OptionData(OptionType.INTEGER, "dimension", "Current dimension")
+                        .addChoice("Overworld", Dimension.OVERWORLD.ordinal()).addChoice("Nether", Dimension.NETHER.ordinal())
+        );
+    }
+
+    @Override
+    public Result run(SlashCommandInteractionEvent e) {
+        String coordinateStr = e.getOption("coordinate", OptionMapping::getAsString);
+        int dimensionInt = e.getOption("dimension", Dimension.OVERWORLD.ordinal(), OptionMapping::getAsInt);
+
+        Optional<Vec3> coordinateOpt = Vec3.parse(coordinateStr);
+        if (!coordinateOpt.isPresent()) {
+            return new Result(Outcome.WARNING, "Could not parse coordinate.");
+        }
+        BlockPos coordinate = new BlockPos(coordinateOpt.get().round());
+        Dimension dimension = dimensionInt == 0 ? Dimension.OVERWORLD : Dimension.NETHER;
+
+        if (!coordinate.isInBounds()) {
+            return new Result(Outcome.WARNING, "Coordinate is outside the world border at 29,999,984 blocks.");
+        }
+
+        return new Result(Outcome.SUCCESS, buildMessage(coordinate, dimension));
+    }
+
+    private static String buildMessage(BlockPos coordinate, Dimension dimension) {
+        if (dimension == Dimension.OVERWORLD) {
+            String overworld = buildCoordinateCalculationString(coordinate);
+            String nether = buildCoordinateCalculationString(coordinate.overworldToNether());
+            return "**Overworld Coordinates**:\n" +
+                    overworld + "\n" +
+                    "\n" +
+                    "**Nether Coordinates**:\n" +
+                    nether;
+        } else {
+            String nether = buildCoordinateCalculationString(coordinate);
+            String overworld = buildCoordinateCalculationString(coordinate.netherToOverworld());
+            return "**Nether Coordinates**:\n" +
+                    nether + "\n" +
+                    "\n" +
+                    "**Overworld Coordinates**:\n" +
+                    overworld;
+        }
+    }
+    private static String buildCoordinateCalculationString(BlockPos blockPos) {
+        SectionPos section = blockPos.getSection();
+        return String.format("Position: `%s`\n", blockPos) +
+                String.format("Position within Section: `%s`\n", blockPos.getPosWithinSection()) +
+                String.format("Section (Chunk): `%s`\n", section) +
+                String.format("Section within Region: `%s`\n", section.getPosWithinRegion()) +
+                String.format("Region file: `%s`", section.getRegionFileName());
+    }
+
+    private enum Dimension {
+        OVERWORLD,
+        NETHER
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/command/utility/RandomCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/RandomCommand.java
@@ -1,0 +1,66 @@
+package com.tisawesomeness.minecord.command.utility;
+
+import com.tisawesomeness.minecord.command.SlashCommand;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class RandomCommand extends SlashCommand {
+
+    @Override
+    public CommandInfo getInfo() {
+        return new CommandInfo(
+                "random",
+                "Looks up the recipes containing an ingredient.",
+                "<type> <arguments...>",
+                0,
+                false,
+                false
+        );
+    }
+
+    @Override
+    public SlashCommandData addCommandSyntax(SlashCommandData builder) {
+        return builder.addSubcommands(
+                new SubcommandData("value", "Generates a random value between a minimum and maximum")
+                        .addOption(OptionType.INTEGER, "min", "Minimum value")
+                        .addOption(OptionType.INTEGER, "max", "Maximum value"),
+                new SubcommandData("uniform", "Generates a random decimal between 0 and 1")
+        );
+    }
+
+    @Override
+    public Result run(SlashCommandInteractionEvent e) {
+        switch (e.getSubcommandName()) {
+            case "value":
+                long min = e.getOption("min", (long) Integer.MIN_VALUE, OptionMapping::getAsLong);
+                long max = e.getOption("max", (long) Integer.MAX_VALUE, OptionMapping::getAsLong);
+                return valueSubcommand(min, max);
+            case "uniform":
+                return uniformSubcommand();
+            default:
+                throw new RuntimeException("Invalid subcommand " + e.getSubcommandName());
+        }
+    }
+
+    private static Result valueSubcommand(long min, long max) {
+        if (min > max) {
+            return new Result(Outcome.WARNING, "Minimum cannot be greater than maximum");
+        }
+        // nextLong upper bound is exclusive, so need to assert that max+1 bound won't overflow
+        assert OptionData.MAX_POSITIVE_NUMBER < Long.MAX_VALUE;
+        long roll = ThreadLocalRandom.current().nextLong(min, max + 1);
+        return new Result(Outcome.SUCCESS, String.format("Rolled %d (from %d to %d)", roll, min, max));
+    }
+
+    private static Result uniformSubcommand() {
+        double value = ThreadLocalRandom.current().nextDouble();
+        return new Result(Outcome.SUCCESS, String.format("Rolled `%f` (uniform random, between 0 and 1)", value));
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/command/utility/RandomCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/RandomCommand.java
@@ -2,6 +2,10 @@ package com.tisawesomeness.minecord.command.utility;
 
 import com.tisawesomeness.minecord.command.SlashCommand;
 import com.tisawesomeness.minecord.util.MathUtils;
+import com.tisawesomeness.minecord.util.dice.DiceCombination;
+import com.tisawesomeness.minecord.util.dice.DiceError;
+import com.tisawesomeness.minecord.util.dice.DiceGroup;
+import com.tisawesomeness.minecord.util.type.Either;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
@@ -9,7 +13,12 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 public class RandomCommand extends SlashCommand {
 
@@ -17,6 +26,10 @@ public class RandomCommand extends SlashCommand {
     private static final int MAX_FORMAT_EXPONENT = 10;
     private static final int ROLL_FRACTION_DIGITS = 20;
     private static final int BOUNDS_FRACTION_DIGITS = 15;
+
+    private static final BigInteger SHOW_ROLLS_LIMIT = BigInteger.valueOf(25);
+    private static final int DICE_GROUP_ROLL_EXACT_LIMIT = 50;
+    private static final BigInteger ROLL_EXACT_LIMIT = BigInteger.valueOf(1000);
 
     @Override
     public CommandInfo getInfo() {
@@ -30,15 +43,20 @@ public class RandomCommand extends SlashCommand {
         );
     }
 
+    private static final String DICE_DESCRIPTION = "One or more dice in dice notation, such as `d20`, `2d6+12`, or `d6-d20`";
+
     @Override
     public SlashCommandData addCommandSyntax(SlashCommandData builder) {
         return builder.addSubcommands(
                 new SubcommandData("value", "Generates a random value between a minimum and maximum")
-                        .addOption(OptionType.INTEGER, "min", "Minimum value")
-                        .addOption(OptionType.INTEGER, "max", "Maximum value"),
-                new SubcommandData("uniform", "Generates a random decimal between 0 and 1")
-                        .addOption(OptionType.NUMBER, "min", "Minimum value")
-                        .addOption(OptionType.NUMBER, "max", "Maximum value")
+                        .addOption(OptionType.INTEGER, "min", "Minimum value, inclusive")
+                        .addOption(OptionType.INTEGER, "max", "Maximum value, inclusive"),
+                new SubcommandData("uniform", "Generates a random decimal between a minimum and maximum")
+                        .addOption(OptionType.NUMBER, "min", "Minimum value, inclusive")
+                        .addOption(OptionType.NUMBER, "max", "Maximum value, exclusive"),
+                new SubcommandData("dice", "Roll multiple dice and sum the result")
+                        .addOptions(new OptionData(OptionType.STRING, "dice", DICE_DESCRIPTION, true)
+                                .setMinLength(1))
         );
     }
 
@@ -49,6 +67,8 @@ public class RandomCommand extends SlashCommand {
                 return valueSubcommand(e);
             case "uniform":
                 return uniformSubcommand(e);
+            case "dice":
+                return diceSubcommand(e);
             default:
                 throw new RuntimeException("Invalid subcommand " + e.getSubcommandName());
         }
@@ -64,7 +84,7 @@ public class RandomCommand extends SlashCommand {
         assert OptionData.MAX_POSITIVE_NUMBER < Long.MAX_VALUE;
 
         long roll = ThreadLocalRandom.current().nextLong(min, max + 1);
-        return new Result(Outcome.SUCCESS, String.format("Rolled %d (from %d to %d)", roll, min, max));
+        return new Result(Outcome.SUCCESS, String.format("Rolled **%d** (from %d to %d)", roll, min, max));
     }
 
     private static Result uniformSubcommand(SlashCommandInteractionEvent e) {
@@ -75,11 +95,110 @@ public class RandomCommand extends SlashCommand {
 
         double value = ThreadLocalRandom.current().nextDouble(min, max);
         String valueStr = format(value, ROLL_FRACTION_DIGITS);
-        return new Result(Outcome.SUCCESS, String.format("Rolled `%s` (uniform random, from %s to %s)",
+        return new Result(Outcome.SUCCESS, String.format("Rolled **`%s`** (uniform random, from %s to %s)",
                 valueStr, minStr, maxStr));
     }
     private static String format(double d, int maxFractionDigits) {
         return MathUtils.formatHumanReadable(d, maxFractionDigits, MIN_FORMAT_EXPONENT, MAX_FORMAT_EXPONENT);
+    }
+
+    private static Result diceSubcommand(SlashCommandInteractionEvent e) {
+        String diceNotation = e.getOption("dice", OptionMapping::getAsString);
+        assert diceNotation != null;
+
+        Either<DiceCombination.Error, DiceCombination> errorOrDice = DiceCombination.parse(diceNotation);
+        if (errorOrDice.isLeft()) {
+            String msg = handleParseError(errorOrDice.getLeft());
+            return new Result(Outcome.WARNING, msg);
+        }
+        DiceCombination dc = errorOrDice.getRight();
+
+        BigInteger numDice = dc.getNumberOfDice();
+        if (numDice.compareTo(SHOW_ROLLS_LIMIT) <= 0) {
+            String msg = buildMessageFromRollEach(dc);
+            return new Result(Outcome.SUCCESS, msg);
+        } else if (numDice.compareTo(ROLL_EXACT_LIMIT) <= 0) {
+            long roll = dc.roll();
+            return new Result(Outcome.SUCCESS, String.format("Rolled **%d**", roll));
+        } else {
+            long roll = dc.rollApprox(diceGroup -> diceGroup.getNumberOfDice() > DICE_GROUP_ROLL_EXACT_LIMIT);
+            return new Result(Outcome.SUCCESS, String.format("Rolled **%d**", roll));
+        }
+    }
+    private static String handleParseError(DiceCombination.Error error) {
+        switch (error.getType()) {
+            case DICE_ERROR:
+                return String.format("`%s` could not be parsed: %s.",
+                        error.getFailedDiceString(), translateDiceError(error.getDiceError()));
+            case PARSE_FAILED:
+                return "Could not parse dice notation.";
+            case MAX_TOO_HIGH:
+                return "The maximum value the dice could roll is too high.";
+            case MIN_TOO_LOW:
+                return "The minimum value the dice could roll is too low.";
+            default:
+                throw new AssertionError("unreachable");
+        }
+    }
+    private static String translateDiceError(DiceError error) {
+        switch (error) {
+            case DICE_INVALID:
+                return "the number of dice is not a number";
+            case DICE_ZERO:
+                return "the number of dice cannot be 0";
+            case FACES_INVALID:
+                return "the number of faces is not a number";
+            case FACES_NOT_POSITIVE:
+                return "the number of faces must be positive";
+            case NO_DELIMITER:
+                return "missing `d` separator";
+            case MAX_TOO_HIGH:
+                return "the maximum value the dice could roll is too high";
+            case MIN_TOO_LOW:
+                return "the minimum value the dice could roll is too low";
+            default:
+                throw new AssertionError("unreachable");
+        }
+    }
+
+    private static String buildMessageFromRollEach(DiceCombination dc) {
+        List<Map<Long, Long>> rollCountsByGroup = dc.rollEach();
+
+        if (rollCountsByGroup.size() == 1) {
+            Map<Long, Long> rollCounts = rollCountsByGroup.get(0);
+            if (rollCounts.size() == 1) {
+                long roll = rollCounts.entrySet().iterator().next().getKey();
+                return String.format("Rolled **%d**", roll);
+            }
+            long roll = sumRolls(rollCounts);
+            String rolledValuesStr = buildRolledValuesString(rollCounts);
+            return String.format("Rolled **%d**: `[%s]`", roll, rolledValuesStr);
+        }
+
+        List<DiceGroup> dice = dc.getDice();
+        StringJoiner diceGroupJoiner = new StringJoiner("\n");
+        long total = 0;
+        for (int i = 0; i < rollCountsByGroup.size(); i++) {
+            DiceGroup diceGroup = dice.get(i);
+            Map<Long, Long> rollCounts = rollCountsByGroup.get(i);
+            total += sumRolls(rollCounts);
+            String rolledValuesStr = buildRolledValuesString(rollCounts);
+            diceGroupJoiner.add(String.format("%s: `[%s]`", diceGroup, rolledValuesStr));
+        }
+        return String.format("Rolled **%d**\n%s", total, diceGroupJoiner);
+    }
+    private static long sumRolls(Map<Long, Long> rollCounts) {
+        return rollCounts.entrySet().stream()
+                .mapToLong(en -> en.getKey() * en.getValue())
+                .reduce(Long::sum)
+                .orElse(0);
+    }
+    private static String buildRolledValuesString(Map<Long, Long> rollCounts) {
+        // returned map may have patterns, simulate random order by shuffling
+        List<Long> rolledValues = MathUtils.shuffle(rollCounts.keySet());
+        return rolledValues.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(", "));
     }
 
 }

--- a/src/com/tisawesomeness/minecord/command/utility/RandomCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/RandomCommand.java
@@ -1,6 +1,7 @@
 package com.tisawesomeness.minecord.command.utility;
 
 import com.tisawesomeness.minecord.command.SlashCommand;
+import com.tisawesomeness.minecord.util.MathUtils;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
@@ -11,6 +12,11 @@ import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class RandomCommand extends SlashCommand {
+
+    private static final int MIN_FORMAT_EXPONENT = -5;
+    private static final int MAX_FORMAT_EXPONENT = 10;
+    private static final int ROLL_FRACTION_DIGITS = 20;
+    private static final int BOUNDS_FRACTION_DIGITS = 15;
 
     @Override
     public CommandInfo getInfo() {
@@ -31,6 +37,8 @@ public class RandomCommand extends SlashCommand {
                         .addOption(OptionType.INTEGER, "min", "Minimum value")
                         .addOption(OptionType.INTEGER, "max", "Maximum value"),
                 new SubcommandData("uniform", "Generates a random decimal between 0 and 1")
+                        .addOption(OptionType.NUMBER, "min", "Minimum value")
+                        .addOption(OptionType.NUMBER, "max", "Maximum value")
         );
     }
 
@@ -38,29 +46,40 @@ public class RandomCommand extends SlashCommand {
     public Result run(SlashCommandInteractionEvent e) {
         switch (e.getSubcommandName()) {
             case "value":
-                long min = e.getOption("min", (long) Integer.MIN_VALUE, OptionMapping::getAsLong);
-                long max = e.getOption("max", (long) Integer.MAX_VALUE, OptionMapping::getAsLong);
-                return valueSubcommand(min, max);
+                return valueSubcommand(e);
             case "uniform":
-                return uniformSubcommand();
+                return uniformSubcommand(e);
             default:
                 throw new RuntimeException("Invalid subcommand " + e.getSubcommandName());
         }
     }
 
-    private static Result valueSubcommand(long min, long max) {
+    private static Result valueSubcommand(SlashCommandInteractionEvent e) {
+        long min = e.getOption("min", (long) Integer.MIN_VALUE, OptionMapping::getAsLong);
+        long max = e.getOption("max", (long) Integer.MAX_VALUE, OptionMapping::getAsLong);
         if (min > max) {
             return new Result(Outcome.WARNING, "Minimum cannot be greater than maximum");
         }
         // nextLong upper bound is exclusive, so need to assert that max+1 bound won't overflow
         assert OptionData.MAX_POSITIVE_NUMBER < Long.MAX_VALUE;
+
         long roll = ThreadLocalRandom.current().nextLong(min, max + 1);
         return new Result(Outcome.SUCCESS, String.format("Rolled %d (from %d to %d)", roll, min, max));
     }
 
-    private static Result uniformSubcommand() {
-        double value = ThreadLocalRandom.current().nextDouble();
-        return new Result(Outcome.SUCCESS, String.format("Rolled `%f` (uniform random, between 0 and 1)", value));
+    private static Result uniformSubcommand(SlashCommandInteractionEvent e) {
+        double min = e.getOption("min", 0.0, OptionMapping::getAsDouble);
+        String minStr = format(min, BOUNDS_FRACTION_DIGITS);
+        double max = e.getOption("max", 1.0, OptionMapping::getAsDouble);
+        String maxStr = format(max, BOUNDS_FRACTION_DIGITS);
+
+        double value = ThreadLocalRandom.current().nextDouble(min, max);
+        String valueStr = format(value, ROLL_FRACTION_DIGITS);
+        return new Result(Outcome.SUCCESS, String.format("Rolled `%s` (uniform random, from %s to %s)",
+                valueStr, minStr, maxStr));
+    }
+    private static String format(double d, int maxFractionDigits) {
+        return MathUtils.formatHumanReadable(d, maxFractionDigits, MIN_FORMAT_EXPONENT, MAX_FORMAT_EXPONENT);
     }
 
 }

--- a/src/com/tisawesomeness/minecord/command/utility/RandomCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/RandomCommand.java
@@ -6,6 +6,7 @@ import com.tisawesomeness.minecord.util.dice.DiceCombination;
 import com.tisawesomeness.minecord.util.dice.DiceError;
 import com.tisawesomeness.minecord.util.dice.DiceGroup;
 import com.tisawesomeness.minecord.util.type.Either;
+import com.tisawesomeness.minecord.util.type.HumanDecimalFormat;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
@@ -23,10 +24,18 @@ import java.util.stream.Collectors;
 
 public class RandomCommand extends SlashCommand {
 
-    private static final int MIN_FORMAT_EXPONENT = -5;
-    private static final int MAX_FORMAT_EXPONENT = 10;
-    private static final int ROLL_FRACTION_DIGITS = 20;
-    private static final int BOUNDS_FRACTION_DIGITS = 15;
+    private static final HumanDecimalFormat ROLL_FORMAT = HumanDecimalFormat.builder()
+            .minimumExponentForExactValues(-5)
+            .maximumExponentForExactValues(10)
+            .minimumFractionDigits(1)
+            .maximumFractionDigits(20)
+            .build();
+    private static final HumanDecimalFormat BOUNDS_FORMAT = HumanDecimalFormat.builder()
+            .minimumExponentForExactValues(-5)
+            .maximumExponentForExactValues(10)
+            .minimumFractionDigits(1)
+            .maximumFractionDigits(10)
+            .build();
 
     private static final Pattern COMMA_PATTERN = Pattern.compile(",");
 
@@ -38,7 +47,7 @@ public class RandomCommand extends SlashCommand {
     public CommandInfo getInfo() {
         return new CommandInfo(
                 "random",
-                "Looks up the recipes containing an ingredient.",
+                "Generate random numbers",
                 "<type> <arguments...>",
                 0,
                 false,
@@ -97,17 +106,14 @@ public class RandomCommand extends SlashCommand {
 
     private static Result uniformSubcommand(SlashCommandInteractionEvent e) {
         double min = e.getOption("min", 0.0, OptionMapping::getAsDouble);
-        String minStr = format(min, BOUNDS_FRACTION_DIGITS);
+        String minStr = BOUNDS_FORMAT.format(min);
         double max = e.getOption("max", 1.0, OptionMapping::getAsDouble);
-        String maxStr = format(max, BOUNDS_FRACTION_DIGITS);
+        String maxStr = BOUNDS_FORMAT.format(max);
 
         double value = ThreadLocalRandom.current().nextDouble(min, max);
-        String valueStr = format(value, ROLL_FRACTION_DIGITS);
+        String valueStr = ROLL_FORMAT.format(value);
         return new Result(Outcome.SUCCESS, String.format("Rolled **`%s`** (uniform random, from %s to %s)",
                 valueStr, minStr, maxStr));
-    }
-    private static String format(double d, int maxFractionDigits) {
-        return MathUtils.formatHumanReadable(d, maxFractionDigits, MIN_FORMAT_EXPONENT, MAX_FORMAT_EXPONENT);
     }
 
     private static Result chooseSubcommand(SlashCommandInteractionEvent e) {

--- a/src/com/tisawesomeness/minecord/command/utility/ServerCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/ServerCommand.java
@@ -10,7 +10,6 @@ import com.tisawesomeness.minecord.command.SlashCommand;
 import com.tisawesomeness.minecord.util.MathUtils;
 import com.tisawesomeness.minecord.util.MessageUtils;
 import com.tisawesomeness.minecord.util.RequestUtils;
-
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -140,8 +139,16 @@ public class ServerCommand extends SlashCommand {
         List<Player> sample = reply.getPlayers().getSample();
 
         // Build and format message
-        if (reply.isPreventsChatReports()) {
+        if (reply.isPreventsChatReports() && reply.isEnforcesSecureChat()) {
+            m += ":interrobang: **Enforces and prevents chat reports at the same time? " +
+                    "Server is sending contradictory messages.\n";
+        } else if (reply.isPreventsChatReports()) {
             m += ":white_check_mark: **Prevents chat reports**\n";
+        } else if (reply.isEnforcesSecureChat()) {
+            m += ":shield: **Enforces chat reports**\n";
+        }
+        if (reply.isPreviewsChat()) {
+            m += ":speech_balloon: Enables chat preview\n";
         }
         m += "**Address:** " + address +
                 "\n" + "**Version:** " + version +
@@ -149,7 +156,7 @@ public class ServerCommand extends SlashCommand {
         if (motd != null) {
             m += "\n" + "**MOTD:** " + motd;
         }
-        if (sample != null && sample.size() > 0) {
+        if (sample != null && !sample.isEmpty()) {
             String sampleStr = sample.stream()
                     .map(p -> MCPingUtil.stripColors(p.getName()))
                     .collect(Collectors.joining("\n"));

--- a/src/com/tisawesomeness/minecord/command/utility/StackCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/StackCommand.java
@@ -1,0 +1,140 @@
+package com.tisawesomeness.minecord.command.utility;
+
+import com.tisawesomeness.minecord.command.SlashCommand;
+import com.tisawesomeness.minecord.mc.item.Container;
+import com.tisawesomeness.minecord.mc.item.ItemCount;
+import com.tisawesomeness.minecord.util.type.HumanDecimalFormat;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+
+import java.util.*;
+
+public class StackCommand extends SlashCommand {
+
+    private static final HumanDecimalFormat FORMAT = HumanDecimalFormat.builder()
+            .maximumFractionDigits(6)
+            .minimumExponentForExactValues(-5)
+            .includeApproximationSymbol(true)
+            .includeGroupingCommas(true)
+            .build();
+    private static final EnumSet<Container> ALL_CONTAINERS = EnumSet.allOf(Container.class);
+    private static final EnumSet<Container> NO_SHULKERS = EnumSet.complementOf(EnumSet.of(
+            Container.CHEST_SHULKER, Container.DOUBLE_CHEST_SHULKER));
+
+    @Override
+    public CommandInfo getInfo() {
+        return new CommandInfo(
+                "stack",
+                "Convert item counts to stacks, chests, shulkers, and back",
+                "<arguments...>",
+                0,
+                false,
+                false
+        );
+    }
+
+    @Override
+    public SlashCommandData addCommandSyntax(SlashCommandData builder) {
+        return builder.addOptions(
+                new OptionData(OptionType.INTEGER, "items", "Number of items").setMinValue(0),
+                new OptionData(OptionType.INTEGER, "stacks", "Number of stacks of items").setMinValue(0),
+                new OptionData(OptionType.INTEGER, "chests", "Number of chests full of items").setMinValue(0),
+                new OptionData(OptionType.INTEGER, "double-chests", "Number of double chests full of items").setMinValue(0),
+                new OptionData(OptionType.INTEGER, "chest-shulkers", "Number of chests full of shulkers").setMinValue(0),
+                new OptionData(OptionType.INTEGER, "double-chest-shulkers", "Number of double chests full of shulkers").setMinValue(0),
+                new OptionData(OptionType.INTEGER, "stack-size", "Stack size of the item")
+                        .addChoice("1", 1).addChoice("16", 16).addChoice("64", 64)
+        );
+    }
+
+    @Override
+    public Result run(SlashCommandInteractionEvent e) {
+        long items = e.getOption("items", 0L, OptionMapping::getAsLong);
+        long stacks = e.getOption("stacks", 0L, OptionMapping::getAsLong);
+        long chests = e.getOption("chests", 0L, OptionMapping::getAsLong);
+        long doubleChests = e.getOption("double-chests", 0L, OptionMapping::getAsLong);
+        long chestShulkers = e.getOption("chest-shulkers", 0L, OptionMapping::getAsLong);
+        long doubleChestShulkers = e.getOption("double-chest-shulkers", 0L, OptionMapping::getAsLong);
+        int stackSize = e.getOption("stack-size", 64, OptionMapping::getAsInt);
+
+        ItemCount itemCount = new ItemCount(items, stackSize)
+                .addStacks(stacks)
+                .addContainers(Container.CHEST, chests)
+                .addContainers(Container.DOUBLE_CHEST, doubleChests)
+                .addContainers(Container.CHEST_SHULKER, chestShulkers)
+                .addContainers(Container.DOUBLE_CHEST_SHULKER, doubleChestShulkers);
+        if (itemCount.getCount() == 0) {
+            return new Result(Outcome.WARNING, "Must add at least one item");
+        }
+
+        List<Long> inputDistribution = Arrays.asList(doubleChestShulkers, chestShulkers, doubleChests, chests, stacks, items);
+        String inputDistributionStr = itemDistributionToPlusString(inputDistribution, ALL_CONTAINERS);
+        String output = String.format("%s is equal to:\n", inputDistributionStr) +
+                buildDistributionLine(itemCount) +
+                buildDistributionLineNoShulkers(itemCount) +
+                "\n" +
+                "Or:\n" +
+                itemLine(itemCount) +
+                itemCountExactLine(itemCount, Container.STACK) +
+                itemCountExactLine(itemCount, Container.CHEST) +
+                itemCountExactLine(itemCount, Container.DOUBLE_CHEST) +
+                itemCountExactLine(itemCount, Container.CHEST_SHULKER) +
+                itemCountExactLine(itemCount, Container.DOUBLE_CHEST_SHULKER);
+
+        return new Result(Outcome.SUCCESS, output);
+    }
+
+    private static String buildDistributionLine(ItemCount itemCount) {
+        List<Long> distribution = itemCount.distribute(ALL_CONTAINERS);
+        String distributionStr = itemDistributionToPlusString(distribution, ALL_CONTAINERS);
+        return String.format("- %s\n", distributionStr);
+    }
+    private static String buildDistributionLineNoShulkers(ItemCount itemCount) {
+        // Don't include line if distribution wouldn't change by removing shulkers
+        if (itemCount.getExact(Container.CHEST_SHULKER) < 1) {
+            return "";
+        }
+        List<Long> distribution = itemCount.distribute(NO_SHULKERS);
+        String distributionStr = itemDistributionToPlusString(distribution, NO_SHULKERS);
+        return String.format("- %s\n", distributionStr);
+    }
+    private static String itemDistributionToPlusString(List<Long> distribution, EnumSet<Container> containers) {
+        List<Container> containersList = new ArrayList<>(containers); // Keeps natural order
+
+        // Does not include items since items is less than smallest container (STACK)
+        StringJoiner distributionJoiner = new StringJoiner(" + ");
+        for (int i = 0; i < distribution.size() - 1; i++) {
+            long value = distribution.get(i);
+            if (value != 0) {
+                Container container = Container.values()[containersList.size() - i - 1];
+                String formatted = String.format("**%d** %s", value, container.getDescription(value));
+                distributionJoiner.add(formatted);
+            }
+        }
+
+        // Account for items (last element of distribution list)
+        long leftoverItems = distribution.get(distribution.size() - 1);
+        if (leftoverItems != 0) {
+            String formatted = String.format("**%d** %s", leftoverItems, pluralItems(leftoverItems));
+            distributionJoiner.add(formatted);
+        }
+        return distributionJoiner.toString();
+    }
+
+    private static String pluralItems(double count) {
+        return count == 1.0 ? "item" : "items";
+    }
+
+    private static String itemLine(ItemCount itemCount) {
+        long count = itemCount.getCount();
+        return String.format("- **%d** %s\n", count, pluralItems(count));
+    }
+    private static String itemCountExactLine(ItemCount itemCount, Container container) {
+        double value = itemCount.getExact(container);
+        return String.format("- **%s** %s\n", FORMAT.format(value), container.getDescription((int) value));
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/mc/Favicon.java
+++ b/src/com/tisawesomeness/minecord/mc/Favicon.java
@@ -1,0 +1,125 @@
+package com.tisawesomeness.minecord.mc;
+
+import com.tisawesomeness.minecord.util.type.Dimensions;
+import com.tisawesomeness.minecord.util.type.Either;
+import lombok.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class Favicon {
+
+    /** The expected width and height of a favicon. Older clients may not display favicons with different sizes. */
+    public static final int EXPECTED_SIZE = 64;
+
+    private static final String PREAMBLE = "data:image/png;base64,";
+    private static final Pattern NEWLINES_PATTERN = Pattern.compile("[\r\n]");
+    private static final int MIN_LENGTH = 24;
+    private static final long PNG_SIGNATURE = 0x89_504E47_0D0A_1A_0AL;
+    private static final int IHDR_LENGTH = 13;
+    private static final int IHDR_TYPE = ('I' << 24) + ('H' << 16) + ('D' << 8) + 'R';
+
+    /** The image data for the favicon. */
+    @Getter private final byte[] data;
+    private final boolean usesNewlines;
+
+    /**
+     * Creates a favicon from image bytes.
+     * @param data byte array representing a raw PNG image
+     * @return new favicon
+     */
+    public static Favicon from(byte[] data) {
+        return new Favicon(data, false);
+    }
+
+    /**
+     * Parses a base64-encoded favicon, according to the server ping
+     * <a href="https://wiki.vg/Server_List_Ping#Status_Response">specification</a>. Newlines are accepted and trimmed
+     * before parsing, use {@link #usesNewlines()} to check if newlines were used.
+     * @param str the string to parse
+     * @return the favicon, or empty if the input is malformed
+     */
+    public static Optional<Favicon> parse(@NonNull String str) {
+        if (!str.startsWith(PREAMBLE)) {
+            return Optional.empty();
+        }
+        String imageData = str.substring(PREAMBLE.length());
+        boolean usesNewlines = false;
+        if (imageData.indexOf('\r') != -1 || imageData.indexOf('\n') != -1) {
+            imageData = NEWLINES_PATTERN.matcher(imageData).replaceAll("");
+            usesNewlines = true;
+        }
+        try {
+            byte[] decoded = Base64.getDecoder().decode(imageData);
+            return Optional.of(new Favicon(decoded, usesNewlines));
+        } catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * If this favicon was created through {@link #parse(String)}, returns whether newlines were in the original input.
+     * Favicons with newlines no longer work since 1.13.
+     * @return whether newlines were used to create this favicon
+     */
+    public boolean usesNewlines() {
+        return usesNewlines;
+    }
+
+    /**
+     * Checks if the favicon is a valid PNG image. If the PNG can be read, returns the width and height.
+     * This method only checks if a PNG can be <strong>read</strong>, not necessarily displayed.
+     * <br>This method can return any {@link PngError PngError}.
+     * @return the image dimensions if the PNG is valid, or a {@link PngError PngError} otherwise
+     */
+    @SneakyThrows // IOE, not possible with ByteArrayInputStream
+    public Either<PngError, Dimensions> validate() {
+        if (data.length < MIN_LENGTH) {
+            return Either.left(PngError.TOO_SHORT);
+        }
+        DataInput is = new DataInputStream(new ByteArrayInputStream(data));
+        if (is.readLong() != PNG_SIGNATURE) {
+            return Either.left(PngError.BAD_SIGNATURE);
+        }
+        if (is.readInt() != IHDR_LENGTH) {
+            return Either.left(PngError.BAD_IHDR_LENGTH);
+        }
+        if (is.readInt() != IHDR_TYPE) {
+            return Either.left(PngError.BAD_IHDR_TYPE);
+        }
+        int width = is.readInt();
+        if (width < 0) {
+            return Either.left(PngError.NEGATIVE_WIDTH);
+        }
+        int height = is.readInt();
+        if (height < 0) {
+            return Either.left(PngError.NEGATIVE_WIDTH);
+        }
+        return Either.right(new Dimensions(width, height));
+    }
+
+    /**
+     * An error that can occur when validating a PNG image. See the
+     * <a href="https://en.wikipedia.org/wiki/PNG#File_format">Wikipedia page</a> for more details.
+     */
+    public enum PngError {
+        /** Image data is too small to be a valid PNG */
+        TOO_SHORT,
+        /** Does not contain PNG file header */
+        BAD_SIGNATURE,
+        /** IHDR chunk length is invalid */
+        BAD_IHDR_LENGTH,
+        /** First PNG chunk is not IHDR */
+        BAD_IHDR_TYPE,
+        /** Width of PNG is negative (or overflow) */
+        NEGATIVE_WIDTH,
+        /** Height of PNG is negative (or overflow) */
+        NEGATIVE_HEIGHT
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/mc/external/ElectroidAPI.java
+++ b/src/com/tisawesomeness/minecord/mc/external/ElectroidAPI.java
@@ -1,19 +1,17 @@
 package com.tisawesomeness.minecord.mc.external;
 
-import com.tisawesomeness.minecord.mc.player.Player;
-import com.tisawesomeness.minecord.mc.player.Profile;
-import com.tisawesomeness.minecord.mc.player.SkinModel;
-import com.tisawesomeness.minecord.mc.player.Username;
+import com.tisawesomeness.minecord.mc.player.*;
 import com.tisawesomeness.minecord.util.UrlUtils;
 import com.tisawesomeness.minecord.util.UuidUtils;
-
 import lombok.NonNull;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -110,7 +108,10 @@ public abstract class ElectroidAPI {
             }
         }
 
-        return new Profile(username, legacy, demo, skinModel, skinUrl, capeUrl);
+        JSONArray profileActionsArr = obj.optJSONArray("profile_actions");
+        Set<ProfileAction> profileActions = ProfileAction.parseProfileActions(profileActionsArr);
+
+        return new Profile(username, legacy, demo, skinModel, skinUrl, capeUrl, profileActions);
     }
 
 }

--- a/src/com/tisawesomeness/minecord/mc/external/MojangAPI.java
+++ b/src/com/tisawesomeness/minecord/mc/external/MojangAPI.java
@@ -14,7 +14,10 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * A wrapper for the Mojang API. See <a href="https://wiki.vg/Mojang_API">the docs</a>
@@ -108,7 +111,7 @@ public abstract class MojangAPI {
         }
 
         JSONArray profileActionsArr = json.optJSONArray("profileActions");
-        Set<ProfileAction> profileActions = parseProfileActions(profileActionsArr);
+        Set<ProfileAction> profileActions = ProfileAction.parseProfileActions(profileActionsArr);
 
         return Optional.of(new Profile(username, legacy, demo, skinModel, skinUrl, capeUrl, profileActions));
     }
@@ -125,18 +128,6 @@ public abstract class MojangAPI {
 
     private static String decodeBase64(@NonNull String base64String) {
         return new String(Base64.getDecoder().decode(base64String), StandardCharsets.UTF_8);
-    }
-
-    private static Set<ProfileAction> parseProfileActions(JSONArray arr) {
-        if (arr == null) {
-            return Collections.emptySet();
-        }
-        Set<ProfileAction> profileActions = EnumSet.noneOf(ProfileAction.class);
-        for (int i = 0; i < arr.length(); i++) {
-            String actionStr = arr.getString(i);
-            ProfileAction.from(actionStr.toUpperCase(Locale.ROOT)).ifPresent(profileActions::add);
-        }
-        return profileActions;
     }
 
 }

--- a/src/com/tisawesomeness/minecord/mc/external/MojangAPIImpl.java
+++ b/src/com/tisawesomeness/minecord/mc/external/MojangAPIImpl.java
@@ -6,7 +6,6 @@ import com.tisawesomeness.minecord.network.NetUtil;
 import com.tisawesomeness.minecord.network.StatusCodes;
 import com.tisawesomeness.minecord.util.UrlUtils;
 import com.tisawesomeness.minecord.util.UuidUtils;
-
 import lombok.Cleanup;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -62,6 +61,9 @@ public class MojangAPIImpl extends MojangAPI {
     }
 
     private static Optional<String> getContentIfPresent(@NonNull Response response) throws IOException {
+        if (response.code() == StatusCodes.NOT_FOUND) {
+            return Optional.empty();
+        }
         NetUtil.throwIfError(response, "Mojang API");
         if (response.code() == StatusCodes.NO_CONTENT) {
             return Optional.empty();

--- a/src/com/tisawesomeness/minecord/mc/item/Container.java
+++ b/src/com/tisawesomeness/minecord/mc/item/Container.java
@@ -1,0 +1,29 @@
+package com.tisawesomeness.minecord.mc.item;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A container that can hold one or more stacks of Minecraft items.
+ */
+@RequiredArgsConstructor
+public enum Container {
+    STACK(1, "stacks"),
+    CHEST(27, "chests"),
+    DOUBLE_CHEST(2 * 27, "double chests"),
+    CHEST_SHULKER(27 * 27, "chests full of shulkers"),
+    DOUBLE_CHEST_SHULKER(2 * 27 * 27, "double chests full of shulkers");
+
+    @Getter private final int slots;
+    private final String description;
+
+    /**
+     * Gets the description of this container, taking into account whether the number of containers is plural.
+     * @param count number of containers
+     * @return description
+     */
+    public String getDescription(double count) {
+        return count == 1.0 ? description.substring(0, description.length() - 1) : description;
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/mc/item/ItemCount.java
+++ b/src/com/tisawesomeness/minecord/mc/item/ItemCount.java
@@ -1,0 +1,102 @@
+package com.tisawesomeness.minecord.mc.item;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A specific number of Minecraft items. Item count may be negative.
+ */
+public class ItemCount {
+
+    private final long itemCount;
+    @Getter private final int stackSize;
+
+    /**
+     * Creates a new item count.
+     * @param itemCount number of starting items
+     * @param stackSize stack size of the item
+     * @throws IllegalArgumentException if the stack size is not within 1-64
+     */
+    public ItemCount(long itemCount, int stackSize) {
+        this.itemCount = itemCount;
+        if (stackSize < 1 || 64 < stackSize) {
+            throw new IllegalArgumentException("stackSize must be between 1 and 64 but was " + stackSize);
+        }
+        this.stackSize = stackSize;
+
+    }
+
+    /**
+     * Creates a new item count with the added items and same stack size.
+     * @param items number of items to add
+     * @return new item count
+     */
+    public ItemCount addItems(long items) {
+        return new ItemCount(itemCount + items, stackSize);
+    }
+    /**
+     * Creates a new item count with the added stacks and same stack size.
+     * @param stacks number of stacks to add
+     * @return new item count
+     */
+    public ItemCount addStacks(long stacks) {
+        return addItems(stackSize * stacks);
+    }
+    /**
+     * Creates a new item count, adding the given number of containers, keeping the same stack size.
+     * @param container container holding the items
+     * @param count number of containers to add
+     * @return new item count
+     */
+    public ItemCount addContainers(Container container, long count) {
+        return addStacks(container.getSlots() * count);
+    }
+
+    /**
+     * @return item count
+     */
+    public long getCount() {
+        return itemCount;
+    }
+
+    /**
+     * Gets the exact number of containers needed to hold this item count.
+     * @param container container holding the items
+     * @return number of containers, possibly fractional
+     */
+    public double getExact(Container container) {
+        return (double) itemCount / (stackSize * container.getSlots());
+    }
+
+    /**
+     * Computes a combination of containers that holds this item count.
+     * Containers with higher capacities are prioritized.
+     * <br>Example: 1863 items is equal to 1 chest, 2 stacks, 7 items.
+     * @param containers containers allowed to be used
+     * @return list of length {@code containers.size() + 1}, each element is the amount of containers necessary in
+     * descending order, and one extra element at the end for leftover items (above example would return
+     * {@code [1, 2, 7]})
+     */
+    public List<Long> distribute(Collection<Container> containers) {
+        long stacks = itemCount / stackSize;
+        long items = itemCount % stackSize;
+
+        List<Long> list = new ArrayList<>();
+        for (int i = Container.values().length - 1; i >= 0; i--) {
+            Container container = Container.values()[i];
+            if (containers.contains(container)) {
+
+                list.add(stacks / container.getSlots());
+                stacks %= container.getSlots();
+
+            }
+        }
+
+        list.add(items);
+        return list;
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/mc/player/DefaultSkin.java
+++ b/src/com/tisawesomeness/minecord/mc/player/DefaultSkin.java
@@ -2,6 +2,8 @@ package com.tisawesomeness.minecord.mc.player;
 
 import lombok.Value;
 
+import java.net.URL;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -20,6 +22,29 @@ public class DefaultSkin {
     public static DefaultSkin defaultFor(UUID uuid) {
         int n = Math.floorMod(uuid.hashCode(), 18);
         return new DefaultSkin(SkinModel.values()[n / 9], DefaultSkinType.values()[n % 9]);
+    }
+    /**
+     * Gets the default skin hosted by the given URL, for versions 1.19.3+
+     * @param url the skin URL
+     * @return the default skin, or empty if the URL is for a custom skin
+     */
+    public static Optional<DefaultSkin> fromUrl(URL url) {
+        for (DefaultSkinType type : DefaultSkinType.values()) {
+            if (type.getUrl(SkinModel.WIDE).sameFile(url)) {
+                return Optional.of(new DefaultSkin(SkinModel.WIDE, type));
+            }
+            if (type.getUrl(SkinModel.SLIM).sameFile(url)) {
+                return Optional.of(new DefaultSkin(SkinModel.SLIM, type));
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * @return the URL of the default skin
+     */
+    public URL getURL() {
+        return type.getUrl(model);
     }
 
     @Override

--- a/src/com/tisawesomeness/minecord/mc/player/DefaultSkinType.java
+++ b/src/com/tisawesomeness/minecord/mc/player/DefaultSkinType.java
@@ -1,23 +1,42 @@
 package com.tisawesomeness.minecord.mc.player;
 
-import lombok.RequiredArgsConstructor;
+import com.tisawesomeness.minecord.util.UrlUtils;
+
+import java.net.URL;
 
 /**
  * An enum with every possible default skin types: Steve, Alex, and the 7 new skins.
  */
-@RequiredArgsConstructor
 public enum DefaultSkinType {
-    ALEX("Alex"),
-    ARI("Ari"),
-    EFE("Efe"),
-    KAI("Kai"),
-    MAKENA("Makena"),
-    NOOR("Noor"),
-    STEVE("Steve"),
-    SUNNY("Sunny"),
-    ZURI("Zuri");
+    ALEX("Alex", "1abc803022d8300ab7578b189294cce39622d9a404cdc00d3feacfdf45be6981", "46acd06e8483b176e8ea39fc12fe105eb3a2a4970f5100057e9d84d4b60bdfa7"),
+    ARI("Ari", "4c05ab9e07b3505dc3ec11370c3bdce5570ad2fb2b562e9b9dd9cf271f81aa44", "6ac6ca262d67bcfb3dbc924ba8215a18195497c780058a5749de674217721892"),
+    EFE("Efe", "daf3d88ccb38f11f74814e92053d92f7728ddb1a7955652a60e30cb27ae6659f", "fece7017b1bb13926d1158864b283b8b930271f80a90482f174cca6a17e88236"),
+    KAI("Kai", "e5cdc3243b2153ab28a159861be643a4fc1e3c17d291cdd3e57a7f370ad676f3", "226c617fde5b1ba569aa08bd2cb6fd84c93337532a872b3eb7bf66bdd5b395f8"),
+    MAKENA("Makena", "dc0fcfaf2aa040a83dc0de4e56058d1bbb2ea40157501f3e7d15dc245e493095", "7cb3ba52ddd5cc82c0b050c3f920f87da36add80165846f479079663805433db"),
+    NOOR("Noor", "90e75cd429ba6331cd210b9bd19399527ee3bab467b5a9f61cb8a27b177f6789", "6c160fbd16adbc4bff2409e70180d911002aebcfa811eb6ec3d1040761aea6dd"),
+    STEVE("Steve", "31f477eb1a7beee631c2ca64d06f8f68fa93a3386d04452ab27f43acdf1b60cb", "d5c4ee5ce20aed9e33e866c66caa37178606234b3721084bf01d13320fb2eb3f"),
+    SUNNY("Sunny", "a3bd16079f764cd541e072e888fe43885e711f98658323db0f9a6045da91ee7a", "b66bc80f002b10371e2fa23de6f230dd5e2f3affc2e15786f65bc9be4c6eb71a"),
+    ZURI("Zuri", "f5dddb41dcafef616e959c2817808e0be741c89ffbfed39134a13e75b811863d", "eee522611005acf256dbd152e992c60c0bb7978cb0f3127807700e478ad97664");
+
+    private static final String BASE_URL = "https://textures.minecraft.net/texture/";
 
     private final String label;
+    private final URL wideUrl;
+    private final URL slimUrl;
+
+    DefaultSkinType(String label, String wide, String slim) {
+        this.label = label;
+        wideUrl = UrlUtils.createUrl(BASE_URL + wide);
+        slimUrl = UrlUtils.createUrl(BASE_URL + slim);
+    }
+
+    /**
+     * @param model whether the skin is slim or wide
+     * @return The URL of the skin
+     */
+    public URL getUrl(SkinModel model) {
+        return model == SkinModel.SLIM ? slimUrl : wideUrl;
+    }
 
     @Override
     public String toString() {

--- a/src/com/tisawesomeness/minecord/mc/player/Profile.java
+++ b/src/com/tisawesomeness/minecord/mc/player/Profile.java
@@ -1,18 +1,21 @@
 package com.tisawesomeness.minecord.mc.player;
 
 import com.tisawesomeness.minecord.util.UrlUtils;
-
+import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.Value;
 
 import javax.annotation.Nullable;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Provides additional account information about a player.
  */
 @Value
+@AllArgsConstructor
 public class Profile {
 
     private static final String MOJANG_STUDIOS_CAPE_URL = "https://textures.minecraft.net/texture/" +
@@ -38,6 +41,12 @@ public class Profile {
     SkinModel skinModel;
     @Nullable URL skinUrl;
     @Nullable URL capeUrl;
+    Set<ProfileAction> profileActions;
+
+    public Profile(@NonNull Username username, boolean legacy, boolean demo, SkinModel skinModel, @Nullable URL skinUrl,
+                   @Nullable URL capeUrl) {
+        this(username, legacy, demo, skinModel, skinUrl, capeUrl, Collections.emptySet());
+    }
 
     /**
      * @return The skin URL, or empty if the player has no <b>custom</b> skin

--- a/src/com/tisawesomeness/minecord/mc/player/ProfileAction.java
+++ b/src/com/tisawesomeness/minecord/mc/player/ProfileAction.java
@@ -1,0 +1,20 @@
+package com.tisawesomeness.minecord.mc.player;
+
+import lombok.NonNull;
+
+import java.util.Optional;
+
+/** A moderation action taken against a profile */
+public enum ProfileAction {
+    FORCED_NAME_CHANGE,
+    USING_BANNED_SKIN;
+
+    public static Optional<ProfileAction> from(@NonNull String str) {
+        for (ProfileAction action : values()) {
+            if (action.toString().equals(str)) {
+                return Optional.of(action);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/com/tisawesomeness/minecord/mc/player/ProfileAction.java
+++ b/src/com/tisawesomeness/minecord/mc/player/ProfileAction.java
@@ -1,8 +1,9 @@
 package com.tisawesomeness.minecord.mc.player;
 
 import lombok.NonNull;
+import org.json.JSONArray;
 
-import java.util.Optional;
+import java.util.*;
 
 /** A moderation action taken against a profile */
 public enum ProfileAction {
@@ -17,4 +18,17 @@ public enum ProfileAction {
         }
         return Optional.empty();
     }
+
+    public static Set<ProfileAction> parseProfileActions(JSONArray arr) {
+        if (arr == null) {
+            return Collections.emptySet();
+        }
+        Set<ProfileAction> profileActions = EnumSet.noneOf(ProfileAction.class);
+        for (int i = 0; i < arr.length(); i++) {
+            String actionStr = arr.getString(i);
+            ProfileAction.from(actionStr.toUpperCase(Locale.ROOT)).ifPresent(profileActions::add);
+        }
+        return profileActions;
+    }
+
 }

--- a/src/com/tisawesomeness/minecord/mc/player/RenderType.java
+++ b/src/com/tisawesomeness/minecord/mc/player/RenderType.java
@@ -3,9 +3,6 @@ package com.tisawesomeness.minecord.mc.player;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import java.util.Arrays;
-import java.util.Optional;
-
 /**
  * An enum of renders supported by {@link Render}.
  * See <a href="https://crafatar.com/">https://crafatar.com/</a>
@@ -51,12 +48,6 @@ public enum RenderType {
     @Override
     public String toString() {
         return name;
-    }
-
-    public static Optional<RenderType> from(String id) {
-        return Arrays.stream(values())
-                .filter(type -> type.getId().equalsIgnoreCase(id))
-                .findFirst();
     }
 
 }

--- a/src/com/tisawesomeness/minecord/mc/player/SkinModel.java
+++ b/src/com/tisawesomeness/minecord/mc/player/SkinModel.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+import java.util.UUID;
+
 /**
  * An enum with every possible skin model type.
  */
@@ -20,6 +22,13 @@ public enum SkinModel {
 
     @Getter private final @NonNull String description;
     private final @NonNull String label;
+
+    /**
+     * @return The default skin model according to the UUID
+     */
+    public static SkinModel defaultFor(UUID uuid) {
+        return uuid.hashCode() % 2 == 0 ? WIDE : SLIM;
+    }
 
     @Override
     public String toString() {

--- a/src/com/tisawesomeness/minecord/mc/player/Username.java
+++ b/src/com/tisawesomeness/minecord/mc/player/Username.java
@@ -54,15 +54,6 @@ public class Username implements CharSequence, Comparable<Username> {
     }
 
     /**
-     * If this username was parsed from a command, determines the number of arguments (separated by spaces) this
-     * username takes up.
-     * @return A number greater than or equal to 1
-     */
-    public int argsUsed() {
-        return (int) name.chars().filter(c -> c == ' ').count() + 1;
-    }
-
-    /**
      * Checks if a username can be sent to the Mojang API.
      * Some characters (such as {@code -} or {@code $} are not valid but Mojang will process them.
      * Others (such as {@code #} and all non-ASCII) have appeared in usernames before but make Mojang freak out.
@@ -76,18 +67,6 @@ public class Username implements CharSequence, Comparable<Username> {
         return name.contains(s);
     }
 
-    /**
-     * Determines if a string will be treated as quoted. Both the starting and ending quote are necessary.
-     * @param input The string
-     * @return Whether the string will be parsed like a quoted name
-     */
-    public static boolean isQuoted(@NonNull CharSequence input) {
-        if (input.length() == 0) {
-            return false;
-        }
-        char ch = input.charAt(0);
-        return ch == QUOTE || ch == BACKTICK;
-    }
 
     /**
      * <p>

--- a/src/com/tisawesomeness/minecord/mc/pos/BlockPos.java
+++ b/src/com/tisawesomeness/minecord/mc/pos/BlockPos.java
@@ -1,0 +1,57 @@
+package com.tisawesomeness.minecord.mc.pos;
+
+import com.tisawesomeness.minecord.util.MathUtils;
+
+/**
+ * A block position within a Minecraft world.
+ */
+public class BlockPos extends Vec3i {
+
+    /** Max world border distance from origin, 1 chunk size from 30 mil limit */
+    public static final int MAX_BORDER_DISTANCE = 29_999_984;
+    /** Max distance from origin nether portals can generate, 128 blocks from max border */
+    public static final int MAX_PORTAL_DISTANCE = 29_999_872;
+
+    public BlockPos(int x, int y, int z) {
+        super(x, y, z);
+    }
+    public BlockPos(Vec3i vec) {
+        super(vec.getX(), vec.getY(), vec.getZ());
+    }
+
+    /**
+     * Converts overworld to nether coordinates. Y values are clamped to nether height.
+     * @return nether block pos
+     */
+    public BlockPos overworldToNether() {
+        int netherY = MathUtils.clamp(y, 0, 127);
+        return new BlockPos(horizontal().floorDiv(8).withY(netherY));
+    }
+    /**
+     * Converts nether to overworld coordinates, clamped to world border/height.
+     * @return overworld block pos
+     */
+    public BlockPos netherToOverworld() {
+        int overworldX = MathUtils.clamp(x * 8, -MAX_PORTAL_DISTANCE, MAX_PORTAL_DISTANCE);
+        int overworldY = MathUtils.clamp(y, -64, 319);
+        int overworldZ = MathUtils.clamp(z * 8, -MAX_PORTAL_DISTANCE, MAX_PORTAL_DISTANCE);
+        return new BlockPos(overworldX, overworldY, overworldZ);
+    }
+
+    public SectionPos getSection() {
+        return new SectionPos(floorDiv(16));
+    }
+    public Vec3i getPosWithinSection() {
+        return floorMod(16);
+    }
+
+    /**
+     * @return true if the X/Z (not Y!) coordinates are within the world border
+     * @see #MAX_BORDER_DISTANCE
+     */
+    public boolean isInBounds() {
+        return -MAX_BORDER_DISTANCE <= x && x <= MAX_BORDER_DISTANCE &&
+                -MAX_BORDER_DISTANCE <= z && z <= MAX_BORDER_DISTANCE;
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/mc/pos/SectionPos.java
+++ b/src/com/tisawesomeness/minecord/mc/pos/SectionPos.java
@@ -1,0 +1,23 @@
+package com.tisawesomeness.minecord.mc.pos;
+
+/**
+ * A 16x16x16 section of a Minecraft world. {@link #horizontal()} gives the chunk coordinates.
+ */
+public class SectionPos extends Vec3i {
+
+    public SectionPos(int x, int y, int z) {
+        super(x, y, z);
+    }
+    public SectionPos(Vec3i vec) {
+        super(vec.getX(), vec.getY(), vec.getZ());
+    }
+
+    public String getRegionFileName() {
+        Vec2i regionVec = horizontal().floorDiv(32);
+        return String.format("r.%d.%d.mca", regionVec.getX(), regionVec.getZ());
+    }
+    public Vec2i getPosWithinRegion() {
+        return horizontal().floorMod(32);
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/mc/pos/Vec2i.java
+++ b/src/com/tisawesomeness/minecord/mc/pos/Vec2i.java
@@ -1,0 +1,29 @@
+package com.tisawesomeness.minecord.mc.pos;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class Vec2i {
+    protected final int x;
+    protected final int z;
+
+    public Vec2i floorDiv(int n) {
+        return new Vec2i(Math.floorDiv(x, n), Math.floorDiv(z, n));
+    }
+    public Vec2i floorMod(int n) {
+        return new Vec2i(Math.floorMod(x, n), Math.floorMod(z, n));
+    }
+
+    public Vec3i withY(int y) {
+        return new Vec3i(x, y, z);
+    }
+
+    @Override
+    public String toString() {
+        return x + ", " + z;
+    }
+}

--- a/src/com/tisawesomeness/minecord/mc/pos/Vec3.java
+++ b/src/com/tisawesomeness/minecord/mc/pos/Vec3.java
@@ -1,0 +1,163 @@
+package com.tisawesomeness.minecord.mc.pos;
+
+import com.tisawesomeness.minecord.util.MathUtils;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class Vec3 {
+
+    private static final String LEFT_BRACKETS = "([{<";
+    private static final String RIGHT_BRACKETS = ")]}>";
+
+    // Regex used to parse a coordinate
+    // prefix: `([xyz] *[=:]? *)`, matches "x", "x:", "x=", with optional spaces
+    // num: `([+-]?\d*\.?\d+)`, matches a number with optional decimal part, ".9" matches but "9." doesn't
+    // sep: `(?: +| *[,/] *|(?=[xyz]))`, matches a separator, which can be either:
+    // - 1+ spaces
+    // - ',' or '/' with optional spaces
+    // - nothing, as long as the next number begins with a prefix (next char is in [xyz])
+    // Complete pattern is `{prefix}?{num}{sep}{prefix}?{num}{sep}{prefix}?{num}`
+    // Prefixes are groups 1, 3, 5, numbers are groups 4, 5, 6, separator is non-capturing
+    private static final Pattern PARSE_REGEX = Pattern.compile("([xyz] *[=:]? *)?([+-]?\\d*\\.?\\d+)(?: +| *[,/] *|(?=[xyz]))([xyz] *[=:]? *)?([+-]?\\d*\\.?\\d+)(?: +| *[,/] *|(?=[xyz]))([xyz] *[=:]? *)?([+-]?\\d*\\.?\\d+)", Pattern.CASE_INSENSITIVE);
+
+    private final double x;
+    private final double y;
+    private final double z;
+
+    /**
+     * Parses a Vec3 from a string. The string must contain three <strong>numbers</strong>, each number optionally
+     * starting with a <strong>prefix</strong>, separated by a <strong>separator</strong>. Optionally, the input can be
+     * surrounded by one matching pair of <strong>brackets</strong>.
+     * <h4>Number</h4>
+     * A decimal number that can be parsed by {@link Double#parseDouble(String)}.
+     * Leading periods (".9") are allowed, but trailing periods ("9.") are not. A leading plus sign is allowed.
+     * <h4>Prefix</h4>
+     * One of "x=", "x:", or "x" for any of x, y, or z, case-insensitive. Spaces are ignored.
+     * Prefixes may be used to specify numbers in any order, such as "y=1, z=2, x=7".
+     * However, coordinates must be used for all numbers, or none at all.
+     * If no prefixes are used, then the coordinate is specified in x, y, z order.
+     * <h4>Separator</h4>
+     * Numbers can be separated by spaces, commas, or forward slashes. Extra spaces are ignored.
+     * If all numbers have a prefix, then a separator is not needed, such as in "x5y2z-3".
+     * <h4>Brackets</h4>
+     * The input string may start and end with one pair of matching brackets: "()", "[]", "{}", or "<>".
+     * @param str input string
+     * @return parsed vec, or empty if the string could not be parsed
+     */
+    public static Optional<Vec3> parse(@NonNull String str) {
+        // Shortest possible input is "1 2 3", reject shorter strings
+        if (str.length() < 5) {
+            return Optional.empty();
+        }
+
+        // Regex doesn't take into account brackets, any extra chars will cause match to fail
+        Optional<String> trimmedOpt = trimBrackets(str);
+        if (!trimmedOpt.isPresent()) {
+            return Optional.empty();
+        }
+        String trimmed = trimmedOpt.get().trim(); // This trim is necessary
+
+        // Entire trimmed string must match to prevent "a3, 4, 5" from parsing
+        Matcher matcher = PARSE_REGEX.matcher(trimmed);
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+
+        // Case 1: no prefixes used (ex: "73, 4, -5")
+        String prefix1 = matcher.group(1);
+        String prefix2 = matcher.group(3);
+        String prefix3 = matcher.group(5);
+        if (prefix1 == null && prefix2 == null && prefix3 == null) {
+            String numStr1 = matcher.group(2);
+            String numStr2 = matcher.group(4);
+            String numStr3 = matcher.group(6);
+            return parse(numStr1, numStr2, numStr3);
+        }
+
+        // Case 2: all prefixes used (ex: "x=73, y=4, z=-5")
+        // If prefixes only used on some numbers, input is ambiguous and rejected
+        // x, y, and z can be processed in any order, but if any strings are left null, they'll fail in parse(String...)
+        String xStr = null;
+        String yStr = null;
+        String zStr = null;
+        for (int i = 0; i < 3; i++) {
+            String prefix = matcher.group(2 * i + 1);
+            if (prefix == null) {
+                return Optional.empty();
+            }
+            String numStr = matcher.group(2 * i + 2);
+            // [xyz] is always the first character matched in the prefix group
+            char maybeXyz = Character.toLowerCase(prefix.charAt(0));
+            switch (maybeXyz) {
+                case 'x':
+                    xStr = numStr;
+                    break;
+                case 'y':
+                    yStr = numStr;
+                    break;
+                case 'z':
+                    zStr = numStr;
+                    break;
+                default:
+                    throw new AssertionError("unreachable");
+            }
+        }
+        return parse(xStr, yStr, zStr);
+    }
+
+    private static Optional<Vec3> parse(@Nullable String xStr, @Nullable String yStr, @Nullable String zStr) {
+        OptionalDouble xOpt = MathUtils.safeParseDouble(xStr);
+        if (!xOpt.isPresent()) {
+            return Optional.empty();
+        }
+        OptionalDouble yOpt = MathUtils.safeParseDouble(yStr);
+        if (!yOpt.isPresent()) {
+            return Optional.empty();
+        }
+        OptionalDouble zOpt = MathUtils.safeParseDouble(zStr);
+        if (!zOpt.isPresent()) {
+            return Optional.empty();
+        }
+        return Optional.of(new Vec3(xOpt.getAsDouble(), yOpt.getAsDouble(), zOpt.getAsDouble()));
+    }
+
+    // Trims brackets in the first/last character if they exist, returning empty if brackets are mismatched
+    private static Optional<String> trimBrackets(String str) {
+        assert str.length() >= 2;
+        char first = str.charAt(0);
+        char last = str.charAt(str.length() - 1);
+
+        // If first character isn't a bracket, no need to trim brackets
+        int bracketId = LEFT_BRACKETS.indexOf(first);
+        if (bracketId == -1) {
+            return Optional.of(str);
+        }
+        // Brackets must match
+        if (last == RIGHT_BRACKETS.charAt(bracketId)) {
+            return Optional.of(str.substring(1, str.length() - 1));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public Vec3i round() {
+        return new Vec3i((int) Math.round(x), (int) Math.round(y), (int) Math.round(z));
+    }
+
+    @Override
+    public String toString() {
+        return x + ", " + y + ", " + z;
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/mc/pos/Vec3i.java
+++ b/src/com/tisawesomeness/minecord/mc/pos/Vec3i.java
@@ -1,0 +1,30 @@
+package com.tisawesomeness.minecord.mc.pos;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class Vec3i {
+    protected final int x;
+    protected final int y;
+    protected final int z;
+
+    public Vec3i floorDiv(int n) {
+        return new Vec3i(Math.floorDiv(x, n), Math.floorDiv(y, n), Math.floorDiv(z, n));
+    }
+    public Vec3i floorMod(int n) {
+        return new Vec3i(Math.floorMod(x, n), Math.floorMod(y, n), Math.floorMod(z, n));
+    }
+
+    public Vec2i horizontal() {
+        return new Vec2i(x, z);
+    }
+
+    @Override
+    public String toString() {
+        return x + ", " + y + ", " + z;
+    }
+}

--- a/src/com/tisawesomeness/minecord/util/ArrayUtils.java
+++ b/src/com/tisawesomeness/minecord/util/ArrayUtils.java
@@ -1,8 +1,6 @@
 package com.tisawesomeness.minecord.util;
 
 import java.lang.reflect.Array;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 // Adapted from apache lang3
 public class ArrayUtils {
@@ -70,15 +68,6 @@ public class ArrayUtils {
             }
         }
         return -1;
-    }
-
-    public static String joinSlice(String[] arr, int beginIndex, String separator) {
-        if (beginIndex < 0) {
-            throw new IllegalArgumentException("beginIndex was " + beginIndex + " but must be nonnegative.");
-        }
-        return Arrays.stream(arr)
-                .skip(beginIndex)
-                .collect(Collectors.joining(separator));
     }
 
 }

--- a/src/com/tisawesomeness/minecord/util/MathUtils.java
+++ b/src/com/tisawesomeness/minecord/util/MathUtils.java
@@ -4,20 +4,64 @@ import lombok.NonNull;
 import lombok.SneakyThrows;
 
 import javax.annotation.Nullable;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.Locale;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 
 public final class MathUtils {
+
+    public static final BigInteger LONG_MAX_VALUE = BigInteger.valueOf(Long.MAX_VALUE);
+    public static final BigInteger LONG_MIN_VALUE = BigInteger.valueOf(Long.MIN_VALUE);
 
     private static final long LOWER_FOUR_BYTES = 0x0000_0000_FFFF_FFFFL;
 
     private MathUtils() {}
+
+    /**
+     * Clamps a value between a low and high bound.
+     * If the value is lower than the low bound, the low bound is returned.
+     * If the value is higher than the high bound, the high bound is returned.
+     * Otherwise, the value itself is returned.
+     * @param val The input number
+     * @param low The low bound, inclusive
+     * @param high The high bound, inclusive
+     * @return A number guaranteed to be between the low and high bounds inclusive
+     * @throws IllegalArgumentException If the low bound is not less than or equal to the high bound
+     */
+    public static long clamp(long val, long low, long high) {
+        if (low > high) {
+            throw new IllegalArgumentException(String.format("low=%d must be <= high=%d", low, high));
+        }
+        return Math.max(low, Math.min(val, high));
+    }
+
+    /**
+     * Checks if an addition operation will overflow
+     * @param a first number
+     * @param b second number
+     * @return whether an overflow will occur
+     */
+    public static boolean additionOverflows(long a, long b) {
+        long result = a + b;
+        return ((a ^ result) & (b ^ result)) < 0;
+    }
+
+    // https://stackoverflow.com/a/6195065
+    /**
+     * Checks if a multiplication operation will overflow
+     * @param a first number
+     * @param b second number
+     * @return whether an overflow will occur
+     */
+    public static boolean multiplicationOverflows(long a, long b) {
+        long result = a * b;
+        return (Long.signum(a) * Long.signum(b) != Long.signum(result)) || (a != 0L && result / a != b);
+    }
 
     /**
      * Casts an int to a long without sign extension.
@@ -27,6 +71,28 @@ public final class MathUtils {
      */
     public static long castWithoutSignExtension(int n) {
         return n & LOWER_FOUR_BYTES;
+    }
+
+    /**
+     * Shuffles a collection into a new list.
+     * @param collection input collection, remains unmodified
+     * @return new list with shuffled elements
+     * @param <T> type of list
+     */
+    public static <T> List<T> shuffle(Collection<T> collection) {
+        List<T> list = new ArrayList<>(collection);
+        Collections.shuffle(list);
+        return list;
+    }
+
+    /**
+     * Generates a pseudorandom Gaussian distributed value, using {@link ThreadLocalRandom#nextGaussian()}.
+     * @param mean the mean of the distribution
+     * @param standardDeviation the standard deviation (square root of variance) of the distribution
+     * @return a randomly generated value
+     */
+    public static double randomGaussian(double mean, double standardDeviation) {
+        return ThreadLocalRandom.current().nextGaussian() * standardDeviation + mean;
     }
 
     /**

--- a/src/com/tisawesomeness/minecord/util/MathUtils.java
+++ b/src/com/tisawesomeness/minecord/util/MathUtils.java
@@ -74,6 +74,16 @@ public final class MathUtils {
     }
 
     /**
+     * Chooses a random element from the array.
+     * @param arr input array
+     * @return random element
+     * @param <T> type of array
+     */
+    public static <T> T choose(T[] arr) {
+        return arr[ThreadLocalRandom.current().nextInt(arr.length)];
+    }
+
+    /**
      * Shuffles a collection into a new list.
      * @param collection input collection, remains unmodified
      * @return new list with shuffled elements

--- a/src/com/tisawesomeness/minecord/util/MathUtils.java
+++ b/src/com/tisawesomeness/minecord/util/MathUtils.java
@@ -8,8 +8,6 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -38,6 +36,19 @@ public final class MathUtils {
             throw new IllegalArgumentException(String.format("low=%d must be <= high=%d", low, high));
         }
         return Math.max(low, Math.min(val, high));
+    }
+
+    /**
+     * Computes the largest mantissa {@code n} such that {@code d = x * 10^n} for some {@code 1 <= abs(x) < 10}.
+     * <br>In other words, computes the largest exponent {@code n} such that {@code 10^n < abs(d)}.
+     * @param d input number
+     * @return {@code n}, or 0 if the input is 0
+     */
+    public static int mantissa(double d) {
+        if (d == 0.0) {
+            return 0;
+        }
+        return (int) Math.floor(StrictMath.log10(Math.abs(d)));
     }
 
     /**
@@ -103,47 +114,6 @@ public final class MathUtils {
      */
     public static double randomGaussian(double mean, double standardDeviation) {
         return ThreadLocalRandom.current().nextGaussian() * standardDeviation + mean;
-    }
-
-    /**
-     * Formats a decimal into a human-readable string, such as "2.7" or "3.72e-8". If the number's scientific notation
-     * has an exponent between the provided min and max, then the number will be formatted exactly. Otherwise, the
-     * number will be formatted in scientific notation. Numbers that cannot be expressed with the given fraction digits
-     * will start with a '~'.
-     * @param d the value to format
-     * @param maxFractionDigits the maximum number of fraction digits to be shown
-     * @param minExactExponent the minimum exponent to show exact values
-     * @param maxExactExponent the maximum exponent to show exact values
-     * @return the formatted number
-     * @throws IllegalArgumentException if {@code minExactExponent > maxExactExponent}
-     */
-    public static String formatHumanReadable(double d, int maxFractionDigits, int minExactExponent, int maxExactExponent) {
-        if (minExactExponent > maxExactExponent) {
-            throw new IllegalArgumentException(String.format("minExactExponent %d cannot be greater than maxExactExponent %d",
-                    minExactExponent, maxExactExponent));
-        }
-
-        NumberFormat scientificNotationFormat = new DecimalFormat("0.#E0");
-        scientificNotationFormat.setMaximumFractionDigits(maxFractionDigits);
-        String formattedScientific = scientificNotationFormat.format(d);
-
-        String exponentStr = formattedScientific.substring(formattedScientific.indexOf('E') + 1);
-        int exponent = Integer.parseInt(exponentStr); // always succeeds
-        if (exponent < minExactExponent || maxExactExponent < exponent) {
-            return addApproxSymbolIfNotExact(scientificNotationFormat, d).toLowerCase(Locale.ROOT);
-        }
-
-        NumberFormat decimalFormat = new DecimalFormat("0.#");
-        decimalFormat.setMinimumFractionDigits(1);
-        decimalFormat.setMaximumFractionDigits(maxFractionDigits);
-        return addApproxSymbolIfNotExact(decimalFormat, d);
-    }
-    // Modifies format
-    private static String addApproxSymbolIfNotExact(NumberFormat format, double d) {
-        String original = format.format(d);
-        format.setMaximumFractionDigits(format.getMaximumFractionDigits() + 1);
-        String withOneMoreDigit = format.format(d);
-        return original.equals(withOneMoreDigit) ? original : "~" + original;
     }
 
     /**

--- a/src/com/tisawesomeness/minecord/util/MathUtils.java
+++ b/src/com/tisawesomeness/minecord/util/MathUtils.java
@@ -31,6 +31,24 @@ public final class MathUtils {
      * @return A number guaranteed to be between the low and high bounds inclusive
      * @throws IllegalArgumentException If the low bound is not less than or equal to the high bound
      */
+    public static int clamp(int val, int low, int high) {
+        if (low > high) {
+            throw new IllegalArgumentException(String.format("low=%d must be <= high=%d", low, high));
+        }
+        return Math.max(low, Math.min(val, high));
+    }
+
+    /**
+     * Clamps a value between a low and high bound.
+     * If the value is lower than the low bound, the low bound is returned.
+     * If the value is higher than the high bound, the high bound is returned.
+     * Otherwise, the value itself is returned.
+     * @param val The input number
+     * @param low The low bound, inclusive
+     * @param high The high bound, inclusive
+     * @return A number guaranteed to be between the low and high bounds inclusive
+     * @throws IllegalArgumentException If the low bound is not less than or equal to the high bound
+     */
     public static long clamp(long val, long low, long high) {
         if (low > high) {
             throw new IllegalArgumentException(String.format("low=%d must be <= high=%d", low, high));
@@ -133,6 +151,22 @@ public final class MathUtils {
     @SneakyThrows(NoSuchAlgorithmException.class) // not possible
     private static MessageDigest getDigest() {
         return MessageDigest.getInstance("SHA-1");
+    }
+
+    /**
+     * Parses a double from a string.
+     * @param str The string to parse, may or may not be a double
+     * @return The double if present, empty if null
+     */
+    public static OptionalDouble safeParseDouble(@Nullable String str) {
+        if (str == null) {
+            return OptionalDouble.empty();
+        }
+        try {
+            return OptionalDouble.of(Double.parseDouble(str));
+        } catch (NumberFormatException ignore) {
+            return OptionalDouble.empty();
+        }
     }
 
 

--- a/src/com/tisawesomeness/minecord/util/StringUtils.java
+++ b/src/com/tisawesomeness/minecord/util/StringUtils.java
@@ -1,17 +1,8 @@
 package com.tisawesomeness.minecord.util;
 
-import lombok.NonNull;
-
 import java.util.*;
 
 public class StringUtils {
-
-    public static boolean isTruthy(String s) {
-        return s != null && (s.equalsIgnoreCase("true") || s.equalsIgnoreCase("yes"));
-    }
-    public static boolean isFalsy(String s) {
-        return s != null && (s.equalsIgnoreCase("false") || s.equalsIgnoreCase("no"));
-    }
 
     /**
      * Splits a string with newlines into groups, making sure that every group is a whole number of lines and at most the max length.
@@ -71,23 +62,6 @@ public class StringUtils {
             chars += line.length() + 1; // +1 for newline
         }
         return chars;
-    }
-
-    /**
-     * Joins a list of lines into a series of partitions, ensuring that no line in the returned list
-     * has a length over the max length (as long as every input line is no longer than the max length).
-     * This is useful for transforming a single message (split into inseparable pieces) into multiple message that
-     * satisfy all length limits.
-     * <br>If the input list contains any line that is over the max length, it will appear in the output list
-     * unmodified. Therefore, you should ensure that the input list has strings with the correct length.
-     * @param lines The list of lines to partition
-     * @param maxLength The max length of any string in the output list
-     * @return A list of strings, where no string has a length over the max length
-     * @throws IllegalArgumentException if the max length is negative
-     * @throws NullPointerException if the list contains null
-     */
-    public static List<String> partitionLinesByLength(List<@NonNull String> lines, int maxLength) {
-        return partitionByLength(lines, "\n", maxLength);
     }
 
     /**

--- a/src/com/tisawesomeness/minecord/util/dice/DiceCombination.java
+++ b/src/com/tisawesomeness/minecord/util/dice/DiceCombination.java
@@ -1,0 +1,327 @@
+package com.tisawesomeness.minecord.util.dice;
+
+import com.tisawesomeness.minecord.util.MathUtils;
+import com.tisawesomeness.minecord.util.type.Either;
+import lombok.*;
+
+import javax.annotation.Nullable;
+import java.math.BigInteger;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a collection of dice which may have different face counts, plus/minus a final constant. Dice combinations
+ * support common dice notation "2d20+5" as well as multiple dice "d20-2d6-1".
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class DiceCombination {
+
+    private final List<DiceGroup> dice;
+    /**
+     * The number added to the final dice roll.
+     */
+    @Getter private final long constant;
+
+    /**
+     * @return an unmodifiable list of the dice in this combination
+     */
+    public List<DiceGroup> getDice() {
+        return Collections.unmodifiableList(dice);
+    }
+
+    /**
+     * Creates a dice combination from the list of dice.
+     * <br>This method can return the following {@link ErrorType ErrorTypes}:
+     * <ul>
+     *     <li>{@link ErrorType#MIN_TOO_LOW MIN_TOO_LOW}
+     *     <br>If the total minimum value of the dice underflows a long integer.
+     *     </li>
+     *     <li>{@link ErrorType#MAX_TOO_HIGH MAX_TOO_HIGH}
+     *     <br>If the total maximum value of the dice overflows a long integer.
+     *     </li>
+     * </ul>
+     * @param dice list of dice to use in this combination
+     * @return the dice group, or a {@link Error} if the inputs are invalid
+     */
+    public static Either<Error, DiceCombination> from(List<? extends DiceGroup> dice) {
+        return from(dice, 0);
+    }
+    /**
+     * Creates a dice combination from the list of dice, plus/minus some constant.
+     * <br>This method can return the following {@link ErrorType ErrorTypes}:
+     * <ul>
+     *     <li>{@link ErrorType#MIN_TOO_LOW MIN_TOO_LOW}
+     *     <br>If the total minimum value of the dice underflows a long integer.
+     *     </li>
+     *     <li>{@link ErrorType#MAX_TOO_HIGH MAX_TOO_HIGH}
+     *     <br>If the total maximum value of the dice overflows a long integer.
+     *     </li>
+     * </ul>
+     * @param dice list of dice to use in this combination
+     * @param constant number added to final roll
+     * @return the dice group, or a {@link Error} if the inputs are invalid
+     */
+    public static Either<Error, DiceCombination> from(List<? extends DiceGroup> dice, long constant) {
+        long max = constant;
+        long min = constant;
+        for (DiceGroup dg : dice) {
+            long dgMin = dg.getMin();
+            if (MathUtils.additionOverflows(min, dgMin)) {
+                // If min overflows MAX_VALUE, then the max also overflows
+                ErrorType type = min > 0 ? ErrorType.MAX_TOO_HIGH : ErrorType.MIN_TOO_LOW;
+                return Either.left(new Error(type));
+            }
+            min += dgMin;
+            long dgMax = dg.getMax();
+            if (MathUtils.additionOverflows(max, dgMax)) {
+                // Min overflow checked earlier, must be a max overflow
+                return Either.left(new Error(ErrorType.MAX_TOO_HIGH));
+            }
+            max += dgMax;
+        }
+        return Either.right(new DiceCombination(new ArrayList<>(dice), constant));
+    }
+
+    /**
+     * Parses a string in dice notation format (such as "d6" or "3d20+d6-2") into a dice combination. Zero or more
+     * dice in {@link DiceGroup#parse(String)} format may be specified, along with one or more constants that will
+     * be added or subtracted from the final dice roll.
+     * <br>This method can return the following {@link ErrorType ErrorTypes}:
+     * <ul>
+     *     <li>{@link ErrorType#DICE_ERROR DICE_ERROR}
+     *     <br>If one of the dice could not be parsed. {@link Error#getDiceError()} and
+     *     {@link Error#getFailedDiceString()} have more information on what caused the error.
+     *     <li>{@link ErrorType#PARSE_FAILED PARSE_FAILED}
+     *     <br>If the whole expression could not be parsed.
+     *     </li>
+     *     <li>Any ErrorType returned from {@link #from(List, long)}.
+     *     </li>
+     * </ul>
+     * @param str the dice notation string
+     * @return the dice group, or a {@link Error} if the inputs are invalid
+     */
+    public static Either<Error, DiceCombination> parse(@NonNull String str) {
+        List<DiceGroup> dice = new ArrayList<>();
+        BigInteger constant = BigInteger.ZERO; // using BigInteger so Long.MAX_VALUE + 1 - 1 doesn't overflow
+
+        // Tokens are either dice (when token contains "d"), or a constant number
+        // Tokens are separated by either + or - for add or subtract
+        // +/- are returned as tokens since whether the dice/constant are negative is important
+        StringTokenizer st = new StringTokenizer(str, "+-", true);
+        boolean negative = false;
+        while (st.hasMoreTokens()) {
+            String token = st.nextToken();
+            if ("+".equals(token)) {
+                negative = false;
+            } else if ("-".equals(token)) {
+                negative = true;
+            } else if (token.toLowerCase(Locale.ROOT).contains("d")) {
+                String diceStr = negative ? "-" + token : token;
+                Either<DiceError, DiceGroup> maybeDiceGroup = DiceGroup.parse(diceStr);
+                if (maybeDiceGroup.isLeft()) {
+                    return Either.left(new Error(ErrorType.DICE_ERROR, maybeDiceGroup.getLeft(), diceStr));
+                }
+                dice.add(maybeDiceGroup.getRight());
+            } else {
+                String constantStr = negative ? "-" + token : token;
+                OptionalLong maybeConstant = MathUtils.safeParseLong(constantStr);
+                if (!maybeConstant.isPresent()) {
+                    return Either.left(new Error(ErrorType.PARSE_FAILED));
+                }
+                constant = constant.add(BigInteger.valueOf(maybeConstant.getAsLong()));
+            }
+        }
+
+        // Although -20d1 + Long.MAX_VALUE + 1 won't overflow, the constant is not allowed to overflow
+        if (constant.compareTo(MathUtils.LONG_MIN_VALUE) < 0) {
+            return Either.left(new Error(ErrorType.MIN_TOO_LOW));
+        }
+        if (constant.compareTo(MathUtils.LONG_MAX_VALUE) > 0) {
+            return Either.left(new Error(ErrorType.MAX_TOO_HIGH));
+        }
+
+        return from(dice, constant.longValue());
+    }
+
+    /**
+     * Gets the total number of dice rolled by this DiceCombination. Negative dice still add to the total.
+     * @return number of dice rolled
+     */
+    public BigInteger getNumberOfDice() {
+        return dice.stream()
+                .map(DiceGroup::getNumberOfDice)
+                .map(BigInteger::valueOf)
+                .map(BigInteger::abs) // must abs after converting to BigInteger since abs(Long.MIN_VALUE) < 0 (!!)
+                .reduce(BigInteger::add)
+                .orElse(BigInteger.ZERO);
+    }
+
+    /**
+     * @return the minimum possible value this dice combination could roll
+     */
+    public long getMin() {
+        return dice.stream()
+                .mapToLong(DiceGroup::getMin)
+                .sum() + constant;
+    }
+    /**
+     * @return the maximum possible value this dice combination could roll
+     */
+    public long getMax() {
+        return dice.stream()
+                .mapToLong(DiceGroup::getMax)
+                .sum() + constant;
+    }
+    /**
+     * @return the average value of the dice
+     */
+    public double getMean() {
+        return dice.stream()
+                .mapToDouble(DiceGroup::getMean)
+                .sum() + constant;
+    }
+    /**
+     * @return the variance (standard deviation squared) of the dice
+     */
+    public double getVariance() {
+        return dice.stream()
+                .mapToDouble(DiceGroup::getVariance)
+                .sum();
+    }
+
+    /**
+     * Rolls all dice and sums the result, adding the constant.
+     * <br><strong>WARNING: This method rolls each die individually for 100% accuracy. Rolling very large numbers of
+     * dice may take minutes, hours, or even centuries.</strong> Consider using {@link #rollApprox()}.
+     * <br>If all dice have one face, the method will complete immediately.
+     * @return the total of all rolls
+     * @see #rollEach()
+     */
+    public long roll() {
+        return rollApprox(dice -> false);
+    }
+
+    /**
+     * Rolls all dice, counting the frequency that each value appears in each dice group.
+     * <br><strong>WARNING: This method rolls each die individually for 100% accuracy. Rolling very large numbers of
+     * dice may take minutes, hours, or even centuries.</strong> Consider using {@link #rollApprox()}.
+     * <br>If the dice have one face, the method will complete immediately.
+     * @return a list with the same length and order as {@link #getDice()}, each item specifying the frequency that
+     * each value appears (see {@link DiceGroup#rollEach()} for details)
+     * @see #roll()
+     */
+    public List<Map<Long, Long>> rollEach() {
+        return dice.stream()
+                .map(DiceGroup::rollEach)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Rolls all dice and sums the result, adding the constant. See {@link DiceGroup#rollApprox()} for approximation
+     * details.
+     * @return the total of all rolls
+     * @see #rollEach()
+     */
+    public long rollApprox() {
+        return MathUtils.clamp(Math.round(MathUtils.randomGaussian(getMean(), Math.sqrt(getVariance()))), getMin(), getMax());
+    }
+    /**
+     * Rolls all dice and sums the result, adding the constant. The {@code shouldApproximate} predicate can be used to
+     * approximate rolls for very large numbers of dice while using exact values for small numbers of dice.
+     * @param shouldApproximate function that inputs each dice group in this combination, and outputs whether that
+     *                          group's roll should be approximated using {@link DiceGroup#rollApprox()}
+     * @return the total of all rolls
+     * @see #rollEach()
+     */
+    public long rollApprox(Predicate<? super DiceGroup> shouldApproximate) {
+        return dice.stream()
+                .mapToLong(dice -> shouldApproximate.test(dice) ? dice.rollApprox() : dice.roll())
+                .sum() + constant;
+    }
+
+    /**
+     * Converts the dice combination to dice notation, such as "4d6+5".
+     * Combinations with zero dice will return the constant number, even if it's 0.
+     * The returned string will create the same dice combination when passed to {@link #parse(String)}.
+     * @return the dice combination in dice notation
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < dice.size(); i++) {
+            DiceGroup dg = dice.get(i);
+            if (i > 0 && dg.getNumberOfDice() > 0) {
+                sb.append('+');
+            }
+            sb.append(dg.toString());
+        }
+        if (constant != 0 || dice.isEmpty()) {
+            if (!dice.isEmpty() && constant > 0) {
+                sb.append('+');
+            }
+            sb.append(constant);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Error class communicating what went wrong during {@link #parse(String)}.
+     */
+    @RequiredArgsConstructor
+    @EqualsAndHashCode
+    public static class Error {
+        @Getter private final ErrorType type;
+        private final @Nullable DiceError diceError;
+        private final @Nullable String failedDiceString;
+
+        private Error(ErrorType type) {
+            this(type, null, null);
+        }
+
+        /**
+         * @return if {@link #getDiceError()} will return a valid dice error
+         */
+        public boolean isDiceError() {
+            return type == ErrorType.DICE_ERROR;
+        }
+        /**
+         * @return the dice error for this error
+         * @throws IllegalStateException if {@link #isDiceError()} is false
+         */
+        public DiceError getDiceError() {
+            if (diceError == null) {
+                throw new IllegalStateException("This error is not a DICE_ERROR");
+            }
+            return diceError;
+        }
+        /**
+         * @return the dice group string that failed to parse
+         * @throws IllegalStateException if {@link #isDiceError()} is false
+         */
+        public String getFailedDiceString() {
+            if (failedDiceString == null) {
+                throw new IllegalStateException("This error is not a DICE_ERROR");
+            }
+            return failedDiceString;
+        }
+
+        @Override
+        public String toString() {
+            StringJoiner sj = new StringJoiner(", ", Error.class.getSimpleName() + "[", "]")
+                    .add("type=" + type);
+            if (diceError != null) {
+                sj.add("diceError=" + diceError).add("failedDiceString='" + failedDiceString + "'");
+            }
+            return sj.toString();
+        }
+    }
+
+    public enum ErrorType {
+        DICE_ERROR,
+        PARSE_FAILED,
+        MIN_TOO_LOW,
+        MAX_TOO_HIGH
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/util/dice/DiceError.java
+++ b/src/com/tisawesomeness/minecord/util/dice/DiceError.java
@@ -1,0 +1,11 @@
+package com.tisawesomeness.minecord.util.dice;
+
+public enum DiceError {
+    NO_DELIMITER,
+    DICE_INVALID,
+    DICE_ZERO,
+    FACES_INVALID,
+    FACES_NOT_POSITIVE,
+    MAX_TOO_HIGH,
+    MIN_TOO_LOW
+}

--- a/src/com/tisawesomeness/minecord/util/dice/DiceGroup.java
+++ b/src/com/tisawesomeness/minecord/util/dice/DiceGroup.java
@@ -1,0 +1,212 @@
+package com.tisawesomeness.minecord.util.dice;
+
+import com.tisawesomeness.minecord.util.MathUtils;
+import com.tisawesomeness.minecord.util.type.Either;
+import lombok.*;
+import org.checkerframework.checker.index.qual.Positive;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Represents a group of fair dice, all of which have the same number of faces.
+ * Negative numbers of dice are supported and will negate the rolled values.
+ */
+@Getter
+@EqualsAndHashCode
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class DiceGroup {
+
+    private final long numberOfDice; // n
+    @Positive
+    private final long numberOfFaces; // s
+
+    /**
+     * Creates a dice group from the given inputs.
+     * <br>This method can return the following {@link DiceError DiceErrors}:
+     * <ul>
+     *     <li>{@link DiceError#DICE_ZERO DICE_ZERO}
+     *     <br>If the number of dice is zero.
+     *     </li>
+     *     <li>{@link DiceError#FACES_NOT_POSITIVE FACES_NOT_POSITIVE}
+     *     <br>If the number of faces is not positive.
+     *     </li>
+     *     <li>{@link DiceError#MAX_TOO_HIGH MAX_TOO_HIGH}
+     *     <br>If the maximum rolled value ({@code numberOfDice * numberOfFaces}) would overflow a long integer.
+     *     </li>
+     *     <li>{@link DiceError#MIN_TOO_LOW MIN_TOO_LOW}
+     *     <br>If the maximum rolled value ({@code numberOfDice * numberOfFaces}) would underflow a long integer.
+     *     </li>
+     * </ul>
+     * @param numberOfDice the number of dice
+     * @param numberOfFaces the number of sides on each die
+     * @return the dice group, or a {@link DiceError} if the inputs are invalid
+     */
+    public static Either<DiceError, DiceGroup> from(long numberOfDice, long numberOfFaces) {
+        if (numberOfDice == 0) {
+            return Either.left(DiceError.DICE_ZERO);
+        }
+        if (numberOfFaces <= 0) {
+            return Either.left(DiceError.FACES_NOT_POSITIVE);
+        }
+        if (MathUtils.multiplicationOverflows(numberOfDice, numberOfFaces)) {
+            return Either.left(numberOfDice > 0 ? DiceError.MAX_TOO_HIGH : DiceError.MIN_TOO_LOW);
+        }
+        return Either.right(new DiceGroup(numberOfDice, numberOfFaces));
+    }
+
+    /**
+     * Parses a string in dice notation format (such as "d6" or "3d20") into a dice group. The format is the number
+     * of dice, then 'd', then the number of faces.
+     * <br>Negative values for the number of dice are allowed, but not zero.
+     * <br>Whitespaces is <strong>not</strong> ignored.
+     * <br>This method can return the following {@link DiceError DiceErrors}:
+     * <ul>
+     *     <li>{@link DiceError#NO_DELIMITER NO_DELIMITER}
+     *     <br>If the 'd' character is not found in the lowercased string.
+     *     </li>
+     *     <li>{@link DiceError#DICE_INVALID DICE_INVALID} or {@link DiceError#FACES_INVALID FACES_INVALID}
+     *     <br>If the dice or faces could not be parsed as a number, respectively.
+     *     </li>
+     *     <li>Any DiceError returned from {@link #from(long, long)}.
+     *     </li>
+     * </ul>
+     * @param str the dice notation string
+     * @return the dice group, or a {@link DiceError} if the string is invalid
+     */
+    public static Either<DiceError, DiceGroup> parse(@NonNull String str) {
+        int dIdx = str.toLowerCase(Locale.ROOT).indexOf('d');
+        if (dIdx == -1) {
+            return Either.left(DiceError.NO_DELIMITER);
+        }
+
+        String diceStr = str.substring(0, dIdx);
+        OptionalLong diceOpt = parseDice(diceStr);
+        if (!diceOpt.isPresent()) {
+            return Either.left(DiceError.DICE_INVALID);
+        }
+
+        String facesStr = str.substring(dIdx + 1);
+        OptionalLong facesOpt = MathUtils.safeParseLong(facesStr);
+        if (!facesOpt.isPresent()) {
+            return Either.left(DiceError.FACES_INVALID);
+        }
+
+        return from(diceOpt.getAsLong(), facesOpt.getAsLong());
+    }
+    private static OptionalLong parseDice(String diceStr) {
+        if (diceStr.isEmpty()) {
+            return OptionalLong.of(1);
+        }
+        if ("-".equals(diceStr)) {
+            return OptionalLong.of(-1);
+        }
+        return MathUtils.safeParseLong(diceStr);
+    }
+
+    /**
+     * @return the minimum possible value this dice group could roll
+     */
+    public long getMin() {
+        return numberOfDice > 0 ? numberOfDice : numberOfDice * numberOfFaces;
+    }
+    /**
+     * @return the maximum possible value this dice group could roll
+     */
+    public long getMax() {
+        return numberOfDice > 0 ? numberOfDice * numberOfFaces : numberOfDice;
+    }
+    /**
+     * @return the average value of the dice
+     */
+    public double getMean() {
+        // n(s + 1) / 2
+        return numberOfDice * (numberOfFaces + 1.0) / 2.0;
+    }
+    /**
+     * @return the variance (standard deviation squared) of the dice
+     */
+    public double getVariance() {
+        // n(s^2 - 1) / 12, must convert to double early to avoid overflow
+        return Math.abs((double) numberOfDice) * (((double) numberOfFaces) * numberOfFaces - 1.0) / 12.0;
+    }
+
+    /**
+     * Rolls each die in the group and sums the result. If the number of dice is negative, the result will be negative.
+     * <br><strong>WARNING: This method rolls each die individually for 100% accuracy. Rolling very large numbers of
+     * dice may take minutes, hours, or even centuries.</strong> Consider using {@link #rollApprox()}.
+     * <br>If the dice have one face, the method will complete immediately.
+     * @return the total of all rolls
+     * @see #rollEach()
+     */
+    public long roll() {
+        if (numberOfFaces == 1) {
+            return numberOfDice;
+        }
+        long total = 0;
+        for (long i = 0; i < Math.abs(numberOfDice); i++) {
+            // Roll from 0..s-1 instead of usual 1..s
+            total += ThreadLocalRandom.current().nextLong(numberOfFaces);
+        }
+        // Adding number of dice (n) changes rolls from n(0..s-1) to n(1..s)
+        // If number of dice is negative, need to negate total sum
+        return (numberOfDice > 0 ? total : -total) + numberOfDice;
+    }
+
+    /**
+     * Rolls each die in the group, counting the frequency that each value appears.
+     * <br><strong>WARNING: This method rolls each die individually for 100% accuracy. Rolling very large numbers of
+     * dice may take minutes, hours, or even centuries.</strong> Consider using {@link #rollApprox()}.
+     * <br>If the dice have one face, the method will complete immediately.
+     * @return a map with each die value as the key and the number of times it appears as the value
+     * @see #roll()
+     */
+    public Map<Long, Long> rollEach() {
+        Map<Long, Long> rollsToCounts = new HashMap<>();
+        if (numberOfFaces == 1) {
+            rollsToCounts.put(1L, numberOfDice);
+            return rollsToCounts;
+        }
+        for (long i = 0; i < Math.abs(numberOfDice); i++) {
+            long roll = ThreadLocalRandom.current().nextLong(numberOfFaces) + 1;
+            long negatedRoll = numberOfDice > 0 ? roll : -roll;
+            long currentCount = rollsToCounts.getOrDefault(negatedRoll, 0L);
+            rollsToCounts.put(negatedRoll, currentCount + 1);
+        }
+        return rollsToCounts;
+    }
+
+    /**
+     * Calculates an approximation for {@link #roll()} using a Gaussian distribution with the parameters
+     * {@link #getMean()} and {@link #getVariance()}. The result is clamped to within {@link #getMin()} and
+     * {@link #getMax()}.
+     * <br>For sufficiently large numbers of dice, the approximation is highly accurate. Otherwise, {@link #roll()}
+     * is recommended.
+     * <br>If dice have one face, this method returns the exact value.
+     * <br>This method always returns in constant time.
+     * @return the total of all rolls, approximated
+     */
+    public long rollApprox() {
+        if (numberOfFaces == 1) {
+            return numberOfFaces;
+        }
+        return MathUtils.clamp(Math.round(MathUtils.randomGaussian(getMean(), Math.sqrt(getVariance()))), getMin(), getMax());
+    }
+
+    /**
+     * Converts the dice group to dice notation, such as "4d6". If the number of dice is 1, then it is omitted from
+     * the string. The returned string will create the same dice group when passed to {@link #parse(String)}.
+     * @return the dice group in dice notation
+     */
+    @Override
+    public String toString() {
+        if (numberOfDice == 1) {
+            return "d" + numberOfFaces;
+        }
+        return numberOfDice + "d" + numberOfFaces;
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/util/type/Dimensions.java
+++ b/src/com/tisawesomeness/minecord/util/type/Dimensions.java
@@ -1,0 +1,26 @@
+package com.tisawesomeness.minecord.util.type;
+
+import lombok.Value;
+
+@Value
+public class Dimensions {
+    int width;
+    int height;
+
+    /**
+     * Creates a new Dimensions object
+     * @param width width
+     * @param height height
+     * @throws IllegalArgumentException if width or height are negative
+     */
+    public Dimensions(int width, int height) {
+        if (width < 0) {
+            throw new IllegalArgumentException("width cannot be negative but was " + width);
+        }
+        if (height < 0) {
+            throw new IllegalArgumentException("height cannot be negative but was " + height);
+        }
+        this.width = width;
+        this.height = height;
+    }
+}

--- a/src/com/tisawesomeness/minecord/util/type/HumanDecimalFormat.java
+++ b/src/com/tisawesomeness/minecord/util/type/HumanDecimalFormat.java
@@ -1,0 +1,147 @@
+package com.tisawesomeness.minecord.util.type;
+
+import com.tisawesomeness.minecord.util.MathUtils;
+import lombok.Builder;
+
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+/**
+ * Formats decimal numbers in a human-readable format.
+ */
+@Builder
+public class HumanDecimalFormat {
+
+    /**
+     * Minimum number of digits allowed in the fractional portion of a number.
+     * <br>Default 0, must be >= 0 and <= {@code maximumFractionDigits}.
+     */
+    @Builder.Default
+    private final int minimumFractionDigits = 0;
+    /**
+     * Maximum number of digits allowed in the fractional portion of a number.
+     * <br>Default {@link Integer#MAX_VALUE MAX_VALUE}, must be >= 0 and >= {@code minimumFractionDigits}.
+     */
+    @Builder.Default
+    private final int maximumFractionDigits = Integer.MAX_VALUE;
+    /**
+     * If the number is between {@code 10^minimumExponentForExactValues} and {@code 10^maximumExponentForExactValues},
+     * then the number is formatted exactly. Otherwise, the number is formatted in scientific notation.
+     * <br>Default {@link Integer#MIN_VALUE MIN_VALUE}, must be <= {@code maximumExponentForExactValues}.
+     */
+    @Builder.Default
+    private final int minimumExponentForExactValues = Integer.MIN_VALUE;
+    /**
+     * If the number is between {@code 10^minimumExponentForExactValues} and {@code 10^maximumExponentForExactValues},
+     * then the number is formatted exactly. Otherwise, the number is formatted in scientific notation.
+     * <br>Default {@link Integer#MAX_VALUE MAX_VALUE}, must be >= {@code minimumExponentForExactValues}.
+     */
+    @Builder.Default
+    private final int maximumExponentForExactValues = Integer.MAX_VALUE;
+    /**
+     * Whether to include grouping separators, such as in "1,234,567.89". Grouping separators are not used in
+     * scientific notation.
+     * <br>Default false.
+     */
+    @Builder.Default
+    private final boolean includeGroupingCommas = false;
+    /**
+     * Whether to prefix the number with '~' when the formatter rounds the number before formatting. This ONLY accounts
+     * for rounding due to the maximum fractional digits, not roundoff error.
+     * <br>Default false.
+     */
+    @Builder.Default
+    private final boolean includeApproximationSymbol = false;
+    /**
+     * The rounding behavior of this formatter. Note that the rounding modes are designed around rounding to integers,
+     * and may not work as expected when rounding to a specific number of fractional digits.
+     * <br>Default {@link RoundingMode#DOWN}.
+     */
+    @Builder.Default
+    private final RoundingMode roundingMode = RoundingMode.DOWN;
+
+    // Overrides generated bulider() from @Builder
+    // Only way to check arguments before building is to return a subclass of the generated builder
+    public static HumanDecimalFormatBuilder builder() {
+        return new HumanDecimalFormatBuilderInternal();
+    }
+
+    private static class HumanDecimalFormatBuilderInternal extends HumanDecimalFormatBuilder {
+
+        @Override
+        public HumanDecimalFormatBuilder minimumFractionDigits(int minimumFractionDigits) {
+            if (minimumFractionDigits < 0) {
+                throw new IllegalArgumentException("minimumFractionDigits cannot be negative");
+            }
+            return super.minimumFractionDigits(minimumFractionDigits);
+        }
+
+        @Override
+        public HumanDecimalFormatBuilder maximumFractionDigits(int maximumFractionDigits) {
+            if (maximumFractionDigits < 0) {
+                throw new IllegalArgumentException("maximumFractionDigits cannot be negative");
+            }
+            return super.maximumFractionDigits(maximumFractionDigits);
+        }
+
+        @Override
+        public HumanDecimalFormat build() {
+            HumanDecimalFormat format = super.build();
+            if (format.minimumFractionDigits > format.maximumFractionDigits) {
+                throw new IllegalArgumentException(String.format(
+                        "minimumFractionDigits %d cannot be greater than maximumFractionDigits %d",
+                        format.minimumFractionDigits, format.maximumFractionDigits
+                ));
+            }
+            if (format.minimumExponentForExactValues > format.maximumExponentForExactValues) {
+                throw new IllegalArgumentException(String.format(
+                        "minimumExponentForExactValues %d cannot be greater than maximumExponentForExactValues %d",
+                        format.minimumExponentForExactValues, format.maximumExponentForExactValues
+                ));
+            }
+            return format;
+        }
+
+    }
+
+    /**
+     * Formats a number according to this formatter.
+     * See the builder methods for a description of what each argument does.
+     * @param d input number
+     * @return formatted string
+     */
+    public String format(double d) {
+        int exponent = MathUtils.mantissa(d);
+        if (minimumExponentForExactValues <= exponent && exponent <= maximumExponentForExactValues) {
+            NumberFormat decimalFormat = createFormat(createPattern(false));
+            return addApproxSymbolIfNotExact(decimalFormat, d);
+        }
+        NumberFormat scientificNotationFormat = createFormat(createPattern(true));
+        return addApproxSymbolIfNotExact(scientificNotationFormat, d).toLowerCase(Locale.ROOT);
+    }
+    private String createPattern(boolean scientificNotation) {
+        String integralPart = includeGroupingCommas ? "#,##0" : "0";
+        String mantissaPart = scientificNotation ? "E0" : "";
+        return String.format("%s.0%s", integralPart, mantissaPart);
+    }
+    private NumberFormat createFormat(String pattern) {
+        NumberFormat format = new DecimalFormat(pattern);
+        format.setMinimumFractionDigits(minimumFractionDigits);
+        format.setMaximumFractionDigits(maximumFractionDigits);
+        format.setRoundingMode(roundingMode);
+        return format;
+    }
+    // Modifies format
+    private String addApproxSymbolIfNotExact(NumberFormat format, double d) {
+        String original = format.format(d);
+        if (!includeApproximationSymbol || format.getMaximumFractionDigits() > -Double.MIN_EXPONENT) {
+            return original;
+        }
+        format.setMaximumFractionDigits(-Double.MIN_EXPONENT);
+        String withAllDigits = format.format(d);
+        return original.equals(withAllDigits) ? original : "~" + original;
+    }
+
+}


### PR DESCRIPTION
- Added `/random`, a new command for generating random numbers
  - `/random value` - generate a random integer
  - `/random uniform` - generate a random decimal
  - `/random choice` - choose randomly from a list
  - `/random dice` - roll dice using DND dice notation
- Added `/stack`, a new command for converting "1 chest, 2 stacks, 7 items" to "1863 items" and vice-versa
- Added `/coords`, a new command for converting Overworld to Nether coordinates, finding chunk coordinates, and more
- Updated player lookup commands with 1.20.2's new skin/name bans
  - Added skin/name ban info to `/profile`
  - Added skin ban info to `/skin`
- `/server` now shows if a server enforces chat reports or has chat preview enabled (note that not all servers that enforce chat reports will announce it when pinged)
- `/server` now shows more details about invalid server icons
- Updated developer names in `/credits`
- Fixed custom skin detection not working with the new 1.19.3+ default skins
- Fixed player commands showing a Mojang API error when player does not exist, due to an internal API change
- Fixed an exception when running `/recipe` or `/ingredient` without message history permissions
- (Self-hosting change) Updated dependencies

From 0.16.2:
- Added a few "suspicious" item search names
- (Self-hosting change) Fixed `&useradmin` and `&settingsadmin` not being accessible
- (Self-hosting change) Updated dependencies