### PR TITLE
Update Minecraft Wiki references to new domain

### DIFF
--- a/minecord-bot/src/main/java/com/tisawesomeness/minecord/command/utility/CodesCommand.java
+++ b/minecord-bot/src/main/java/com/tisawesomeness/minecord/command/utility/CodesCommand.java
@@ -12,7 +12,7 @@ public class CodesCommand extends AbstractUtilityCommand {
         return "codes";
     }
 
-    private String img = "https://minecraft.gamepedia.com/media/minecraft.gamepedia.com/7/7e/Minecraft_Formatting.gif";
+    private String img = "https://minecraft.wiki/images/Minecraft_Formatting.gif?2311f";
 
     public void run(String[] args, CommandContext ctx) {
 

--- a/minecord-bot/src/main/resources/lang/lang.properties
+++ b/minecord-bot/src/main/resources/lang/lang.properties
@@ -756,7 +756,7 @@ help.extra.uuidInput.name=uuidInput
 help.extra.uuidInput.title=UUID Input Help
 help.extra.uuidInput.description=Show help for NBT formats for UUIDs
 help.extra.uuidInput.aliases=
-help.extra.uuidInput.help=A [UUID](https://minecraft.gamepedia.com/Universally_unique_identifier) \
+help.extra.uuidInput.help=A [UUID](https://minecraft.wiki/w/Universally_unique_identifier) \
   (Universally Unique IDentifier) is a player''s unique ID.\n\
   UUIDs can be in any format shown in `{0}uuid`.\n\
   \n\


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all Gamepedia, owned now by Fandom, references accordingly.