### PR TITLE
Version 0.17.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,17 @@ A robust Discord bot using the JDA library for various Minecraft functions.
 #### Utility Commands
 - `/status` - Checks the status of Mojang servers.
 - `/server <address>[:<port>]` - Fetches the stats of a server.
-- `/recipe <item name|id>` - Look up recipes.
 - `/item <item name|id>` - Looks up an item.
+- `/recipe <item name|id>` - Look up recipes.
 - `/ingredient <item name|id>` - Looks up the recipes an ingredient is used in.
+- `/stack <arguments...>` - Convert item counts to stacks, chests, shulkers, and back.
+- `/coords <coordinate> [<dimension>]` - Convert Overworld <-> Nether coordinates and compute chunk positions.
 - `/codes` - Lists the available chat codes.
 - `/color` - Look up a color. Shows color code and background color for Minecraft colors.
 - `/seed <text>` - Converts some text to a seed number.
 - `/shadow <seed>` - Gets the shadow of a seed.
 - `/sha1 <text>` - Computes the sha1 hash of some text.
+- `/random <type> [<arguments...>]` - Generate random numbers.
 
 #### General Commands
 - `/user <user|id>` - Shows user info.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A robust Discord bot using the JDA library for various Minecraft functions.
 - *Join Log Channel:* The bot will send server join/leave messages to this channel. Set to 0 to disable.
 - *Log Webhook:* The webhook URL to send log messages to. Set to blank to disable.
 - *Status Webhook:* The webhook URL to send status messages to. Set to blank to disable.
+- *Supported MC Version:* The latest MC version that the bot supports. This only changes the version shown in `/help recipe` and other commands, and does not change behavior. Update if a new Minecraft version releases that does not change items or recipes.
 - *Is Self Hosted:* Leave as `true` if you are self-hosting the bot.
 - *Author:* The name of the person hosting the bot.
 - *Author Tag:* The Discord tag of the person hosting the bot.
@@ -138,6 +139,7 @@ A robust Discord bot using the JDA library for various Minecraft functions.
     "joinLogChannel": "0",
     "logWebhook": "",
     "statusWebhook": "",
+    "supportedMCVersion":  "1.20.3",
     "isSelfHosted": true,
     "author": "Tis_awesomeness",
     "authorTag": "@Tis_awesomeness#8617",

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ A robust Discord bot using the JDA library for various Minecraft functions.
     "supportedMCVersion":  "1.20.3",
     "isSelfHosted": true,
     "author": "Tis_awesomeness",
-    "authorTag": "@Tis_awesomeness#8617",
+    "authorTag": "@tis_awesomeness",
     "invite": "https://minecord.github.io/invite",
     "helpServer": "https://minecord.github.io/support",
     "website": "https://minecord.github.io",

--- a/config.json
+++ b/config.json
@@ -9,6 +9,7 @@
         "joinLogChannel": "0",
         "logWebhook": "",
         "statusWebhook": "",
+        "supportedMCVersion": "1.20.3",
         "isSelfHosted": true,
         "author": "Tis_awesomeness",
         "authorTag": "@Tis_awesomeness#8617",

--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
         "supportedMCVersion": "1.20.3",
         "isSelfHosted": true,
         "author": "Tis_awesomeness",
-        "authorTag": "@Tis_awesomeness#8617",
+        "authorTag": "@tis_awesomeness",
         "invite": "https://minecord.github.io/invite",
         "helpServer": "https://minecord.github.io/support",
         "website": "https://minecord.github.io",

--- a/items.json
+++ b/items.json
@@ -99,6 +99,9 @@
   "minecraft.grass_block": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Grass"
+        ],
         "display_name": "Grass Block"
       }
     },
@@ -361,6 +364,7 @@
       }
     },
     "properties": {
+      "image_key": "Flowing Water",
       "id": 9
     }
   },
@@ -382,6 +386,7 @@
       }
     },
     "properties": {
+      "image_key": "Flowing Lava",
       "id": 11
     }
   },
@@ -709,15 +714,20 @@
       "id": 31
     }
   },
-  "minecraft.grass": {
+  "minecraft.short_grass": {
     "lang": {
       "en_US": {
-        "display_name": "Grass"
+        "previously": "Grass",
+        "skip_previous": true,
+        "display_name": "Short Grass"
       }
     },
     "properties": {
       "data": 1,
-      "id": 31
+      "image_key": "Grass",
+      "previous_id": "minecraft.grass",
+      "id": 31,
+      "conflict": true
     }
   },
   "minecraft.fern": {
@@ -736,49 +746,7 @@
       "en_US": {
         "previously": "Dead Shrub",
         "search_names": [
-          "deadbush",
-          "fuck",
-          "fucks",
-          "fucking",
-          "fucker",
-          "fuckers",
-          "shit",
-          "shits",
-          "damn",
-          "dammit",
-          "god damn",
-          "god dammit",
-          "ass",
-          "asses",
-          "hell",
-          "dick",
-          "dicks",
-          "penis",
-          "penises",
-          "bitch",
-          "bitches",
-          "the n word",
-          "n word",
-          "nigga",
-          "nigger",
-          "niggas",
-          "niggers",
-          "sex",
-          "xxx",
-          "cum",
-          "tits",
-          "boobs",
-          "b00bs",
-          "porn",
-          "pron",
-          "pr0n",
-          "emerald armor",
-          "emerald armour",
-          "emerald helmet",
-          "emerald chestplate",
-          "emerald leggings",
-          "emerald boots",
-          "php"
+          "Deadbush"
         ],
         "display_name": "Dead Bush"
       }
@@ -805,6 +773,7 @@
       }
     },
     "properties": {
+      "image_key": "Piston Head Model",
       "id": 34
     }
   },
@@ -1269,7 +1238,7 @@
     },
     "properties": {
       "data": 2,
-      "image_key": "Double Oak Wood Slab",
+      "image_key": "Double Oak Slab",
       "actual_id": "minecraft.double_wooden_slab",
       "id": 43
     }
@@ -1385,6 +1354,7 @@
     "properties": {
       "data": 1,
       "previous_id": "minecraft.stone_slab",
+      "conflict": true,
       "id": 44
     }
   },
@@ -1400,7 +1370,9 @@
     },
     "properties": {
       "data": 2,
+      "image_key": "Oak Wood Slab",
       "previous_id": "minecraft.stone_slab",
+      "conflict": true,
       "id": 44
     }
   },
@@ -1416,6 +1388,7 @@
     "properties": {
       "data": 3,
       "previous_id": "minecraft.stone_slab",
+      "conflict": true,
       "id": 44,
       "version": "1.14"
     }
@@ -1432,6 +1405,7 @@
     "properties": {
       "data": 4,
       "previous_id": "minecraft.stone_slab",
+      "conflict": true,
       "id": 44
     }
   },
@@ -1447,6 +1421,7 @@
     "properties": {
       "data": 5,
       "previous_id": "minecraft.stone_slab",
+      "conflict": true,
       "id": 44
     }
   },
@@ -1459,6 +1434,7 @@
     "properties": {
       "data": 6,
       "previous_id": "minecraft.stone_slab",
+      "conflict": true,
       "id": 44
     }
   },
@@ -1471,6 +1447,7 @@
     "properties": {
       "data": 7,
       "previous_id": "minecraft.stone_slab",
+      "conflict": true,
       "id": 44
     }
   },
@@ -1606,6 +1583,7 @@
       }
     },
     "properties": {
+      "image_key": "Redstone Wire",
       "id": 55
     }
   },
@@ -1673,6 +1651,7 @@
       }
     },
     "properties": {
+      "image_key": "Lit Furnace",
       "id": 62
     }
   },
@@ -1814,6 +1793,7 @@
       }
     },
     "properties": {
+      "image_key": "Redstone Torch Off",
       "id": 75
     }
   },
@@ -1887,6 +1867,9 @@
   "minecraft.cactus": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cacti"
+        ],
         "display_name": "Cactus"
       }
     },
@@ -2009,7 +1992,7 @@
       }
     },
     "properties": {
-      "image_key": "Powered Repeater",
+      "image_key": "Redstone Repeater On",
       "id": 94
     }
   },
@@ -2318,6 +2301,7 @@
       }
     },
     "properties": {
+      "image_key": "Stone",
       "id": 97
     }
   },
@@ -2334,6 +2318,7 @@
     },
     "properties": {
       "data": 1,
+      "image_key": "Cobblestone",
       "id": 97
     }
   },
@@ -2349,6 +2334,7 @@
     },
     "properties": {
       "data": 2,
+      "image_key": "Stone Bricks",
       "id": 97
     }
   },
@@ -2369,6 +2355,7 @@
     },
     "properties": {
       "data": 3,
+      "image_key": "Mossy Stone Bricks",
       "id": 97
     }
   },
@@ -2385,6 +2372,7 @@
     },
     "properties": {
       "data": 4,
+      "image_key": "Cracked Stone Bricks",
       "id": 97
     }
   },
@@ -2401,6 +2389,7 @@
     },
     "properties": {
       "data": 5,
+      "image_key": "Chiseled Stone Bricks",
       "id": 97
     }
   },
@@ -2722,6 +2711,9 @@
   "minecraft.redstone_lamp": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Redstone Light"
+        ],
         "display_name": "Redstone Lamp"
       }
     },
@@ -2733,7 +2725,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Redstone Lamp (on)"
+          "Redstone Lamp (on)",
+          "Redstone Light (on)",
+          "Lit Redstone Light"
         ],
         "display_name": "Lit Redstone Lamp"
       }
@@ -2754,6 +2748,7 @@
       }
     },
     "properties": {
+      "image_key": "Double Oak Slab",
       "actual_id": "minecraft.double_wooden_slab",
       "id": 125
     }
@@ -2771,6 +2766,7 @@
     },
     "properties": {
       "data": 1,
+      "image_key": "Double Spruce Slab",
       "actual_id": "minecraft.double_wooden_slab",
       "id": 125
     }
@@ -2788,6 +2784,7 @@
     },
     "properties": {
       "data": 2,
+      "image_key": "Double Birch Slab",
       "actual_id": "minecraft.double_wooden_slab",
       "id": 125
     }
@@ -2805,6 +2802,7 @@
     },
     "properties": {
       "data": 3,
+      "image_key": "Double Jungle Slab",
       "actual_id": "minecraft.double_wooden_slab",
       "id": 125
     }
@@ -2822,6 +2820,7 @@
     },
     "properties": {
       "data": 4,
+      "image_key": "Double Acacia Slab",
       "actual_id": "minecraft.double_wooden_slab",
       "id": 125
     }
@@ -2840,6 +2839,7 @@
     },
     "properties": {
       "data": 5,
+      "image_key": "Double Dark Oak Slab",
       "actual_id": "minecraft.double_wooden_slab",
       "id": 125
     }
@@ -3105,6 +3105,11 @@
   "minecraft.potted_acacia_sapling": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Potted Acacia",
+          "Acacia Sapling Pot",
+          "Acacia Pot"
+        ],
         "display_name": "Potted Acacia Sapling"
       }
     },
@@ -3115,6 +3120,9 @@
   "minecraft.potted_allium": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Allium Pot"
+        ],
         "display_name": "Potted Allium"
       }
     },
@@ -3129,7 +3137,12 @@
           "Potted Azure Flower",
           "Potted Azure",
           "Potted Microsoft Azure",
-          "Potted Bluet"
+          "Potted Bluet",
+          "Azure Bluet Pot",
+          "Azure Flower Pot",
+          "Azure Pot",
+          "Microsoft Azure Pot",
+          "Bluet Pot"
         ],
         "display_name": "Potted Azure Bluet"
       }
@@ -3141,6 +3154,11 @@
   "minecraft.potted_birch_sapling": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Potted Birch",
+          "Birch Sapling Pot",
+          "Birch Pot"
+        ],
         "display_name": "Potted Birch Sapling"
       }
     },
@@ -3153,7 +3171,10 @@
       "en_US": {
         "search_names": [
           "Potted Blue Flower",
-          "Potted Orchid"
+          "Potted Orchid",
+          "Blue Orchid Pot",
+          "Blue Flower Pot",
+          "Orchid Pot"
         ],
         "display_name": "Potted Blue Orchid"
       }
@@ -3165,6 +3186,9 @@
   "minecraft.potted_brown_mushroom": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Brown Mushroom Pot"
+        ],
         "display_name": "Potted Brown Mushroom"
       }
     },
@@ -3176,7 +3200,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Potted Cacti"
+          "Potted Cacti",
+          "Cactus Pot",
+          "Cacti Pot"
         ],
         "display_name": "Potted Cactus"
       }
@@ -3189,7 +3215,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Potted Yellow Flower"
+          "Potted Yellow Flower",
+          "Dandelion Pot",
+          "Yellow Flower Pot"
         ],
         "display_name": "Potted Dandelion"
       }
@@ -3202,7 +3230,11 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Potted Dark Sapling"
+          "Potted Dark Sapling",
+          "Potted Dark Oak",
+          "Dark Oak Sapling Pot",
+          "Dark Sapling Pot",
+          "Dark Oak Pot"
         ],
         "display_name": "Potted Dark Oak Sapling"
       }
@@ -3217,45 +3249,9 @@
         "search_names": [
           "Potted Deadbush",
           "Potted Dead Shrub",
-          "potted fuck",
-          "potted fucks",
-          "potted fucking",
-          "potted fucker",
-          "potted fuckers",
-          "potted shit",
-          "potted shits",
-          "potted damn",
-          "potted dammit",
-          "potted ass",
-          "potted asses",
-          "potted hell",
-          "potted dick",
-          "potted dicks",
-          "potted penis",
-          "potted penises",
-          "potted bitch",
-          "potted bitches",
-          "potted n word",
-          "potted nigga",
-          "potted nigger",
-          "potted niggas",
-          "potted niggers",
-          "potted sex",
-          "potted xxx",
-          "potted cum",
-          "potted tits",
-          "potted boobs",
-          "potted b00bs",
-          "potted porn",
-          "potted pron",
-          "potted pr0n",
-          "potted emerald armor",
-          "potted emerald armour",
-          "potted emerald helmet",
-          "potted emerald chestplate",
-          "potted emerald leggings",
-          "potted emerald boots",
-          "potted php"
+          "Dead Bush Pot",
+          "Deadbush Pot",
+          "Dead Shrub Pot"
         ],
         "display_name": "Potted Dead Bush"
       }
@@ -3267,6 +3263,9 @@
   "minecraft.potted_fern": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Fern Pot"
+        ],
         "display_name": "Potted Fern"
       }
     },
@@ -3277,6 +3276,9 @@
   "minecraft.potted_jungle_sapling": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Jungle Sapling Pot"
+        ],
         "display_name": "Potted Jungle Sapling"
       }
     },
@@ -3287,6 +3289,11 @@
   "minecraft.potted_oak_sapling": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Potted Oak",
+          "Oak Sapling Pot",
+          "Oak Pot"
+        ],
         "display_name": "Potted Oak Sapling"
       }
     },
@@ -3297,6 +3304,9 @@
   "minecraft.potted_orange_tulip": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Orange Tulip Pot"
+        ],
         "display_name": "Potted Orange Tulip"
       }
     },
@@ -3309,7 +3319,10 @@
       "en_US": {
         "search_names": [
           "Potted Oxeye",
-          "Potted Daisy"
+          "Potted Daisy",
+          "Oxeye Daisy Pot",
+          "Oxeye Pot",
+          "Daisy Pot"
         ],
         "display_name": "Potted Oxeye Daisy"
       }
@@ -3321,6 +3334,9 @@
   "minecraft.potted_pink_tulip": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Pink Tulip Pot"
+        ],
         "display_name": "Potted Pink Tulip"
       }
     },
@@ -3333,7 +3349,10 @@
       "en_US": {
         "search_names": [
           "Potted Rose",
-          "Potted Red Flower"
+          "Potted Red Flower",
+          "Poppy Pot",
+          "Rose Pot",
+          "Red Flower Pot"
         ],
         "display_name": "Potted Poppy"
       }
@@ -3345,6 +3364,9 @@
   "minecraft.potted_red_mushroom": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Red Mushroom Pot"
+        ],
         "display_name": "Potted Red Mushroom"
       }
     },
@@ -3355,6 +3377,9 @@
   "minecraft.potted_red_tulip": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Red Tulip Pot"
+        ],
         "display_name": "Potted Red Tulip"
       }
     },
@@ -3365,6 +3390,11 @@
   "minecraft.potted_spruce_sapling": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Potted Spruce",
+          "Spruce Sapling Pot",
+          "Spruce Pot"
+        ],
         "display_name": "Potted Spruce Sapling"
       }
     },
@@ -3375,6 +3405,9 @@
   "minecraft.potted_white_tulip": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "White Tulip Pot"
+        ],
         "display_name": "Potted White Tulip"
       }
     },
@@ -3590,7 +3623,7 @@
       }
     },
     "properties": {
-      "image_key": "Powered Comparator",
+      "image_key": "Redstone Comparator On",
       "id": 150
     }
   },
@@ -4766,6 +4799,7 @@
       }
     },
     "properties": {
+      "image_key": "White Banner",
       "id": 176,
       "version": "1.8"
     }
@@ -4779,6 +4813,7 @@
       }
     },
     "properties": {
+      "image_key": "White Banner",
       "id": 177,
       "version": "1.8"
     }
@@ -5109,12 +5144,17 @@
         "search_names": [
           "Moonlight Sensor",
           "Nighttime Sensor",
-          "Night Sensor"
+          "Night Sensor",
+          "Inverted Daylight Detector",
+          "Moonlight Detector",
+          "Nighttime Detector",
+          "Night Detector"
         ],
         "display_name": "Inverted Daylight Sensor"
       }
     },
     "properties": {
+      "image_key": "Inverted Daylight Detector",
       "id": 178,
       "version": "1.8"
     }
@@ -7398,6 +7438,7 @@
       }
     },
     "properties": {
+      "image_key": "Redstone",
       "id": 331
     }
   },
@@ -7470,7 +7511,6 @@
       }
     },
     "properties": {
-      "image_key": "Clay (ball)",
       "id": 337
     }
   },
@@ -7700,7 +7740,9 @@
       "en_US": {
         "previously": "Cactus Green",
         "search_names": [
-          "Cactus Dye"
+          "Cactus Dye",
+          "Cacti Green",
+          "Cacti Dye"
         ],
         "display_name": "Green Dye"
       }
@@ -7954,10 +7996,15 @@
   "minecraft.filled_map": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Buried Treasure Map",
+          "Treasure Map"
+        ],
         "display_name": "Map"
       }
     },
     "properties": {
+      "image_key": "Buried Treasure Map",
       "id": 358
     }
   },
@@ -8024,6 +8071,7 @@
       }
     },
     "properties": {
+      "image_key": "Cooked Beef",
       "id": 364
     }
   },
@@ -9523,6 +9571,7 @@
       }
     },
     "properties": {
+      "image_key": "White Banner",
       "id": 425
     }
   },
@@ -10907,6 +10956,7 @@
       }
     },
     "properties": {
+      "image_key": "Air",
       "version": "1.13"
     }
   },
@@ -12064,6 +12114,7 @@
       }
     },
     "properties": {
+      "image_key": "Turtle Helmet",
       "version": "1.13"
     }
   },
@@ -12087,6 +12138,7 @@
       }
     },
     "properties": {
+      "image_key": "Air",
       "version": "1.13"
     }
   },
@@ -12179,6 +12231,7 @@
       }
     },
     "properties": {
+      "image_key": "Bamboo Sapling",
       "version": "1.14"
     }
   },
@@ -12883,6 +12936,9 @@
   "minecraft.potted_bamboo": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Bamboo Pot"
+        ],
         "display_name": "Potted Bamboo"
       }
     },
@@ -12893,6 +12949,9 @@
   "minecraft.potted_cornflower": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cornflower Pot"
+        ],
         "display_name": "Potted Cornflower"
       }
     },
@@ -12904,7 +12963,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Potted Lily Valley"
+          "Potted Lily Valley",
+          "Lily of the Valley Pot",
+          "Lily Valley Pot"
         ],
         "display_name": "Potted Lily of the Valley"
       }
@@ -12916,6 +12977,9 @@
   "minecraft.potted_wither_rose": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Wither Rose Pot"
+        ],
         "display_name": "Potted Wither Rose"
       }
     },
@@ -13567,6 +13631,9 @@
   "minecraft.crimson_fungus": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Crimson Fungi"
+        ],
         "display_name": "Crimson Fungus"
       }
     },
@@ -14155,10 +14222,16 @@
   "minecraft.potted_crimson_fungus": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Potted Crimson Fungi",
+          "Crimson Fungus Pot",
+          "Crimson Fungi Pot"
+        ],
         "display_name": "Potted Crimson Fungus"
       }
     },
     "properties": {
+      "image_key": "Potted Crimson Fungi",
       "version": "1.16"
     }
   },
@@ -14166,7 +14239,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Potted Crimson Root"
+          "Potted Crimson Root",
+          "Crimson Roots Pot",
+          "Crimson Root Pot"
         ],
         "display_name": "Potted Crimson Roots"
       }
@@ -14178,10 +14253,16 @@
   "minecraft.potted_warped_fungus": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Potted Warped Fungi",
+          "Warped Fungus Pot",
+          "Warped Fungi Pot"
+        ],
         "display_name": "Potted Warped Fungus"
       }
     },
     "properties": {
+      "image_key": "Potted Warped Fungi",
       "version": "1.16"
     }
   },
@@ -14189,7 +14270,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Potted Warped Root"
+          "Potted Warped Root",
+          "Warped Roots Pot",
+          "Warped Root Pot"
         ],
         "display_name": "Potted Warped Roots"
       }
@@ -14475,6 +14558,9 @@
   "minecraft.warped_fungus": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Warped Fungi"
+        ],
         "display_name": "Warped Fungus"
       }
     },
@@ -14486,7 +14572,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Fungus on a Stick"
+          "Fungus on a Stick",
+          "Warped Fungus on a Stick",
+          "Warped Fungi on a Stick"
         ],
         "display_name": "Warped Fungus on a Stick"
       }
@@ -14858,6 +14946,7 @@
       }
     },
     "properties": {
+      "image_key": "Black Candle Cake",
       "version": "1.17"
     }
   },
@@ -14878,6 +14967,7 @@
       }
     },
     "properties": {
+      "image_key": "Blue Candle Cake",
       "version": "1.17"
     }
   },
@@ -14898,6 +14988,7 @@
       }
     },
     "properties": {
+      "image_key": "Brown Candle Cake",
       "version": "1.17"
     }
   },
@@ -15502,10 +15593,13 @@
     "lang": {
       "en_US": {
         "search_names": [
+          "Lightly-Weathered Copper",
           "Lightly Weathered Copper",
           "Exposed Copper Block",
+          "Lightly-Weathered Copper Block",
           "Lightly Weathered Copper Block",
           "Exposed Block of Copper",
+          "Lightly-Weathered Block of Copper",
           "Lightly Weathered Block of Copper"
         ],
         "display_name": "Exposed Copper"
@@ -15519,16 +15613,22 @@
     "lang": {
       "en_US": {
         "search_names": [
+          "Lightly-Weathered Cut Copper",
           "Lightly Weathered Cut Copper",
           "Exposed Cut Copper Block",
+          "Lightly-Weathered Cut Copper Block",
           "Lightly Weathered Cut Copper Block",
           "Exposed Cut Block of Copper",
+          "Lightly-Weathered Cut Block of Copper",
           "Lightly Weathered Cut Block of Copper",
           "Cut Exposed Copper",
+          "Cut Lightly-Weathered Copper",
           "Cut Lightly Weathered Copper",
           "Cut Exposed Copper Block",
+          "Cut Lightly-Weathered Copper Block",
           "Cut Lightly Weathered Copper Block",
           "Cut Exposed Block of Copper",
+          "Cut Lightly-Weathered Block of Copper",
           "Cut Lightly Weathered Block of Copper"
         ],
         "display_name": "Exposed Cut Copper"
@@ -15542,10 +15642,13 @@
     "lang": {
       "en_US": {
         "search_names": [
+          "Lightly-Weathered Cut Copper Slab",
           "Lightly Weathered Cut Copper Slab",
           "Cut Exposed Copper Slab",
+          "Cut Lightly-Weathered Copper Slab",
           "Cut Lightly Weathered Copper Slab",
           "Exposed Copper Slab",
+          "Lightly-Weathered Copper Slab",
           "Lightly Weathered Copper Slab"
         ],
         "display_name": "Exposed Cut Copper Slab"
@@ -15559,16 +15662,22 @@
     "lang": {
       "en_US": {
         "search_names": [
+          "Lightly-Weathered Cut Copper Stairs",
           "Lightly Weathered Cut Copper Stairs",
           "Cut Exposed Copper Stairs",
+          "Cut Lightly-Weathered Copper Stairs",
           "Cut Lightly Weathered Copper Stairs",
           "Exposed Copper Stairs",
+          "Lightly-Weathered Copper Stairs",
           "Lightly Weathered Copper Stairs",
           "Exposed Cut Copper Stair",
+          "Lightly-Weathered Cut Copper Stair",
           "Lightly Weathered Cut Copper Stair",
           "Cut Exposed Copper Stair",
+          "Cut Lightly-Weathered Copper Stair",
           "Cut Lightly Weathered Copper Stair",
           "Exposed Copper Stair",
+          "Lightly Weathered Copper Stair",
           "Lightly Weathered Copper Stair"
         ],
         "display_name": "Exposed Cut Copper Stairs"
@@ -15762,6 +15871,7 @@
       }
     },
     "properties": {
+      "image_key": "Deepslate",
       "version": "1.17"
     }
   },
@@ -16109,12 +16219,16 @@
       "en_US": {
         "search_names": [
           "Potted Azalea Shrub",
-          "Potted Azalea Bush"
+          "Potted Azalea Bush",
+          "Azalea Pot",
+          "Azalea Shrub Pot",
+          "Azalea Bush Pot"
         ],
         "display_name": "Potted Azalea"
       }
     },
     "properties": {
+      "image_key": "Potted Azalea Bush",
       "version": "1.17"
     }
   },
@@ -16126,12 +16240,19 @@
           "Potted Flowering Azalea Bush",
           "Potted Flower Azalea",
           "Potted Flower Azalea Shrub",
-          "Potted Flower Azalea Bush"
+          "Potted Flower Azalea Bush",
+          "Flowering Azalea Pot",
+          "Flowering Azalea Shrub Pot",
+          "Flowering Azalea Bush Pot",
+          "Flower Azalea Pot",
+          "Flower Azalea Shrub Pot",
+          "Flower Azalea Bush Pot"
         ],
         "display_name": "Potted Flowering Azalea"
       }
     },
     "properties": {
+      "image_key": "Potted Flowering Azalea Bush",
       "version": "1.17"
     }
   },
@@ -16418,6 +16539,7 @@
       }
     },
     "properties": {
+      "image_key": "Block of Copper",
       "version": "1.17"
     }
   },
@@ -16435,6 +16557,7 @@
       }
     },
     "properties": {
+      "image_key": "Cut Copper",
       "version": "1.17"
     }
   },
@@ -16449,6 +16572,7 @@
       }
     },
     "properties": {
+      "image_key": "Cut Copper Slab",
       "version": "1.17"
     }
   },
@@ -16466,6 +16590,7 @@
       }
     },
     "properties": {
+      "image_key": "Cut Copper Stairs",
       "version": "1.17"
     }
   },
@@ -16474,21 +16599,28 @@
       "en_US": {
         "search_names": [
           "Exposed Waxed Copper",
+          "Waxed Lightly-Weathered Copper",
           "Waxed Lightly Weathered Copper",
+          "Lightly-Weathered Waxed Copper",
           "Lightly Weathered Waxed Copper",
           "Waxed Exposed Copper Block",
           "Exposed Waxed Copper Block",
+          "Waxed Lightly-Weathered Copper Block",
           "Waxed Lightly Weathered Copper Block",
+          "Lightly-Weathered Waxed Copper Block",
           "Lightly Weathered Waxed Copper Block",
           "Waxed Exposed Block of Copper",
           "Exposed Waxed Block of Copper",
+          "Waxed Lightly-Weathered Block of Copper",
           "Waxed Lightly Weathered Block of Copper",
+          "Lightly-Weathered Waxed Block of Copper",
           "Lightly Weathered Waxed Block of Copper"
         ],
         "display_name": "Waxed Exposed Copper"
       }
     },
     "properties": {
+      "image_key": "Exposed Copper",
       "version": "1.17"
     }
   },
@@ -16501,41 +16633,60 @@
           "Waxed Lightly Weathered Cut Copper",
           "Lightly Weathered Waxed Cut Copper",
           "Lightly Weathered Cut Waxed Copper",
+          "Waxed Lightly-Weathered Cut Copper",
+          "Lightly-Weathered Waxed Cut Copper",
+          "Lightly-Weathered Cut Waxed Copper",
           "Waxed Exposed Cut Copper Block",
           "Exposed Waxed Cut Copper Block",
           "Exposed Cut Waxed Copper Block",
           "Waxed Lightly Weathered Cut Copper Block",
           "Lightly Weathered Waxed Cut Copper Block",
           "Lightly Weathered Cut Waxed Copper Block",
+          "Waxed Lightly-Weathered Cut Copper Block",
+          "Lightly-Weathered Waxed Cut Copper Block",
+          "Lightly-Weathered Cut Waxed Copper Block",
           "Waxed Exposed Cut Block of Copper",
           "Exposed Waxed Cut Block of Copper",
           "Exposed Cut Waxed Block of Copper",
           "Waxed Lightly Weathered Cut Block of Copper",
           "Lightly Weathered Waxed Cut Block of Copper",
           "Lightly Weathered Cut Waxed Block of Copper",
+          "Waxed Lightly-Weathered Cut Block of Copper",
+          "Lightly-Weathered Waxed Cut Block of Copper",
+          "Lightly-Weathered Cut Waxed Block of Copper",
           "Waxed Cut Exposed Copper",
           "Cut Waxed Exposed Copper",
           "Cut Exposed Waxed Copper",
           "Waxed Cut Lightly Weathered Copper",
           "Cut Waxed Lightly Weathered Copper",
           "Cut Lightly Weathered Waxed Copper",
+          "Waxed Cut Lightly-Weathered Copper",
+          "Cut Waxed Lightly-Weathered Copper",
+          "Cut Lightly-Weathered Waxed Copper",
           "Waxed Cut Exposed Copper Block",
           "Cut Waxed Exposed Copper Block",
           "Cut Exposed Waxed Copper Block",
           "Waxed Cut Lightly Weathered Copper Block",
           "Cut Waxed Lightly Weathered Copper Block",
           "Cut Lightly Weathered Waxed Copper Block",
+          "Waxed Cut Lightly-Weathered Copper Block",
+          "Cut Waxed Lightly-Weathered Copper Block",
+          "Cut Lightly-Weathered Waxed Copper Block",
           "Waxed Cut Exposed Block of Copper",
           "Cut Waxed Exposed Block of Copper",
           "Cut Exposed Waxed Block of Copper",
           "Waxed Cut Lightly Weathered Block of Copper",
           "Cut Waxed Lightly Weathered Block of Copper",
-          "Cut Lightly Weathered Waxed Block of Copper"
+          "Cut Lightly Weathered Waxed Block of Copper",
+          "Waxed Cut Lightly-Weathered Block of Copper",
+          "Cut Waxed Lightly-Weathered Block of Copper",
+          "Cut Lightly-Weathered Waxed Block of Copper"
         ],
         "display_name": "Waxed Exposed Cut Copper"
       }
     },
     "properties": {
+      "image_key": "Exposed Cut Copper",
       "version": "1.17"
     }
   },
@@ -16548,21 +16699,30 @@
           "Waxed Lightly Weathered Cut Copper Slab",
           "Lightly Weathered Waxed Cut Copper Slab",
           "Lightly Weathered Cut Waxed Copper Slab",
+          "Waxed Lightly-Weathered Cut Copper Slab",
+          "Lightly-Weathered Waxed Cut Copper Slab",
+          "Lightly-Weathered Cut Waxed Copper Slab",
           "Waxed Cut Exposed Copper Slab",
           "Cut Waxed Exposed Copper Slab",
           "Cut Exposed Waxed Copper Slab",
           "Waxed Cut Lightly Weathered Copper Slab",
           "Cut Waxed Lightly Weathered Copper Slab",
           "Cut Lightly Weathered Waxed Copper Slab",
+          "Waxed Cut Lightly-Weathered Copper Slab",
+          "Cut Waxed Lightly-Weathered Copper Slab",
+          "Cut Lightly-Weathered Waxed Copper Slab",
           "Waxed Exposed Copper Slab",
           "Exposed Waxed Copper Slab",
           "Waxed Lightly Weathered Copper Slab",
-          "Lightly Weathered Waxed Copper Slab"
+          "Lightly Weathered Waxed Copper Slab",
+          "Waxed Lightly-Weathered Copper Slab",
+          "Lightly-Weathered Waxed Copper Slab"
         ],
         "display_name": "Waxed Exposed Cut Copper Slab"
       }
     },
     "properties": {
+      "image_key": "Exposed Cut Copper Slab",
       "version": "1.17"
     }
   },
@@ -16575,37 +16735,54 @@
           "Waxed Lightly Weathered Cut Copper Stairs",
           "Lightly Weathered Waxed Cut Copper Stairs",
           "Lightly Weathered Cut Waxed Copper Stairs",
+          "Waxed Lightly-Weathered Cut Copper Stairs",
+          "Lightly-Weathered Waxed Cut Copper Stairs",
+          "Lightly-Weathered Cut Waxed Copper Stairs",
           "Waxed Cut Exposed Copper Stairs",
           "Cut Waxed Exposed Copper Stairs",
           "Cut Exposed Waxed Copper Stairs",
           "Waxed Cut Lightly Weathered Copper Stairs",
           "Cut Waxed Lightly Weathered Copper Stairs",
           "Cut Lightly Weathered Waxed Copper Stairs",
+          "Waxed Cut Lightly-Weathered Copper Stairs",
+          "Cut Waxed Lightly-Weathered Copper Stairs",
+          "Cut Lightly-Weathered Waxed Copper Stairs",
           "Waxed Exposed Copper Stairs",
           "Exposed Waxed Copper Stairs",
           "Waxed Lightly Weathered Copper Stairs",
           "Lightly Weathered Waxed Copper Stairs",
+          "Waxed Lightly-Weathered Copper Stairs",
+          "Lightly-Weathered Waxed Copper Stairs",
           "Waxed Exposed Cut Copper Stair",
           "Exposed Waxed Cut Copper Stair",
           "Exposed Cut Waxed Copper Stair",
           "Waxed Lightly Weathered Cut Copper Stair",
           "Lightly Weathered Waxed Cut Copper Stair",
           "Lightly Weathered Cut Waxed Copper Stair",
+          "Waxed Lightly-Weathered Cut Copper Stair",
+          "Lightly-Weathered Waxed Cut Copper Stair",
+          "Lightly-Weathered Cut Waxed Copper Stair",
           "Waxed Cut Exposed Copper Stair",
           "Cut Waxed Exposed Copper Stair",
           "Cut Exposed Waxed Copper Stair",
           "Waxed Cut Lightly Weathered Copper Stair",
           "Cut Waxed Lightly Weathered Copper Stair",
           "Cut Lightly Weathered Waxed Copper Stair",
+          "Waxed Cut Lightly-Weathered Copper Stair",
+          "Cut Waxed Lightly-Weathered Copper Stair",
+          "Cut Lightly-Weathered Waxed Copper Stair",
           "Waxed Exposed Copper Stair",
           "Exposed Waxed Copper Stair",
           "Waxed Lightly Weathered Copper Stair",
-          "Lightly Weathered Waxed Copper Stair"
+          "Lightly Weathered Waxed Copper Stair",
+          "Waxed Lightly-Weathered Copper Stair",
+          "Lightly-Weathered Waxed Copper Stair"
         ],
         "display_name": "Waxed Exposed Cut Copper Stairs"
       }
     },
     "properties": {
+      "image_key": "Exposed Cut Copper Stairs",
       "version": "1.17"
     }
   },
@@ -16623,6 +16800,7 @@
       }
     },
     "properties": {
+      "image_key": "Oxidized Copper",
       "version": "1.17"
     }
   },
@@ -16652,6 +16830,7 @@
       }
     },
     "properties": {
+      "image_key": "Oxidized Cut Copper",
       "version": "1.17"
     }
   },
@@ -16671,6 +16850,7 @@
       }
     },
     "properties": {
+      "image_key": "Oxidized Cut Copper Slab",
       "version": "1.17"
     }
   },
@@ -16698,6 +16878,7 @@
       }
     },
     "properties": {
+      "image_key": "Oxidized Cut Copper Stairs",
       "version": "1.17"
     }
   },
@@ -16727,6 +16908,7 @@
       }
     },
     "properties": {
+      "image_key": "Weathered Copper",
       "version": "1.17"
     }
   },
@@ -16792,6 +16974,7 @@
       }
     },
     "properties": {
+      "image_key": "Weathered Cut Copper",
       "version": "1.17"
     }
   },
@@ -16827,6 +17010,7 @@
       }
     },
     "properties": {
+      "image_key": "Weathered Cut Copper Slab",
       "version": "1.17"
     }
   },
@@ -16886,6 +17070,7 @@
       }
     },
     "properties": {
+      "image_key": "Weathered Cut Copper Stairs",
       "version": "1.17"
     }
   },
@@ -17616,7 +17801,12 @@
       "en_US": {
         "search_names": [
           "Potted Mangrove Sapling",
-          "Potted Propagule"
+          "Potted Propagule",
+          "Potted Mangrove",
+          "Mangrove Propagule Pot",
+          "Mangrove Sapling Pot",
+          "Propagule Pot",
+          "Mangrove Pot"
         ],
         "display_name": "Potted Mangrove Propagule"
       }
@@ -19185,7 +19375,14 @@
       "en_US": {
         "search_names": [
           "Potted Pink Sapling",
-          "Potted Sakura Sapling"
+          "Potted Sakura Sapling",
+          "Potted Cherry",
+          "Potted Sakura",
+          "Cherry Sapling Pot",
+          "Pink Sapling Pot",
+          "Sakura Sapling Pot",
+          "Cherry Pot",
+          "Sakura Pot"
         ],
         "display_name": "Potted Cherry Sapling"
       }
@@ -19199,7 +19396,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Potted Torch Flower"
+          "Potted Torch Flower",
+          "Torchflower Pot",
+          "Torch Flower Pot"
         ],
         "display_name": "Potted Torchflower"
       }
@@ -20338,6 +20537,1056 @@
       "version": "1.20"
     }
   },
+  "minecraft.breeze_spawn_egg": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Spawn Breeze",
+          "Breeze Egg"
+        ],
+        "display_name": "Breeze Spawn Egg"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.chiseled_copper": {
+    "lang": {
+      "en_US": {
+        "display_name": "Chiseled Copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.chiseled_tuff": {
+    "lang": {
+      "en_US": {
+        "display_name": "Chiseled Tuff"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.chiseled_tuff_bricks": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Chiseled Tuff Brick"
+        ],
+        "display_name": "Chiseled Tuff Bricks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.copper_bulb": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Copper Lamp",
+          "Copper Light",
+          "Copper Flopper",
+          "Copper-Flopper",
+          "Cop Flop",
+          "Cop-Flop",
+          "Copflop"
+        ],
+        "display_name": "Copper Bulb"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.copper_door": {
+    "lang": {
+      "en_US": {
+        "display_name": "Copper Door"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.copper_grate": {
+    "lang": {
+      "en_US": {
+        "display_name": "Copper Grate"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.copper_trapdoor": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Copper Trap Door"
+        ],
+        "display_name": "Copper Trapdoor"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.crafter": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Autocrafter",
+          "Auto Crafter",
+          "Autocrafting Table",
+          "Auto Crafting Table",
+          "Auto Workbench",
+          "Auto Crafting Bench"
+        ],
+        "display_name": "Crafter"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.exposed_chiseled_copper": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Lightly-Weathered Chiseled Copper",
+          "Lightly Weathered Chiseled Copper",
+          "Chiseled Exposed Copper",
+          "Chiseled Lightly-Weathered Copper",
+          "Chiseled Lightly Weathered Copper"
+        ],
+        "display_name": "Exposed Chiseled Copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.exposed_copper_bulb": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Exposed Copper Lamp",
+          "Exposed Copper Light",
+          "Exposed Copper Flopper",
+          "Exposed Copper-Flopper",
+          "Exposed Cop Flop",
+          "Exposed Cop-Flop",
+          "Exposed Copflop",
+          "Lightly-Weathered Copper Bulb",
+          "Lightly-Weathered Copper Lamp",
+          "Lightly-Weathered Copper Light",
+          "Lightly-Weathered Copper Flopper",
+          "Lightly-Weathered Copper-Flopper",
+          "Lightly-Weathered Cop Flop",
+          "Lightly-Weathered Cop-Flop",
+          "Lightly-Weathered Copflop",
+          "Lightly Weathered Copper Bulb",
+          "Lightly Weathered Copper Lamp",
+          "Lightly Weathered Copper Light",
+          "Lightly Weathered Copper Flopper",
+          "Lightly Weathered Copper-Flopper",
+          "Lightly Weathered Cop Flop",
+          "Lightly Weathered Cop-Flop",
+          "Lightly Weathered Copflop"
+        ],
+        "display_name": "Exposed Copper Bulb"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.exposed_copper_door": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Lightly-Weathered Copper Door",
+          "Lightly Weathered Copper Door"
+        ],
+        "display_name": "Exposed Copper Door"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.exposed_copper_grate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Lightly-Weathered Copper Grate",
+          "Lightly Weathered Copper Grate"
+        ],
+        "display_name": "Exposed Copper Grate"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.exposed_copper_trapdoor": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Exposed Copper Trap Door",
+          "Lightly-Weathered Copper Trapdoor",
+          "Lightly-Weathered Copper Trap Door",
+          "Lightly Weathered Copper Trapdoor",
+          "Lightly Weathered Copper Trap Door"
+        ],
+        "display_name": "Exposed Copper Trapdoor"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.oxidized_chiseled_copper": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Chiseled Oxidized Copper"
+        ],
+        "display_name": "Oxidized Chiseled Copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.oxidized_copper_bulb": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Oxidized Copper Lamp",
+          "Oxidized Copper Light",
+          "Oxidized Copper Flopper",
+          "Oxidized Copper-Flopper",
+          "Oxidized Cop Flop",
+          "Oxidized Cop-Flop",
+          "Oxidized Copflop"
+        ],
+        "display_name": "Oxidized Copper Bulb"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.oxidized_copper_door": {
+    "lang": {
+      "en_US": {
+        "display_name": "Oxidized Copper Door"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.oxidized_copper_grate": {
+    "lang": {
+      "en_US": {
+        "display_name": "Oxidized Copper Grate"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.oxidized_copper_trapdoor": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Oxidized Copper Trap Door"
+        ],
+        "display_name": "Oxidized Copper Trapdoor"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.polished_tuff": {
+    "lang": {
+      "en_US": {
+        "display_name": "Polished Tuff"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.polished_tuff_slab": {
+    "lang": {
+      "en_US": {
+        "display_name": "Polished Tuff Slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.polished_tuff_stairs": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Polished Tuff Stair"
+        ],
+        "display_name": "Polished Tuff Stairs"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.polished_tuff_wall": {
+    "lang": {
+      "en_US": {
+        "display_name": "Polished Tuff Wall"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.trial_key": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Limbo Key"
+        ],
+        "display_name": "Trial Key"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.trial_spawner": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Trial Mob Spawner",
+          "Trial Monster Spawner"
+        ],
+        "display_name": "Trial Spawner"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.tuff_brick_slab": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Tuff Bricks Slab"
+        ],
+        "display_name": "Tuff Brick Slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.tuff_brick_stairs": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Tuff Brick Stair",
+          "Tuff Bricks Stairs",
+          "Tuff Bricks Stair"
+        ],
+        "display_name": "Tuff Brick Stairs"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.tuff_brick_wall": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Tuff Bricks Wall"
+        ],
+        "display_name": "Tuff Brick Wall"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.tuff_bricks": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Tuff Bricks"
+        ],
+        "display_name": "Tuff Bricks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.tuff_slab": {
+    "lang": {
+      "en_US": {
+        "display_name": "Tuff Slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.tuff_stairs": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Tuff Stair"
+        ],
+        "display_name": "Tuff Stairs"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.tuff_wall": {
+    "lang": {
+      "en_US": {
+        "display_name": "Tuff Wall"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_chiseled_copper": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Chiseled Waxed Copper"
+        ],
+        "display_name": "Waxed Chiseled Copper"
+      }
+    },
+    "properties": {
+      "image_key": "Chiseled Copper",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_copper_bulb": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Copper Lamp",
+          "Waxed Copper Light",
+          "Waxed Copper Flopper",
+          "Waxed Copper-Flopper",
+          "Waxed Cop Flop",
+          "Waxed Cop-Flop",
+          "Waxed Copflop"
+        ],
+        "display_name": "Waxed Copper Bulb"
+      }
+    },
+    "properties": {
+      "image_key": "Copper Bulb",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_copper_door": {
+    "lang": {
+      "en_US": {
+        "display_name": "Waxed Copper Door"
+      }
+    },
+    "properties": {
+      "image_key": "Copper Door",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_copper_grate": {
+    "lang": {
+      "en_US": {
+        "display_name": "Waxed Copper Grate"
+      }
+    },
+    "properties": {
+      "image_key": "Copper Grate",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_copper_trapdoor": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Copper Trap Door"
+        ],
+        "display_name": "Waxed Copper Trapdoor"
+      }
+    },
+    "properties": {
+      "image_key": "Copper Trapdoor",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_exposed_chiseled_copper": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Lightly-Weathered Chiseled Copper",
+          "Waxed Lightly Weathered Chiseled Copper",
+          "Waxed Chiseled Exposed Copper",
+          "Waxed Chiseled Lightly-Weathered Copper",
+          "Waxed Chiseled Lightly Weathered Copper",
+          "Exposed Waxed Chiseled Copper",
+          "Lightly-Weathered Waxed Chiseled Copper",
+          "Lightly Weathered Waxed Chiseled Copper",
+          "Chiseled Waxed Exposed Copper",
+          "Chiseled Waxed Lightly-Weathered Copper",
+          "Chiseled Waxed Lightly Weathered Copper",
+          "Exposed Chiseled Waxed Copper",
+          "Lightly-Weathered Chiseled Waxed Copper",
+          "Lightly Weathered Chiseled Waxed Copper",
+          "Chiseled Exposed Waxed Copper",
+          "Chiseled Lightly-Weathered Waxed Copper",
+          "Chiseled Lightly Weathered Waxed Copper"
+        ],
+        "display_name": "Waxed Exposed Chiseled Copper"
+      }
+    },
+    "properties": {
+      "image_key": "Exposed Chiseled Copper",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_exposed_copper_bulb": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Exposed Copper Lamp",
+          "Waxed Exposed Copper Light",
+          "Waxed Exposed Copper Flopper",
+          "Waxed Exposed Copper-Flopper",
+          "Waxed Exposed Cop Flop",
+          "Waxed Exposed Cop-Flop",
+          "Waxed Exposed Copflop",
+          "Waxed Lightly-Weathered Copper Bulb",
+          "Waxed Lightly-Weathered Copper Lamp",
+          "Waxed Lightly-Weathered Copper Light",
+          "Waxed Lightly-Weathered Copper Flopper",
+          "Waxed Lightly-Weathered Copper-Flopper",
+          "Waxed Lightly-Weathered Cop Flop",
+          "Waxed Lightly-Weathered Cop-Flop",
+          "Waxed Lightly-Weathered Copflop",
+          "Waxed Lightly Weathered Copper Bulb",
+          "Waxed Lightly Weathered Copper Lamp",
+          "Waxed Lightly Weathered Copper Light",
+          "Waxed Lightly Weathered Copper Flopper",
+          "Waxed Lightly Weathered Copper-Flopper",
+          "Waxed Lightly Weathered Cop Flop",
+          "Waxed Lightly Weathered Cop-Flop",
+          "Waxed Lightly Weathered Copflop",
+          "Exposed Waxed Copper Bulb",
+          "Exposed Waxed Copper Lamp",
+          "Exposed Waxed Copper Light",
+          "Exposed Waxed Copper Flopper",
+          "Exposed Waxed Copper-Flopper",
+          "Exposed Waxed Cop Flop",
+          "Exposed Waxed Cop-Flop",
+          "Exposed Waxed Copflop",
+          "Lightly-Weathered Waxed Copper Bulb",
+          "Lightly-Weathered Waxed Copper Lamp",
+          "Lightly-Weathered Waxed Copper Light",
+          "Lightly-Weathered Waxed Copper Flopper",
+          "Lightly-Weathered Waxed Copper-Flopper",
+          "Lightly-Weathered Waxed Cop Flop",
+          "Lightly-Weathered Waxed Cop-Flop",
+          "Lightly-Weathered Waxed Copflop",
+          "Lightly Weathered Waxed Copper Bulb",
+          "Lightly Weathered Waxed Copper Lamp",
+          "Lightly Weathered Waxed Copper Light",
+          "Lightly Weathered Waxed Copper Flopper",
+          "Lightly Weathered Waxed Copper-Flopper",
+          "Lightly Weathered Waxed Cop Flop",
+          "Lightly Weathered Waxed Cop-Flop",
+          "Lightly Weathered Waxed Copflop"
+        ],
+        "display_name": "Waxed Exposed Copper Bulb"
+      }
+    },
+    "properties": {
+      "image_key": "Exposed Copper Bulb",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_exposed_copper_door": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Lightly-Weathered Copper Door",
+          "Waxed Lightly Weathered Copper Door",
+          "Exposed Waxed Copper Door",
+          "Lightly-Weathered Waxed Copper Door",
+          "Lightly Weathered Waxed Copper Door"
+        ],
+        "display_name": "Waxed Exposed Copper Door"
+      }
+    },
+    "properties": {
+      "image_key": "Exposed Copper Door",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_exposed_copper_grate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Lightly-Weathered Copper Grate",
+          "Waxed Lightly Weathered Copper Grate",
+          "Exposed Waxed Copper Grate",
+          "Lightly-Weathered Waxed Copper Grate",
+          "Lightly Weathered Waxed Copper Grate"
+        ],
+        "display_name": "Waxed Exposed Copper Grate"
+      }
+    },
+    "properties": {
+      "image_key": "Exposed Copper Grate",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_exposed_copper_trapdoor": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Exposed Copper Trap Door",
+          "Waxed Lightly-Weathered Copper Trapdoor",
+          "Waxed Lightly-Weathered Copper Trap Door",
+          "Waxed Lightly Weathered Copper Trapdoor",
+          "Waxed Lightly Weathered Copper Trap Door",
+          "Exposed Waxed Copper Trapdoor",
+          "Exposed Waxed Copper Trap Door",
+          "Lightly-Weathered Waxed Copper Trapdoor",
+          "Lightly-Weathered Waxed Copper Trap Door",
+          "Lightly Weathered Waxed Copper Trapdoor",
+          "Lightly Weathered Waxed Copper Trap Door"
+        ],
+        "display_name": "Waxed Exposed Copper Trapdoor"
+      }
+    },
+    "properties": {
+      "image_key": "Exposed Copper Trapdoor",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_oxidized_chiseled_copper": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Chiseled Oxidized Copper",
+          "Oxidized Waxed Chiseled Copper",
+          "Chiseled Waxed Oxidized Copper",
+          "Oxidized Chiseled Waxed Copper",
+          "Chiseled Oxidized Waxed Copper"
+        ],
+        "display_name": "Waxed Oxidized Chiseled Copper"
+      }
+    },
+    "properties": {
+      "image_key": "Oxidized Chiseled Copper",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_oxidized_copper_bulb": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Oxidized Copper Lamp",
+          "Waxed Oxidized Copper Light",
+          "Waxed Oxidized Copper Flopper",
+          "Waxed Oxidized Copper-Flopper",
+          "Waxed Oxidized Cop Flop",
+          "Waxed Oxidized Cop-Flop",
+          "Waxed Oxidized Copflop",
+          "Oxidized Waxed Copper Bulb",
+          "Oxidized Waxed Copper Lamp",
+          "Oxidized Waxed Copper Light",
+          "Oxidized Waxed Copper Flopper",
+          "Oxidized Waxed Copper-Flopper",
+          "Oxidized Waxed Cop Flop",
+          "Oxidized Waxed Cop-Flop",
+          "Oxidized Waxed Copflop"
+        ],
+        "display_name": "Waxed Oxidized Copper Bulb"
+      }
+    },
+    "properties": {
+      "image_key": "Oxidized Copper Bulb",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_oxidized_copper_door": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Oxidized Waxed Copper Door"
+        ],
+        "display_name": "Waxed Oxidized Copper Door"
+      }
+    },
+    "properties": {
+      "image_key": "Oxidized Copper Door",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_oxidized_copper_grate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Oxidized Waxed Copper Grate"
+        ],
+        "display_name": "Waxed Oxidized Copper Grate"
+      }
+    },
+    "properties": {
+      "image_key": "Oxidized Copper Grate",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_oxidized_copper_trapdoor": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Oxidized Copper Trap Door",
+          "Oxidized Waxed Copper Trapdoor",
+          "Oxidized Waxed Copper Trap Door"
+        ],
+        "display_name": "Waxed Oxidized Copper Trapdoor"
+      }
+    },
+    "properties": {
+      "image_key": "Oxidized Copper Trapdoor",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_weathered_chiseled_copper": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Semi-Weathered Chiseled Copper",
+          "Waxed Semi Weathered Chiseled Copper",
+          "Waxed Chiseled Weathered Copper",
+          "Waxed Chiseled Semi-Weathered Copper",
+          "Waxed Chiseled Semi Weathered Copper",
+          "Weathered Waxed Chiseled Copper",
+          "Semi-Weathered Waxed Chiseled Copper",
+          "Semi Weathered Waxed Chiseled Copper",
+          "Chiseled Waxed Weathered Copper",
+          "Chiseled Waxed Semi-Weathered Copper",
+          "Chiseled Waxed Semi Weathered Copper",
+          "Weathered Chiseled Waxed Copper",
+          "Semi-Weathered Chiseled Waxed Copper",
+          "Semi Weathered Chiseled Waxed Copper",
+          "Chiseled Weathered Waxed Copper",
+          "Chiseled Semi-Weathered Waxed Copper",
+          "Chiseled Semi Weathered Waxed Copper"
+        ],
+        "display_name": "Waxed Weathered Chiseled Copper"
+      }
+    },
+    "properties": {
+      "image_key": "Weathered Chiseled Copper",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_weathered_copper_bulb": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Weathered Copper Lamp",
+          "Waxed Weathered Copper Light",
+          "Waxed Weathered Copper Flopper",
+          "Waxed Weathered Copper-Flopper",
+          "Waxed Weathered Cop Flop",
+          "Waxed Weathered Cop-Flop",
+          "Waxed Weathered Copflop",
+          "Waxed Semi-Weathered Copper Bulb",
+          "Waxed Semi-Weathered Copper Lamp",
+          "Waxed Semi-Weathered Copper Light",
+          "Waxed Semi-Weathered Copper Flopper",
+          "Waxed Semi-Weathered Copper-Flopper",
+          "Waxed Semi-Weathered Cop Flop",
+          "Waxed Semi-Weathered Cop-Flop",
+          "Waxed Semi-Weathered Copflop",
+          "Waxed Semi Weathered Copper Bulb",
+          "Waxed Semi Weathered Copper Lamp",
+          "Waxed Semi Weathered Copper Light",
+          "Waxed Semi Weathered Copper Flopper",
+          "Waxed Semi Weathered Copper-Flopper",
+          "Waxed Semi Weathered Cop Flop",
+          "Waxed Semi Weathered Cop-Flop",
+          "Waxed Semi Weathered Copflop",
+          "Weathered Waxed Copper Bulb",
+          "Weathered Waxed Copper Lamp",
+          "Weathered Waxed Copper Light",
+          "Weathered Waxed Copper Flopper",
+          "Weathered Waxed Copper-Flopper",
+          "Weathered Waxed Cop Flop",
+          "Weathered Waxed Cop-Flop",
+          "Weathered Waxed Copflop",
+          "Semi-Weathered Waxed Copper Bulb",
+          "Semi-Weathered Waxed Copper Lamp",
+          "Semi-Weathered Waxed Copper Light",
+          "Semi-Weathered Waxed Copper Flopper",
+          "Semi-Weathered Waxed Copper-Flopper",
+          "Semi-Weathered Waxed Cop Flop",
+          "Semi-Weathered Waxed Cop-Flop",
+          "Semi-Weathered Waxed Copflop",
+          "Semi Weathered Waxed Copper Bulb",
+          "Semi Weathered Waxed Copper Lamp",
+          "Semi Weathered Waxed Copper Light",
+          "Semi Weathered Waxed Copper Flopper",
+          "Semi Weathered Waxed Copper-Flopper",
+          "Semi Weathered Waxed Cop Flop",
+          "Semi Weathered Waxed Cop-Flop",
+          "Semi Weathered Waxed Copflop"
+        ],
+        "display_name": "Waxed Weathered Copper Bulb"
+      }
+    },
+    "properties": {
+      "image_key": "Weathered Copper Bulb",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_weathered_copper_door": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Semi-Weathered Copper Door",
+          "Waxed Semi Weathered Copper Door",
+          "Weathered Waxed Copper Door",
+          "Semi-Weathered Waxed Copper Door",
+          "Semi Weathered Waxed Copper Door"
+        ],
+        "display_name": "Waxed Weathered Copper Door"
+      }
+    },
+    "properties": {
+      "image_key": "Weathered Copper Door",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_weathered_copper_grate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Semi-Weathered Copper Grate",
+          "Waxed Semi Weathered Copper Grate",
+          "Weathered Waxed Copper Grate",
+          "Semi-Weathered Waxed Copper Grate",
+          "Semi Weathered Waxed Copper Grate"
+        ],
+        "display_name": "Waxed Weathered Copper Grate"
+      }
+    },
+    "properties": {
+      "image_key": "Weathered Copper Grate",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.waxed_weathered_copper_trapdoor": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Waxed Weathered Copper Trap Door",
+          "Waxed Semi-Weathered Copper Trapdoor",
+          "Waxed Semi-Weathered Copper Trap Door",
+          "Waxed Semi Weathered Copper Trapdoor",
+          "Waxed Semi Weathered Copper Trap Door",
+          "Weathered Waxed Copper Trapdoor",
+          "Weathered Waxed Copper Trap Door",
+          "Semi-Weathered Waxed Copper Trapdoor",
+          "Semi-Weathered Waxed Copper Trap Door",
+          "Semi Weathered Waxed Copper Trapdoor",
+          "Semi Weathered Waxed Copper Trap Door"
+        ],
+        "display_name": "Waxed Weathered Copper Trapdoor"
+      }
+    },
+    "properties": {
+      "image_key": "Weathered Copper Trapdoor",
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.weathered_chiseled_copper": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Semi-Weathered Chiseled Copper",
+          "Semi Weathered Chiseled Copper",
+          "Chiseled Weathered Copper",
+          "Chiseled Semi-Weathered Copper",
+          "Chiseled Semi Weathered Copper"
+        ],
+        "display_name": "Weathered Chiseled Copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.weathered_copper_bulb": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Weathered Copper Lamp",
+          "Weathered Copper Light",
+          "Weathered Copper Flopper",
+          "Weathered Copper-Flopper",
+          "Weathered Cop Flop",
+          "Weathered Cop-Flop",
+          "Weathered Copflop",
+          "Semi-Weathered Copper Bulb",
+          "Semi-Weathered Copper Lamp",
+          "Semi-Weathered Copper Light",
+          "Semi-Weathered Copper Flopper",
+          "Semi-Weathered Copper-Flopper",
+          "Semi-Weathered Cop Flop",
+          "Semi-Weathered Cop-Flop",
+          "Semi-Weathered Copflop",
+          "Semi Weathered Copper Bulb",
+          "Semi Weathered Copper Lamp",
+          "Semi Weathered Copper Light",
+          "Semi Weathered Copper Flopper",
+          "Semi Weathered Copper-Flopper",
+          "Semi Weathered Cop Flop",
+          "Semi Weathered Cop-Flop",
+          "Semi Weathered Copflop"
+        ],
+        "display_name": "Weathered Copper Bulb"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.weathered_copper_door": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Semi-Weathered Copper Door",
+          "Semi Weathered Copper Door"
+        ],
+        "display_name": "Weathered Copper Door"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.weathered_copper_grate": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Semi-Weathered Copper Grate",
+          "Semi Weathered Copper Grate"
+        ],
+        "display_name": "Weathered Copper Grate"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "minecraft.weathered_copper_trapdoor": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Weathered Copper Trap Door",
+          "Semi-Weathered Copper Trapdoor",
+          "Semi-Weathered Copper Trap Door",
+          "Semi Weathered Copper Trapdoor",
+          "Semi Weathered Copper Trap Door"
+        ],
+        "display_name": "Weathered Copper Trapdoor"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
   "minecraft.lingering_potion.effect.awkward": {
     "lang": {
       "en_US": {
@@ -20349,6 +21598,7 @@
       }
     },
     "properties": {
+      "image_key": "Lingering Water Bottle",
       "actual_id": "minecraft.lingering_potion",
       "id": 441,
       "version": "1.9"
@@ -20822,6 +22072,7 @@
       }
     },
     "properties": {
+      "image_key": "Lingering Water Bottle",
       "actual_id": "minecraft.lingering_potion",
       "id": 441,
       "version": "1.9"
@@ -20847,7 +22098,7 @@
       }
     },
     "properties": {
-      "image_key": "Mundane Lingering Potion",
+      "image_key": "Lingering Water Bottle",
       "actual_id": "minecraft.lingering_potion",
       "id": 441,
       "version": "1.9"
@@ -21525,6 +22776,7 @@
       }
     },
     "properties": {
+      "image_key": "Lingering Water Bottle",
       "actual_id": "minecraft.lingering_potion",
       "id": 441
     }
@@ -21798,6 +23050,7 @@
     },
     "properties": {
       "data": 16,
+      "image_key": "Water Bottle",
       "actual_id": "minecraft.potion",
       "id": 373
     }
@@ -22160,6 +23413,7 @@
     },
     "properties": {
       "data": 8192,
+      "image_key": "Water Bottle",
       "actual_id": "minecraft.potion",
       "id": 373
     }
@@ -22179,7 +23433,7 @@
     },
     "properties": {
       "data": 64,
-      "image_key": "Mundane Potion",
+      "image_key": "Water Bottle",
       "actual_id": "minecraft.potion",
       "id": 373
     }
@@ -22707,6 +23961,7 @@
     },
     "properties": {
       "data": 32,
+      "image_key": "Water Bottle",
       "actual_id": "minecraft.potion",
       "id": 373
     }
@@ -22917,6 +24172,7 @@
       }
     },
     "properties": {
+      "image_key": "Splash Water Bottle",
       "actual_id": "minecraft.splash_potion",
       "id": 438,
       "version": "1.9"
@@ -23410,6 +24666,7 @@
       }
     },
     "properties": {
+      "image_key": "Splash Water Bottle",
       "actual_id": "minecraft.splash_potion",
       "id": 438,
       "version": "1.9"
@@ -23435,7 +24692,7 @@
       }
     },
     "properties": {
-      "image_key": "Mundane Splash Potion",
+      "image_key": "Splash Water Bottle",
       "actual_id": "minecraft.splash_potion",
       "id": 438,
       "version": "1.9"
@@ -24145,6 +25402,7 @@
       }
     },
     "properties": {
+      "image_key": "Splash Water Bottle",
       "actual_id": "minecraft.splash_potion",
       "id": 438,
       "version": "1.9"
@@ -24433,6 +25691,7 @@
       }
     },
     "properties": {
+      "image_key": "Arrow of Splashing",
       "actual_id": "minecraft.tipped_arrow",
       "id": 440,
       "version": "1.9"
@@ -24957,6 +26216,7 @@
       }
     },
     "properties": {
+      "image_key": "Arrow of Splashing",
       "actual_id": "minecraft.tipped_arrow",
       "id": 440,
       "version": "1.9"
@@ -24980,7 +26240,7 @@
       }
     },
     "properties": {
-      "image_key": "Tipped Arrow",
+      "image_key": "Arrow of Splashing",
       "actual_id": "minecraft.tipped_arrow",
       "id": 440,
       "version": "1.9"
@@ -25739,6 +26999,7 @@
       }
     },
     "properties": {
+      "image_key": "Arrow of Splashing",
       "actual_id": "minecraft.tipped_arrow",
       "id": 440
     }

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>5.0.0-beta.17</version>
+      <version>5.0.0-beta.18</version>
       <exclusions>
         <exclusion>
           <groupId>club.minnced</groupId>
@@ -57,12 +57,12 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.43.2.2</version>
+      <version>3.44.1.0</version>
     </dependency>
     <dependency>
       <groupId>dnsjava</groupId>
       <artifactId>dnsjava</artifactId>
-      <version>3.5.2</version>
+      <version>3.5.3</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.17.3</version>
+  <version>0.17.4</version>
 
   <repositories>
     <repository>

--- a/recipes.json
+++ b/recipes.json
@@ -10,11 +10,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true
-    },
-    "group": "planks"
+    }
   },
   "acacia_slab": {
     "result": {
@@ -25,13 +23,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:acacia_planks"
       }
-    },
-    "group": "wooden_slab"
+    }
   },
   "acacia_stairs": {
     "result": {
@@ -44,13 +40,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:acacia_planks"
       }
-    },
-    "group": "wooden_stairs"
+    }
   },
   "activator_rail": {
     "result": {
@@ -63,7 +57,6 @@
       "XSX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:redstone_torch"
@@ -221,7 +214,6 @@
       "iii"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "I": {
         "item": "minecraft:iron_block"
@@ -242,7 +234,6 @@
       "Y"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -271,9 +262,7 @@
       "item": "minecraft:potato"
     },
     "type": "minecraft:smelting",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 200
+    "experience": 0.35
   },
   "baked_potato_from_campfire_cooking": {
     "result": "minecraft:baked_potato",
@@ -281,9 +270,7 @@
       "item": "minecraft:potato"
     },
     "type": "minecraft:campfire_cooking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 600
+    "experience": 0.35
   },
   "baked_potato_from_smoking": {
     "result": "minecraft:baked_potato",
@@ -291,9 +278,7 @@
       "item": "minecraft:potato"
     },
     "type": "minecraft:smoking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 100
+    "experience": 0.35
   },
   "beacon": {
     "result": {
@@ -305,7 +290,6 @@
       "OOO"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "S": {
         "item": "minecraft:nether_star"
@@ -329,11 +313,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true
-    },
-    "group": "planks"
+    }
   },
   "birch_slab": {
     "result": {
@@ -344,13 +326,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:birch_planks"
       }
-    },
-    "group": "wooden_slab"
+    }
   },
   "birch_stairs": {
     "result": {
@@ -363,13 +343,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:birch_planks"
       }
-    },
-    "group": "wooden_stairs"
+    }
   },
   "black_banner": {
     "result": {
@@ -381,7 +359,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:black_wool"
@@ -389,8 +366,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "black_carpet": {
     "result": {
@@ -401,13 +377,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:black_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "black_stained_glass_legacy": {
     "result": {
@@ -430,8 +404,7 @@
     },
     "properties": {
       "removed": "1.14"
-    },
-    "group": "stained_stained_glass"
+    }
   },
   "black_stained_glass_pane": {
     "result": {
@@ -443,13 +416,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:black_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "black_stained_glass_pane_from_glass_pane_legacy": {
     "result": {
@@ -472,8 +443,7 @@
     },
     "properties": {
       "removed": "1.14"
-    },
-    "group": "stained_stained_glass_pane"
+    }
   },
   "black_terracotta_legacy": {
     "result": {
@@ -496,8 +466,7 @@
     },
     "properties": {
       "removed": "1.14"
-    },
-    "group": "stained_terracotta"
+    }
   },
   "black_wool_legacy": {
     "result": {
@@ -514,8 +483,7 @@
     "type": "minecraft:crafting_shapeless",
     "properties": {
       "removed": "1.14"
-    },
-    "group": "wool"
+    }
   },
   "blaze_powder": {
     "result": {
@@ -527,8 +495,7 @@
         "item": "minecraft:blaze_rod"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "blue_banner": {
     "result": {
@@ -540,7 +507,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:blue_wool"
@@ -548,8 +514,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "blue_carpet": {
     "result": {
@@ -560,13 +525,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:blue_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "blue_stained_glass_legacy": {
     "result": {
@@ -589,8 +552,7 @@
     },
     "properties": {
       "removed": "1.14"
-    },
-    "group": "stained_stained_glass"
+    }
   },
   "blue_stained_glass_pane": {
     "result": {
@@ -602,13 +564,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:blue_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "blue_stained_glass_pane_from_glass_pane_legacy": {
     "result": {
@@ -631,8 +591,7 @@
     },
     "properties": {
       "removed": "1.14"
-    },
-    "group": "stained_stained_glass_pane"
+    }
   },
   "blue_terracotta_legacy": {
     "result": {
@@ -655,8 +614,7 @@
     },
     "properties": {
       "removed": "1.14"
-    },
-    "group": "stained_terracotta"
+    }
   },
   "blue_wool_legacy": {
     "result": {
@@ -673,8 +631,7 @@
     "type": "minecraft:crafting_shapeless",
     "properties": {
       "removed": "1.14"
-    },
-    "group": "wool"
+    }
   },
   "bone_meal": {
     "result": {
@@ -686,9 +643,7 @@
         "item": "minecraft:bone"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "bonemeal"
+    "type": "minecraft:crafting_shapeless"
   },
   "book": {
     "result": {
@@ -708,8 +663,7 @@
         "item": "minecraft:leather"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "bookshelf": {
     "result": {
@@ -721,7 +675,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "tag": "minecraft:planks"
@@ -744,7 +697,6 @@
       " #X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -764,7 +716,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "tag": "minecraft:planks"
@@ -782,7 +733,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:wheat"
@@ -798,7 +748,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "B": {
         "item": "minecraft:blaze_rod"
@@ -814,9 +763,7 @@
       "item": "minecraft:clay_ball"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
-    "experience": 0.3,
-    "cookingtime": 200
+    "experience": 0.3
   },
   "brick_slab": {
     "result": {
@@ -827,7 +774,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:bricks"
@@ -845,7 +791,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:bricks"
@@ -861,7 +806,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:brick"
@@ -878,7 +822,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:brown_wool"
@@ -886,8 +829,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "brown_carpet": {
     "result": {
@@ -898,13 +840,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:brown_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "brown_stained_glass_legacy": {
     "result": {
@@ -927,8 +867,7 @@
     },
     "properties": {
       "removed": "1.14"
-    },
-    "group": "stained_stained_glass"
+    }
   },
   "brown_stained_glass_pane": {
     "result": {
@@ -940,13 +879,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:brown_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "brown_stained_glass_pane_from_glass_pane_legacy": {
     "result": {
@@ -969,8 +906,7 @@
     },
     "properties": {
       "removed": "1.14"
-    },
-    "group": "stained_stained_glass_pane"
+    }
   },
   "brown_terracotta_legacy": {
     "result": {
@@ -993,8 +929,7 @@
     },
     "properties": {
       "removed": "1.14"
-    },
-    "group": "stained_terracotta"
+    }
   },
   "brown_wool_legacy": {
     "result": {
@@ -1011,8 +946,7 @@
     "type": "minecraft:crafting_shapeless",
     "properties": {
       "removed": "1.14"
-    },
-    "group": "wool"
+    }
   },
   "bucket": {
     "result": {
@@ -1023,7 +957,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:iron_ingot"
@@ -1040,7 +973,6 @@
       "CCC"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "lang": {
       "en_US": {
         "notes": "Empty buckets are left after crafting."
@@ -1070,7 +1002,6 @@
       " X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:fishing_rod"
@@ -1090,7 +1021,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:iron_ingot"
@@ -1177,12 +1107,10 @@
       "tag": "minecraft:logs_that_burn"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 0.15,
     "properties": {
       "animated": true
-    },
-    "cookingtime": 200
+    }
   },
   "chest": {
     "result": {
@@ -1194,7 +1122,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "tag": "minecraft:planks"
@@ -1217,7 +1144,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "lang": {
       "en_US": {
         "notes": "Before 1.19, recipe is shaped."
@@ -1233,7 +1159,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:quartz_slab"
@@ -1249,7 +1174,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:red_sandstone_slab"
@@ -1265,7 +1189,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:sandstone_slab"
@@ -1281,7 +1204,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:clay_ball"
@@ -1298,7 +1220,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:gold_ingot"
@@ -1318,8 +1239,7 @@
         "item": "minecraft:coal_block"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "coal_block": {
     "result": {
@@ -1331,7 +1251,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:coal"
@@ -1344,10 +1263,7 @@
       "item": "minecraft:coal_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
-    "experience": 0.1,
-    "cookingtime": 200,
-    "group": "coal"
+    "experience": 0.1
   },
   "cobblestone_stairs": {
     "result": {
@@ -1360,7 +1276,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:cobblestone"
@@ -1377,7 +1292,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:cobblestone"
@@ -1394,7 +1308,6 @@
       "III"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:redstone_torch"
@@ -1417,7 +1330,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:iron_ingot"
@@ -1433,9 +1345,7 @@
       "item": "minecraft:beef"
     },
     "type": "minecraft:smelting",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 200
+    "experience": 0.35
   },
   "cooked_beef_from_campfire_cooking": {
     "result": "minecraft:cooked_beef",
@@ -1443,9 +1353,7 @@
       "item": "minecraft:beef"
     },
     "type": "minecraft:campfire_cooking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 600
+    "experience": 0.35
   },
   "cooked_beef_from_smoking": {
     "result": "minecraft:cooked_beef",
@@ -1453,9 +1361,7 @@
       "item": "minecraft:beef"
     },
     "type": "minecraft:smoking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 100
+    "experience": 0.35
   },
   "cooked_chicken": {
     "result": "minecraft:cooked_chicken",
@@ -1463,9 +1369,7 @@
       "item": "minecraft:chicken"
     },
     "type": "minecraft:smelting",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 200
+    "experience": 0.35
   },
   "cooked_chicken_from_campfire_cooking": {
     "result": "minecraft:cooked_chicken",
@@ -1473,9 +1377,7 @@
       "item": "minecraft:chicken"
     },
     "type": "minecraft:campfire_cooking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 600
+    "experience": 0.35
   },
   "cooked_chicken_from_smoking": {
     "result": "minecraft:cooked_chicken",
@@ -1483,9 +1385,7 @@
       "item": "minecraft:chicken"
     },
     "type": "minecraft:smoking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 100
+    "experience": 0.35
   },
   "cooked_cod": {
     "result": "minecraft:cooked_cod",
@@ -1493,9 +1393,7 @@
       "item": "minecraft:cod"
     },
     "type": "minecraft:smelting",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 200
+    "experience": 0.35
   },
   "cooked_cod_from_campfire_cooking": {
     "result": "minecraft:cooked_cod",
@@ -1503,9 +1401,7 @@
       "item": "minecraft:cod"
     },
     "type": "minecraft:campfire_cooking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 600
+    "experience": 0.35
   },
   "cooked_cod_from_smoking": {
     "result": "minecraft:cooked_cod",
@@ -1513,9 +1409,7 @@
       "item": "minecraft:cod"
     },
     "type": "minecraft:smoking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 100
+    "experience": 0.35
   },
   "cooked_mutton": {
     "result": "minecraft:cooked_mutton",
@@ -1523,9 +1417,7 @@
       "item": "minecraft:mutton"
     },
     "type": "minecraft:smelting",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 200
+    "experience": 0.35
   },
   "cooked_porkchop": {
     "result": "minecraft:cooked_porkchop",
@@ -1533,9 +1425,7 @@
       "item": "minecraft:porkchop"
     },
     "type": "minecraft:smelting",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 200
+    "experience": 0.35
   },
   "cooked_porkchop_from_campfire_cooking": {
     "result": "minecraft:cooked_porkchop",
@@ -1543,9 +1433,7 @@
       "item": "minecraft:porkchop"
     },
     "type": "minecraft:campfire_cooking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 600
+    "experience": 0.35
   },
   "cooked_porkchop_from_smoking": {
     "result": "minecraft:cooked_porkchop",
@@ -1553,9 +1441,7 @@
       "item": "minecraft:porkchop"
     },
     "type": "minecraft:smoking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 100
+    "experience": 0.35
   },
   "cooked_rabbit": {
     "result": "minecraft:cooked_rabbit",
@@ -1563,9 +1449,7 @@
       "item": "minecraft:rabbit"
     },
     "type": "minecraft:smelting",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 200
+    "experience": 0.35
   },
   "cooked_rabbit_from_campfire_cooking": {
     "result": "minecraft:cooked_rabbit",
@@ -1573,9 +1457,7 @@
       "item": "minecraft:rabbit"
     },
     "type": "minecraft:campfire_cooking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 600
+    "experience": 0.35
   },
   "cooked_rabbit_from_smoking": {
     "result": "minecraft:cooked_rabbit",
@@ -1583,9 +1465,7 @@
       "item": "minecraft:rabbit"
     },
     "type": "minecraft:smoking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 100
+    "experience": 0.35
   },
   "cooked_salmon": {
     "result": "minecraft:cooked_salmon",
@@ -1593,9 +1473,7 @@
       "item": "minecraft:salmon"
     },
     "type": "minecraft:smelting",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 200
+    "experience": 0.35
   },
   "cooked_salmon_from_campfire_cooking": {
     "result": "minecraft:cooked_salmon",
@@ -1603,9 +1481,7 @@
       "item": "minecraft:salmon"
     },
     "type": "minecraft:campfire_cooking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 600
+    "experience": 0.35
   },
   "cooked_salmon_from_smoking": {
     "result": "minecraft:cooked_salmon",
@@ -1613,9 +1489,7 @@
       "item": "minecraft:salmon"
     },
     "type": "minecraft:smoking",
-    "category": "food",
-    "experience": 0.35,
-    "cookingtime": 100
+    "experience": 0.35
   },
   "cookie": {
     "result": {
@@ -1626,7 +1500,6 @@
       "#X#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:wheat"
@@ -1645,7 +1518,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "tag": "minecraft:planks"
@@ -1665,7 +1537,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:cyan_wool"
@@ -1673,8 +1544,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "cyan_carpet": {
     "result": {
@@ -1685,13 +1555,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:cyan_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "cyan_dye_legacy": {
     "result": {
@@ -1722,7 +1590,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -1730,8 +1597,7 @@
       "X": {
         "item": "minecraft:cyan_dye"
       }
-    },
-    "group": "stained_glass"
+    }
   },
   "cyan_stained_glass_pane": {
     "result": {
@@ -1743,13 +1609,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:cyan_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "cyan_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -1762,7 +1626,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -1770,8 +1633,7 @@
       "$": {
         "item": "minecraft:cyan_dye"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "cyan_terracotta": {
     "result": {
@@ -1784,7 +1646,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -1792,8 +1653,7 @@
       "X": {
         "item": "minecraft:cyan_dye"
       }
-    },
-    "group": "stained_terracotta"
+    }
   },
   "cyan_wool": {
     "result": {
@@ -1808,11 +1668,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dark_oak_planks": {
     "result": {
@@ -1825,11 +1683,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true
-    },
-    "group": "planks"
+    }
   },
   "dark_oak_slab": {
     "result": {
@@ -1840,13 +1696,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:dark_oak_planks"
       }
-    },
-    "group": "wooden_slab"
+    }
   },
   "dark_oak_stairs": {
     "result": {
@@ -1859,13 +1713,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:dark_oak_planks"
       }
-    },
-    "group": "wooden_stairs"
+    }
   },
   "daylight_detector": {
     "result": {
@@ -1877,7 +1729,6 @@
       "WWW"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "Q": {
         "item": "minecraft:quartz"
@@ -1904,7 +1755,6 @@
       "XRX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "R": {
         "item": "minecraft:redstone"
@@ -1927,8 +1777,7 @@
         "item": "minecraft:diamond_block"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "diamond_axe": {
     "result": {
@@ -1940,7 +1789,6 @@
       " #"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -1960,7 +1808,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -1976,7 +1823,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:diamond"
@@ -1993,7 +1839,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:diamond"
@@ -2006,10 +1851,7 @@
       "item": "minecraft:diamond_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
-    "experience": 1,
-    "cookingtime": 100,
-    "group": "diamond"
+    "experience": 1
   },
   "diamond_from_smelting_diamond_ore": {
     "result": "minecraft:diamond",
@@ -2017,10 +1859,7 @@
       "item": "minecraft:diamond_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
-    "experience": 1,
-    "cookingtime": 200,
-    "group": "diamond"
+    "experience": 1
   },
   "diamond_helmet": {
     "result": {
@@ -2031,7 +1870,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:diamond"
@@ -2048,7 +1886,6 @@
       " #"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -2068,7 +1905,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:diamond"
@@ -2085,7 +1921,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -2105,7 +1940,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -2125,7 +1959,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -2145,7 +1978,6 @@
       "#R#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "R": {
         "item": "minecraft:redstone"
@@ -2168,7 +2000,6 @@
       "#R#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "R": {
         "item": "minecraft:redstone"
@@ -2188,8 +2019,7 @@
         "item": "minecraft:emerald_block"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "emerald_block": {
     "result": {
@@ -2201,7 +2031,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:emerald"
@@ -2214,10 +2043,7 @@
       "item": "minecraft:emerald_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
-    "experience": 1,
-    "cookingtime": 100,
-    "group": "emerald"
+    "experience": 1
   },
   "emerald_from_smelting_emerald_ore": {
     "result": "minecraft:emerald",
@@ -2225,10 +2051,7 @@
       "item": "minecraft:emerald_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
-    "experience": 1,
-    "cookingtime": 200,
-    "group": "emerald"
+    "experience": 1
   },
   "enchanted_golden_apple": {
     "result": {
@@ -2262,7 +2085,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "B": {
         "item": "minecraft:book"
@@ -2285,7 +2107,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:obsidian"
@@ -2307,8 +2128,7 @@
         "item": "minecraft:blaze_powder"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "extended_fire_resistance_potion": {
     "result": "minecraft.potion.effect.fire_resistance.extended",
@@ -2594,8 +2414,7 @@
         "item": "minecraft:sugar"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "fire_charge": {
     "result": {
@@ -2619,7 +2438,6 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "animated": true
     }
@@ -2854,7 +2672,6 @@
       "# X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -2876,8 +2693,7 @@
         "item": "minecraft:flint"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "equipment"
+    "type": "minecraft:crafting_shapeless"
   },
   "flower_pot": {
     "result": {
@@ -2888,7 +2704,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:brick"
@@ -2905,7 +2720,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "tag": "minecraft:stone_crafting_materials"
@@ -2928,7 +2742,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "lang": {
       "en_US": {
         "notes": "Before 1.19, recipe is shaped."
@@ -2941,12 +2754,10 @@
       "tag": "minecraft:smelts_to_glass"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "animated": true
-    },
-    "cookingtime": 200
+    }
   },
   "glass_bottle": {
     "result": {
@@ -2958,7 +2769,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -2975,7 +2785,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -2992,7 +2801,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:gold_nugget"
@@ -3011,7 +2819,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glowstone_dust"
@@ -3028,7 +2835,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:gold_ingot"
@@ -3041,10 +2847,7 @@
       "item": "minecraft:gold_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
-    "experience": 1,
-    "cookingtime": 100,
-    "group": "gold_ingot"
+    "experience": 1
   },
   "gold_ingot_from_gold_block": {
     "result": {
@@ -3056,9 +2859,7 @@
         "item": "minecraft:gold_block"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "gold_ingot"
+    "type": "minecraft:crafting_shapeless"
   },
   "gold_ingot_from_nuggets": {
     "result": {
@@ -3070,13 +2871,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:gold_nugget"
       }
-    },
-    "group": "gold_ingot"
+    }
   },
   "gold_ingot_from_smelting_gold_ore": {
     "result": "minecraft:gold_ingot",
@@ -3084,10 +2883,7 @@
       "item": "minecraft:gold_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
-    "experience": 1,
-    "cookingtime": 200,
-    "group": "gold_ingot"
+    "experience": 1
   },
   "gold_nugget": {
     "result": {
@@ -3099,8 +2895,7 @@
         "item": "minecraft:gold_ingot"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "gold_nugget_from_blasting": {
     "result": "minecraft:gold_nugget",
@@ -3137,9 +2932,7 @@
       }
     ],
     "type": "minecraft:blasting",
-    "category": "misc",
-    "experience": 0.1,
-    "cookingtime": 100
+    "experience": 0.1
   },
   "golden_apple": {
     "result": {
@@ -3151,7 +2944,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:gold_ingot"
@@ -3171,7 +2963,6 @@
       " #"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -3190,7 +2981,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:gold_ingot"
@@ -3207,7 +2997,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:gold_nugget"
@@ -3227,7 +3016,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:gold_ingot"
@@ -3243,7 +3031,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:gold_ingot"
@@ -3260,7 +3047,6 @@
       " #"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -3280,7 +3066,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:gold_ingot"
@@ -3297,7 +3082,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -3317,7 +3101,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -3337,7 +3120,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -3357,7 +3139,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:gray_wool"
@@ -3365,8 +3146,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "gray_carpet": {
     "result": {
@@ -3377,13 +3157,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:gray_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "gray_dye_legacy": {
     "result": {
@@ -3414,7 +3192,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -3422,8 +3199,7 @@
       "X": {
         "item": "minecraft:gray_dye"
       }
-    },
-    "group": "stained_glass"
+    }
   },
   "gray_stained_glass_pane": {
     "result": {
@@ -3435,13 +3211,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:gray_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "gray_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -3454,7 +3228,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -3462,8 +3235,7 @@
       "$": {
         "item": "minecraft:gray_dye"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "gray_terracotta": {
     "result": {
@@ -3476,7 +3248,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -3484,8 +3255,7 @@
       "X": {
         "item": "minecraft:gray_dye"
       }
-    },
-    "group": "stained_terracotta"
+    }
   },
   "gray_wool": {
     "result": {
@@ -3500,11 +3270,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "green_banner": {
     "result": {
@@ -3516,7 +3284,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:green_wool"
@@ -3524,8 +3291,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "green_carpet": {
     "result": {
@@ -3536,13 +3302,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:green_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "green_dye": {
     "result": "minecraft:green_dye",
@@ -3550,9 +3314,7 @@
       "item": "minecraft:cactus"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
-    "experience": 1,
-    "cookingtime": 200
+    "experience": 1
   },
   "green_stained_glass": {
     "result": {
@@ -3565,7 +3327,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -3573,8 +3334,7 @@
       "X": {
         "item": "minecraft:green_dye"
       }
-    },
-    "group": "stained_glass"
+    }
   },
   "green_stained_glass_pane": {
     "result": {
@@ -3586,13 +3346,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:green_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "green_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -3605,7 +3363,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -3613,8 +3370,7 @@
       "$": {
         "item": "minecraft:green_dye"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "green_terracotta": {
     "result": {
@@ -3627,7 +3383,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -3635,8 +3390,7 @@
       "X": {
         "item": "minecraft:green_dye"
       }
-    },
-    "group": "stained_terracotta"
+    }
   },
   "green_wool": {
     "result": {
@@ -3651,11 +3405,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "harming_potion": {
     "result": "minecraft.potion.effect.harming",
@@ -3728,8 +3480,7 @@
         "item": "minecraft:wheat"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "building"
+    "type": "minecraft:crafting_shapeless"
   },
   "healing_potion": {
     "result": "minecraft.potion.effect.healing",
@@ -3759,7 +3510,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:iron_ingot"
@@ -3776,7 +3526,6 @@
       " I "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "C": {
         "item": "minecraft:chest"
@@ -3799,7 +3548,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "lang": {
       "en_US": {
         "notes": "Before 1.19, recipe is shaped."
@@ -3836,7 +3584,6 @@
       " #"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -3856,7 +3603,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:iron_ingot"
@@ -3873,7 +3619,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:iron_ingot"
@@ -3889,7 +3634,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:iron_ingot"
@@ -3906,7 +3650,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:iron_ingot"
@@ -3924,7 +3667,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:iron_ingot"
@@ -3940,7 +3682,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:iron_ingot"
@@ -3957,7 +3698,6 @@
       " #"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -3973,10 +3713,7 @@
       "item": "minecraft:iron_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
-    "experience": 0.7,
-    "cookingtime": 100,
-    "group": "iron_ingot"
+    "experience": 0.7
   },
   "iron_ingot_from_iron_block": {
     "result": {
@@ -3988,9 +3725,7 @@
         "item": "minecraft:iron_block"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "iron_ingot"
+    "type": "minecraft:crafting_shapeless"
   },
   "iron_ingot_from_smelting_iron_ore": {
     "result": "minecraft:iron_ingot",
@@ -3998,10 +3733,7 @@
       "item": "minecraft:iron_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
-    "experience": 0.7,
-    "cookingtime": 200,
-    "group": "iron_ingot"
+    "experience": 0.7
   },
   "iron_leggings": {
     "result": {
@@ -4013,7 +3745,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:iron_ingot"
@@ -4030,7 +3761,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -4050,7 +3780,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -4070,7 +3799,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -4090,7 +3818,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -4109,7 +3836,6 @@
       "B"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "A": {
         "item": "minecraft:carved_pumpkin"
@@ -4129,7 +3855,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "tag": "minecraft:planks"
@@ -4153,11 +3878,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true
-    },
-    "group": "planks"
+    }
   },
   "jungle_slab": {
     "result": {
@@ -4168,13 +3891,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:jungle_planks"
       }
-    },
-    "group": "wooden_slab"
+    }
   },
   "jungle_stairs": {
     "result": {
@@ -4187,13 +3908,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:jungle_planks"
       }
-    },
-    "group": "wooden_stairs"
+    }
   },
   "ladder": {
     "result": {
@@ -4206,7 +3925,6 @@
       "# #"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -4223,7 +3941,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:lapis_lazuli"
@@ -4240,8 +3957,7 @@
         "item": "minecraft:lapis_block"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "lapis_lazuli_from_blasting_lapis_ore": {
     "result": "minecraft:lapis_lazuli",
@@ -4249,10 +3965,7 @@
       "item": "minecraft:lapis_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
-    "experience": 0.2,
-    "cookingtime": 100,
-    "group": "lapis_lazuli"
+    "experience": 0.2
   },
   "lapis_lazuli_from_smelting_lapis_ore": {
     "result": "minecraft:lapis_lazuli",
@@ -4260,10 +3973,7 @@
       "item": "minecraft:lapis_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
-    "experience": 0.2,
-    "cookingtime": 200,
-    "group": "lapis_lazuli"
+    "experience": 0.2
   },
   "lead": {
     "result": {
@@ -4276,7 +3986,6 @@
       "  ~"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "~": {
         "item": "minecraft:string"
@@ -4295,7 +4004,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:leather"
@@ -4312,7 +4020,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:leather"
@@ -4328,7 +4035,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:leather"
@@ -4345,7 +4051,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:leather"
@@ -4361,7 +4066,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:cobblestone"
@@ -4381,7 +4085,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:light_blue_wool"
@@ -4389,8 +4092,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "light_blue_carpet": {
     "result": {
@@ -4401,13 +4103,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:light_blue_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "light_blue_dye_from_blue_orchid": {
     "result": {
@@ -4418,9 +4118,7 @@
         "item": "minecraft:blue_orchid"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "light_blue_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "light_blue_dye_from_blue_white_dye_legacy": {
     "result": {
@@ -4438,8 +4136,7 @@
     "type": "minecraft:crafting_shapeless",
     "properties": {
       "removed": "1.14"
-    },
-    "group": "light_blue_dye"
+    }
   },
   "light_blue_stained_glass": {
     "result": {
@@ -4452,7 +4149,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -4460,8 +4156,7 @@
       "X": {
         "item": "minecraft:light_blue_dye"
       }
-    },
-    "group": "stained_glass"
+    }
   },
   "light_blue_stained_glass_pane": {
     "result": {
@@ -4473,13 +4168,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:light_blue_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "light_blue_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -4492,7 +4185,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -4500,8 +4192,7 @@
       "$": {
         "item": "minecraft:light_blue_dye"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "light_blue_terracotta": {
     "result": {
@@ -4514,7 +4205,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -4522,8 +4212,7 @@
       "X": {
         "item": "minecraft:light_blue_dye"
       }
-    },
-    "group": "stained_terracotta"
+    }
   },
   "light_blue_wool": {
     "result": {
@@ -4538,11 +4227,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "light_gray_banner": {
     "result": {
@@ -4554,7 +4241,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:light_gray_wool"
@@ -4562,8 +4248,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "light_gray_carpet": {
     "result": {
@@ -4574,13 +4259,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:light_gray_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "light_gray_dye_from_azure_bluet": {
     "result": {
@@ -4591,9 +4274,7 @@
         "item": "minecraft:azure_bluet"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "light_gray_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "light_gray_dye_from_black_white_dye_legacy": {
     "result": {
@@ -4614,8 +4295,7 @@
     "type": "minecraft:crafting_shapeless",
     "properties": {
       "removed": "1.14"
-    },
-    "group": "light_gray_dye"
+    }
   },
   "light_gray_dye_from_gray_white_dye_legacy": {
     "result": {
@@ -4633,8 +4313,7 @@
     "type": "minecraft:crafting_shapeless",
     "properties": {
       "removed": "1.14"
-    },
-    "group": "light_gray_dye"
+    }
   },
   "light_gray_dye_from_oxeye_daisy": {
     "result": {
@@ -4645,9 +4324,7 @@
         "item": "minecraft:oxeye_daisy"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "light_gray_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "light_gray_dye_from_white_tulip": {
     "result": {
@@ -4658,9 +4335,7 @@
         "item": "minecraft:white_tulip"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "light_gray_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "light_gray_stained_glass": {
     "result": {
@@ -4673,7 +4348,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -4681,8 +4355,7 @@
       "X": {
         "item": "minecraft:light_gray_dye"
       }
-    },
-    "group": "stained_glass"
+    }
   },
   "light_gray_stained_glass_pane": {
     "result": {
@@ -4694,13 +4367,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:light_gray_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "light_gray_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -4713,7 +4384,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -4721,8 +4391,7 @@
       "$": {
         "item": "minecraft:light_gray_dye"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "light_gray_terracotta": {
     "result": {
@@ -4735,7 +4404,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -4743,8 +4411,7 @@
       "X": {
         "item": "minecraft:light_gray_dye"
       }
-    },
-    "group": "stained_terracotta"
+    }
   },
   "light_gray_wool": {
     "result": {
@@ -4759,11 +4426,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "light_weighted_pressure_plate": {
     "result": {
@@ -4773,7 +4438,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:gold_ingot"
@@ -4790,7 +4454,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:lime_wool"
@@ -4798,8 +4461,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "lime_carpet": {
     "result": {
@@ -4810,13 +4472,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:lime_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "lime_dye_legacy": {
     "result": {
@@ -4847,7 +4507,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -4855,8 +4514,7 @@
       "X": {
         "item": "minecraft:lime_dye"
       }
-    },
-    "group": "stained_glass"
+    }
   },
   "lime_stained_glass_pane": {
     "result": {
@@ -4868,13 +4526,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:lime_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "lime_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -4887,7 +4543,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -4895,8 +4550,7 @@
       "$": {
         "item": "minecraft:lime_dye"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "lime_terracotta": {
     "result": {
@@ -4909,7 +4563,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -4917,8 +4570,7 @@
       "X": {
         "item": "minecraft:lime_dye"
       }
-    },
-    "group": "stained_terracotta"
+    }
   },
   "lime_wool": {
     "result": {
@@ -4933,11 +4585,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "lingering_thick_potion": {
     "result": "minecraft.lingering_potion.effect.thick",
@@ -4959,7 +4609,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:magenta_wool"
@@ -4967,8 +4616,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "magenta_carpet": {
     "result": {
@@ -4979,13 +4627,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:magenta_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "magenta_dye_from_allium": {
     "result": {
@@ -4996,9 +4642,7 @@
         "item": "minecraft:allium"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "magenta_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "magenta_dye_from_blue_red_pink_legacy": {
     "result": {
@@ -5019,8 +4663,7 @@
     "type": "minecraft:crafting_shapeless",
     "properties": {
       "removed": "1.14"
-    },
-    "group": "magenta_dye"
+    }
   },
   "magenta_dye_from_blue_red_white_dye_legacy": {
     "result": {
@@ -5044,8 +4687,7 @@
     "type": "minecraft:crafting_shapeless",
     "properties": {
       "removed": "1.14"
-    },
-    "group": "magenta_dye"
+    }
   },
   "magenta_dye_from_lilac": {
     "result": {
@@ -5057,9 +4699,7 @@
         "item": "minecraft:lilac"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "magenta_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "magenta_dye_from_purple_and_pink": {
     "result": {
@@ -5074,9 +4714,7 @@
         "item": "minecraft:pink_dye"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "magenta_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "magenta_stained_glass": {
     "result": {
@@ -5089,7 +4727,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -5097,8 +4734,7 @@
       "X": {
         "item": "minecraft:magenta_dye"
       }
-    },
-    "group": "stained_glass"
+    }
   },
   "magenta_stained_glass_pane": {
     "result": {
@@ -5110,13 +4746,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:magenta_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "magenta_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -5129,7 +4763,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -5137,8 +4770,7 @@
       "$": {
         "item": "minecraft:magenta_dye"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "magenta_terracotta": {
     "result": {
@@ -5151,7 +4783,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -5159,8 +4790,7 @@
       "X": {
         "item": "minecraft:magenta_dye"
       }
-    },
-    "group": "stained_terracotta"
+    }
   },
   "magenta_wool": {
     "result": {
@@ -5175,11 +4805,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "magma_cream": {
     "result": {
@@ -5193,8 +4821,7 @@
         "item": "minecraft:slime_ball"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "map": {
     "result": {
@@ -5206,7 +4833,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:paper"
@@ -5249,8 +4875,7 @@
         "item": "minecraft:melon_slice"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "building"
+    "type": "minecraft:crafting_shapeless"
   },
   "melon_seeds": {
     "result": {
@@ -5261,8 +4886,7 @@
         "item": "minecraft:melon_slice"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "minecart": {
     "result": {
@@ -5273,7 +4897,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:iron_ingot"
@@ -5331,8 +4954,7 @@
         "item": "minecraft:bowl"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "nether_brick": {
     "result": "minecraft:nether_brick",
@@ -5340,9 +4962,7 @@
       "item": "minecraft:netherrack"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
-    "experience": 0.1,
-    "cookingtime": 200
+    "experience": 0.1
   },
   "nether_brick_fence_legacy": {
     "result": {
@@ -5372,7 +4992,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:nether_bricks"
@@ -5390,7 +5009,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:nether_bricks"
@@ -5406,7 +5024,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:nether_brick"
@@ -5443,7 +5060,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "tag": "minecraft:planks"
@@ -5465,13 +5081,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:oak_planks"
       }
-    },
-    "group": "boat"
+    }
   },
   "oak_button": {
     "result": {
@@ -5482,9 +5096,7 @@
         "item": "minecraft:oak_planks"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
-    "group": "wooden_button"
+    "type": "minecraft:crafting_shapeless"
   },
   "oak_door": {
     "result": {
@@ -5497,7 +5109,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "lang": {
       "en_US": {
         "notes": "Before 1.8, recipe gives 1 door."
@@ -5507,8 +5118,7 @@
       "#": {
         "item": "minecraft:oak_planks"
       }
-    },
-    "group": "wooden_door"
+    }
   },
   "oak_fence": {
     "result": {
@@ -5520,7 +5130,6 @@
       "W#W"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -5528,8 +5137,7 @@
       "W": {
         "item": "minecraft:oak_planks"
       }
-    },
-    "group": "wooden_fence"
+    }
   },
   "oak_fence_gate": {
     "result": {
@@ -5540,7 +5148,6 @@
       "#W#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -5548,8 +5155,7 @@
       "W": {
         "item": "minecraft:oak_planks"
       }
-    },
-    "group": "wooden_fence_gate"
+    }
   },
   "oak_fence_legacy": {
     "result": {
@@ -5568,8 +5174,7 @@
     },
     "properties": {
       "removed": "1.8"
-    },
-    "group": "wooden_fence"
+    }
   },
   "oak_planks": {
     "result": {
@@ -5582,11 +5187,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true
-    },
-    "group": "planks"
+    }
   },
   "oak_pressure_plate": {
     "result": {
@@ -5596,13 +5199,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:oak_planks"
       }
-    },
-    "group": "wooden_pressure_plate"
+    }
   },
   "oak_sign": {
     "result": {
@@ -5615,7 +5216,6 @@
       " X "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:oak_planks"
@@ -5623,8 +5223,7 @@
       "X": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "wooden_sign"
+    }
   },
   "oak_slab": {
     "result": {
@@ -5635,13 +5234,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:oak_planks"
       }
-    },
-    "group": "wooden_slab"
+    }
   },
   "oak_stairs": {
     "result": {
@@ -5654,13 +5251,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:oak_planks"
       }
-    },
-    "group": "wooden_stairs"
+    }
   },
   "oak_trapdoor": {
     "result": {
@@ -5672,13 +5267,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:oak_planks"
       }
-    },
-    "group": "wooden_trapdoor"
+    }
   },
   "orange_banner": {
     "result": {
@@ -5690,7 +5283,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:orange_wool"
@@ -5698,8 +5290,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "orange_carpet": {
     "result": {
@@ -5710,13 +5301,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:orange_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "orange_dye_from_orange_tulip": {
     "result": {
@@ -5727,9 +5316,7 @@
         "item": "minecraft:orange_tulip"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "orange_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "orange_dye_from_red_yellow": {
     "result": {
@@ -5744,9 +5331,7 @@
         "item": "minecraft:yellow_dye"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "orange_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "orange_stained_glass": {
     "result": {
@@ -5759,7 +5344,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -5767,8 +5351,7 @@
       "X": {
         "item": "minecraft:orange_dye"
       }
-    },
-    "group": "stained_glass"
+    }
   },
   "orange_stained_glass_pane": {
     "result": {
@@ -5780,13 +5363,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:orange_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "orange_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -5799,7 +5380,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -5807,8 +5387,7 @@
       "$": {
         "item": "minecraft:orange_dye"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "orange_terracotta": {
     "result": {
@@ -5821,7 +5400,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -5829,8 +5407,7 @@
       "X": {
         "item": "minecraft:orange_dye"
       }
-    },
-    "group": "stained_terracotta"
+    }
   },
   "orange_wool": {
     "result": {
@@ -5845,11 +5422,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "painting": {
     "result": {
@@ -5861,7 +5436,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -5883,7 +5457,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:sugar_cane"
@@ -5900,7 +5473,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:pink_wool"
@@ -5908,8 +5480,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "pink_carpet": {
     "result": {
@@ -5920,13 +5491,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:pink_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "pink_dye_from_peony": {
     "result": {
@@ -5938,9 +5507,7 @@
         "item": "minecraft:peony"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "pink_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "pink_dye_from_pink_tulip": {
     "result": {
@@ -5951,9 +5518,7 @@
         "item": "minecraft:pink_tulip"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "pink_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "pink_dye_from_red_white_dye_legacy": {
     "result": {
@@ -5971,8 +5536,7 @@
     "type": "minecraft:crafting_shapeless",
     "properties": {
       "removed": "1.14"
-    },
-    "group": "pink_dye"
+    }
   },
   "pink_stained_glass": {
     "result": {
@@ -5985,7 +5549,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -5993,8 +5556,7 @@
       "X": {
         "item": "minecraft:pink_dye"
       }
-    },
-    "group": "stained_glass"
+    }
   },
   "pink_stained_glass_pane": {
     "result": {
@@ -6006,13 +5568,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:pink_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "pink_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -6025,7 +5585,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -6033,8 +5592,7 @@
       "$": {
         "item": "minecraft:pink_dye"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "pink_terracotta": {
     "result": {
@@ -6047,7 +5605,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -6055,8 +5612,7 @@
       "X": {
         "item": "minecraft:pink_dye"
       }
-    },
-    "group": "stained_terracotta"
+    }
   },
   "pink_wool": {
     "result": {
@@ -6071,11 +5627,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "piston": {
     "result": {
@@ -6087,7 +5641,6 @@
       "#R#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "R": {
         "item": "minecraft:redstone"
@@ -6137,7 +5690,6 @@
       "XRX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "R": {
         "item": "minecraft:redstone"
@@ -6160,7 +5712,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:purple_wool"
@@ -6168,8 +5719,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "purple_carpet": {
     "result": {
@@ -6180,13 +5730,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:purple_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "purple_dye_legacy": {
     "result": {
@@ -6217,7 +5765,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -6225,8 +5772,7 @@
       "X": {
         "item": "minecraft:purple_dye"
       }
-    },
-    "group": "stained_glass"
+    }
   },
   "purple_stained_glass_pane": {
     "result": {
@@ -6238,13 +5784,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:purple_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "purple_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -6257,7 +5801,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -6265,8 +5808,7 @@
       "$": {
         "item": "minecraft:purple_dye"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "purple_terracotta": {
     "result": {
@@ -6279,7 +5821,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -6287,8 +5828,7 @@
       "X": {
         "item": "minecraft:purple_dye"
       }
-    },
-    "group": "stained_terracotta"
+    }
   },
   "purple_wool": {
     "result": {
@@ -6303,11 +5843,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "quartz": {
     "result": "minecraft:quartz",
@@ -6315,9 +5853,7 @@
       "item": "minecraft:nether_quartz_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
-    "experience": 0.2,
-    "cookingtime": 200
+    "experience": 0.2
   },
   "quartz_block": {
     "result": {
@@ -6328,7 +5864,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:quartz"
@@ -6341,9 +5876,7 @@
       "item": "minecraft:nether_quartz_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
-    "experience": 0.2,
-    "cookingtime": 100
+    "experience": 0.2
   },
   "quartz_from_smelting": {
     "result": "minecraft:quartz",
@@ -6351,8 +5884,7 @@
       "item": "minecraft:nether_quartz_ore"
     },
     "type": "minecraft:smelting",
-    "experience": 0.2,
-    "cookingtime": 200
+    "experience": 0.2
   },
   "quartz_pillar": {
     "result": {
@@ -6364,7 +5896,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:quartz_block"
@@ -6380,7 +5911,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": [
         {
@@ -6409,7 +5939,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": [
         {
@@ -6438,7 +5967,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -6458,7 +5986,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:red_wool"
@@ -6466,8 +5993,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "red_carpet": {
     "result": {
@@ -6478,13 +6004,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:red_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "red_dye_from_poppy": {
     "result": {
@@ -6495,9 +6019,7 @@
         "item": "minecraft:poppy"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "red_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "red_dye_from_rose_bush": {
     "result": {
@@ -6509,9 +6031,7 @@
         "item": "minecraft:rose_bush"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "red_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "red_dye_from_tulip": {
     "result": {
@@ -6522,9 +6042,7 @@
         "item": "minecraft:red_tulip"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "red_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "red_sandstone_slab": {
     "result": {
@@ -6535,7 +6053,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": [
         {
@@ -6561,7 +6078,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": [
         {
@@ -6590,7 +6106,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -6598,8 +6113,7 @@
       "X": {
         "item": "minecraft:red_dye"
       }
-    },
-    "group": "stained_glass"
+    }
   },
   "red_stained_glass_pane": {
     "result": {
@@ -6611,13 +6125,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:red_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "red_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -6630,7 +6142,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -6638,8 +6149,7 @@
       "$": {
         "item": "minecraft:red_dye"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "red_terracotta": {
     "result": {
@@ -6652,7 +6162,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -6660,8 +6169,7 @@
       "X": {
         "item": "minecraft:red_dye"
       }
-    },
-    "group": "stained_terracotta"
+    }
   },
   "red_wool": {
     "result": {
@@ -6676,11 +6184,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "redstone": {
     "result": {
@@ -6692,8 +6198,7 @@
         "item": "minecraft:redstone_block"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "redstone"
+    "type": "minecraft:crafting_shapeless"
   },
   "redstone_block": {
     "result": {
@@ -6705,7 +6210,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:redstone"
@@ -6718,10 +6222,7 @@
       "item": "minecraft:redstone_ore"
     },
     "type": "minecraft:blasting",
-    "category": "blocks",
-    "experience": 0.7,
-    "cookingtime": 100,
-    "group": "redstone"
+    "experience": 0.7
   },
   "redstone_from_smelting_redstone_ore": {
     "result": "minecraft:redstone",
@@ -6729,10 +6230,7 @@
       "item": "minecraft:redstone_ore"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
-    "experience": 0.7,
-    "cookingtime": 200,
-    "group": "redstone"
+    "experience": 0.7
   },
   "redstone_lamp": {
     "result": {
@@ -6744,7 +6242,6 @@
       " R "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "R": {
         "item": "minecraft:redstone"
@@ -6763,7 +6260,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -6802,7 +6298,6 @@
       "III"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:redstone_torch"
@@ -6824,7 +6319,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:sand"
@@ -6840,7 +6334,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": [
         {
@@ -6866,7 +6359,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": [
         {
@@ -6893,7 +6385,6 @@
       "# "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:iron_ingot"
@@ -6944,9 +6435,7 @@
       "item": "minecraft:sandstone"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
-    "experience": 0.1,
-    "cookingtime": 200
+    "experience": 0.1
   },
   "smooth_stone_slab": {
     "result": {
@@ -6957,7 +6446,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:smooth_stone"
@@ -6973,7 +6461,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:snow_block"
@@ -6989,7 +6476,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:snowball"
@@ -7436,11 +6922,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true
-    },
-    "group": "planks"
+    }
   },
   "spruce_slab": {
     "result": {
@@ -7451,13 +6935,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:spruce_planks"
       }
-    },
-    "group": "wooden_slab"
+    }
   },
   "spruce_stairs": {
     "result": {
@@ -7470,13 +6952,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:spruce_planks"
       }
-    },
-    "group": "wooden_stairs"
+    }
   },
   "stick": {
     "result": {
@@ -7488,7 +6968,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "tag": "minecraft:planks"
@@ -7496,8 +6975,7 @@
     },
     "properties": {
       "animated": true
-    },
-    "group": "sticks"
+    }
   },
   "sticky_piston": {
     "result": {
@@ -7508,7 +6986,6 @@
       "P"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "P": {
         "item": "minecraft:piston"
@@ -7524,9 +7001,7 @@
       "item": "minecraft:cobblestone"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
-    "experience": 0.1,
-    "cookingtime": 200
+    "experience": 0.1
   },
   "stone_axe": {
     "result": {
@@ -7538,7 +7013,6 @@
       " #"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -7560,7 +7034,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stone_bricks"
@@ -7578,7 +7051,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stone_bricks"
@@ -7595,7 +7067,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stone"
@@ -7611,8 +7082,7 @@
         "item": "minecraft:stone"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "redstone"
+    "type": "minecraft:crafting_shapeless"
   },
   "stone_hoe": {
     "result": {
@@ -7624,7 +7094,6 @@
       " #"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -7647,7 +7116,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -7668,7 +7136,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stone"
@@ -7685,7 +7152,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -7708,7 +7174,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -7750,9 +7215,7 @@
         "item": "minecraft:sugar_cane"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "sugar"
+    "type": "minecraft:crafting_shapeless"
   },
   "swiftness_potion": {
     "result": "minecraft.potion.effect.swiftness",
@@ -7780,9 +7243,7 @@
       "item": "minecraft:clay"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
-    "experience": 0.35,
-    "cookingtime": 200
+    "experience": 0.35
   },
   "thick_lingering_potion": {
     "result": "minecraft.lingering_potion.effect.thick",
@@ -7834,7 +7295,6 @@
       "X#X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": [
         {
@@ -7865,7 +7325,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "lang": {
       "en_US": {
         "notes": "Before 1.19, recipe is shaped."
@@ -7882,7 +7341,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -7913,7 +7371,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
     "lang": {
       "en_US": {
         "notes": "Before 1.9, recipe is shaped."
@@ -7931,7 +7388,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "tag": "minecraft:planks"
@@ -8026,8 +7482,7 @@
         "item": "minecraft:hay_block"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "white_carpet": {
     "result": {
@@ -8038,13 +7493,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "white_stained_glass_legacy": {
     "result": {
@@ -8067,8 +7520,7 @@
     },
     "properties": {
       "removed": "1.14"
-    },
-    "group": "stained_stained_glass"
+    }
   },
   "white_stained_glass_pane": {
     "result": {
@@ -8080,13 +7532,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "white_stained_glass_pane_from_glass_pane_legacy": {
     "result": {
@@ -8109,8 +7559,7 @@
     },
     "properties": {
       "removed": "1.14"
-    },
-    "group": "stained_stained_glass_pane"
+    }
   },
   "white_terracotta_legacy": {
     "result": {
@@ -8133,8 +7582,7 @@
     },
     "properties": {
       "removed": "1.14"
-    },
-    "group": "stained_terracotta"
+    }
   },
   "white_wool_from_string": {
     "result": {
@@ -8145,7 +7593,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:string"
@@ -8162,7 +7609,6 @@
       " #"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8185,7 +7631,6 @@
       " #"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8208,7 +7653,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8231,7 +7675,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8254,7 +7697,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8282,8 +7724,7 @@
         "item": "minecraft:feather"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc"
+    "type": "minecraft:crafting_shapeless"
   },
   "yellow_banner": {
     "result": {
@@ -8295,7 +7736,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:yellow_wool"
@@ -8303,8 +7743,7 @@
       "|": {
         "item": "minecraft:stick"
       }
-    },
-    "group": "banner"
+    }
   },
   "yellow_carpet": {
     "result": {
@@ -8315,13 +7754,11 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:yellow_wool"
       }
-    },
-    "group": "carpet"
+    }
   },
   "yellow_dye_from_dandelion": {
     "result": {
@@ -8332,9 +7769,7 @@
         "item": "minecraft:dandelion"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "yellow_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "yellow_dye_from_sunflower": {
     "result": {
@@ -8346,9 +7781,7 @@
         "item": "minecraft:sunflower"
       }
     ],
-    "type": "minecraft:crafting_shapeless",
-    "category": "misc",
-    "group": "yellow_dye"
+    "type": "minecraft:crafting_shapeless"
   },
   "yellow_stained_glass": {
     "result": {
@@ -8361,7 +7794,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -8369,8 +7801,7 @@
       "X": {
         "item": "minecraft:yellow_dye"
       }
-    },
-    "group": "stained_glass"
+    }
   },
   "yellow_stained_glass_pane": {
     "result": {
@@ -8382,13 +7813,11 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:yellow_stained_glass"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "yellow_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -8401,7 +7830,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -8409,8 +7837,7 @@
       "$": {
         "item": "minecraft:yellow_dye"
       }
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "yellow_terracotta": {
     "result": {
@@ -8423,7 +7850,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -8431,8 +7857,7 @@
       "X": {
         "item": "minecraft:yellow_dye"
       }
-    },
-    "group": "stained_terracotta"
+    }
   },
   "yellow_wool": {
     "result": {
@@ -8447,11 +7872,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "acacia_door": {
     "result": {
@@ -8464,7 +7887,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:acacia_planks"
@@ -8472,8 +7894,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_door"
+    }
   },
   "acacia_fence": {
     "result": {
@@ -8485,7 +7906,6 @@
       "W#W"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8496,8 +7916,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_fence"
+    }
   },
   "acacia_fence_gate": {
     "result": {
@@ -8508,7 +7927,6 @@
       "#W#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8519,8 +7937,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_fence_gate"
+    }
   },
   "amplified_leaping_potion": {
     "result": "minecraft.potion.effect.leaping.ii",
@@ -8562,7 +7979,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.8"
     }
@@ -8577,7 +7993,6 @@
       "/_/"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "/": {
         "item": "minecraft:stick"
@@ -8601,7 +8016,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:birch_planks"
@@ -8609,8 +8023,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_door"
+    }
   },
   "birch_fence": {
     "result": {
@@ -8622,7 +8035,6 @@
       "W#W"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8633,8 +8045,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_fence"
+    }
   },
   "birch_fence_gate": {
     "result": {
@@ -8645,7 +8056,6 @@
       "#W#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8656,8 +8066,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_fence_gate"
+    }
   },
   "chiseled_stone_bricks": {
     "result": {
@@ -8668,7 +8077,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stone_brick_slab"
@@ -8688,7 +8096,6 @@
       "GD"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "D": {
         "item": "minecraft:dirt"
@@ -8707,12 +8114,10 @@
       "item": "minecraft:mutton"
     },
     "type": "minecraft:campfire_cooking",
-    "category": "food",
     "experience": 0.35,
     "properties": {
       "version": "1.8"
-    },
-    "cookingtime": 600
+    }
   },
   "cooked_mutton_from_smoking": {
     "result": "minecraft:cooked_mutton",
@@ -8720,12 +8125,10 @@
       "item": "minecraft:mutton"
     },
     "type": "minecraft:smoking",
-    "category": "food",
     "experience": 0.35,
     "properties": {
       "version": "1.8"
-    },
-    "cookingtime": 100
+    }
   },
   "cracked_stone_bricks": {
     "result": "minecraft:cracked_stone_bricks",
@@ -8733,12 +8136,10 @@
       "item": "minecraft:stone_bricks"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.8"
-    },
-    "cookingtime": 200
+    }
   },
   "dark_oak_door": {
     "result": {
@@ -8751,7 +8152,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:dark_oak_planks"
@@ -8759,8 +8159,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_door"
+    }
   },
   "dark_oak_fence": {
     "result": {
@@ -8772,7 +8171,6 @@
       "W#W"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8783,8 +8181,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_fence"
+    }
   },
   "dark_oak_fence_gate": {
     "result": {
@@ -8795,7 +8192,6 @@
       "#W#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8806,8 +8202,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_fence_gate"
+    }
   },
   "dark_prismarine_legacy": {
     "result": {
@@ -8842,7 +8237,6 @@
       "QC"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "Q": {
         "item": "minecraft:quartz"
@@ -8894,7 +8288,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.8"
     }
@@ -8908,7 +8301,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:iron_ingot"
@@ -8929,7 +8321,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:jungle_planks"
@@ -8937,8 +8328,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_door"
+    }
   },
   "jungle_fence": {
     "result": {
@@ -8950,7 +8340,6 @@
       "W#W"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8961,8 +8350,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_fence"
+    }
   },
   "jungle_fence_gate": {
     "result": {
@@ -8973,7 +8361,6 @@
       "#W#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -8984,8 +8371,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_fence_gate"
+    }
   },
   "leaping_potion": {
     "result": "minecraft.potion.effect.leaping",
@@ -9022,7 +8408,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:rabbit_hide"
@@ -9045,11 +8430,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.8"
-    },
-    "group": "mossy_cobblestone"
+    }
   },
   "mossy_stone_bricks_from_vine": {
     "result": {
@@ -9064,11 +8447,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.8"
-    },
-    "group": "mossy_stone_bricks"
+    }
   },
   "polished_andesite": {
     "result": {
@@ -9080,7 +8461,6 @@
       "SS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "S": {
         "item": "minecraft:andesite"
@@ -9100,7 +8480,6 @@
       "SS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "S": {
         "item": "minecraft:diorite"
@@ -9120,7 +8499,6 @@
       "SS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "S": {
         "item": "minecraft:granite"
@@ -9139,7 +8517,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:prismarine_shard"
@@ -9183,7 +8560,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.8"
     }
@@ -9210,7 +8586,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "lang": {
       "en_US": {
         "notes": "Before 1.14, recipe is shaped."
@@ -9218,8 +8593,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "rabbit_stew"
+    }
   },
   "rabbit_stew_from_red_mushroom": {
     "result": {
@@ -9243,7 +8617,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "lang": {
       "en_US": {
         "notes": "Before 1.14, recipe is shaped."
@@ -9251,8 +8624,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "rabbit_stew"
+    }
   },
   "red_sandstone": {
     "result": {
@@ -9263,7 +8635,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:red_sand"
@@ -9283,7 +8654,6 @@
       "SCS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "C": {
         "item": "minecraft:prismarine_crystals"
@@ -9307,7 +8677,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.8"
     }
@@ -9322,7 +8691,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:slime_ball"
@@ -9338,12 +8706,10 @@
       "item": "minecraft:red_sandstone"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.8"
-    },
-    "cookingtime": 200
+    }
   },
   "splash_amplified_leaping_potion": {
     "result": "minecraft.splash_potion.effect.leaping.ii",
@@ -9384,7 +8750,7 @@
       "item": "minecraft.splash_potion.effect.awkward"
     }
   },
-  "sponge_bucket": {
+  "sponge": {
     "result": "minecraft:sponge",
     "ingredient": {
       "item": "minecraft:wet_sponge"
@@ -9393,13 +8759,12 @@
     "experience": 0.15,
     "lang": {
       "en_US": {
-        "notes": "The empty bucket is filled with water after smelting."
+        "notes": "If an empty bucket is in the fuel slot, the bucket is filled with water."
       }
     },
     "properties": {
       "version": "1.8"
-    },
-    "cookingtime": 200
+    }
   },
   "spruce_door": {
     "result": {
@@ -9412,7 +8777,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:spruce_planks"
@@ -9420,8 +8784,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_door"
+    }
   },
   "spruce_fence": {
     "result": {
@@ -9433,7 +8796,6 @@
       "W#W"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -9444,8 +8806,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_fence"
+    }
   },
   "spruce_fence_gate": {
     "result": {
@@ -9456,7 +8817,6 @@
       "#W#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -9467,8 +8827,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "wooden_fence_gate"
+    }
   },
   "white_banner": {
     "result": {
@@ -9480,7 +8839,6 @@
       " | "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_wool"
@@ -9491,8 +8849,7 @@
     },
     "properties": {
       "version": "1.8"
-    },
-    "group": "banner"
+    }
   },
   "acacia_boat": {
     "result": {
@@ -9503,7 +8860,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:acacia_planks"
@@ -9511,8 +8867,7 @@
     },
     "properties": {
       "version": "1.9"
-    },
-    "group": "boat"
+    }
   },
   "amplified_harming_lingering_potion": {
     "result": "minecraft.lingering_potion.effect.harming.ii",
@@ -9659,7 +9014,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "lang": {
       "en_US": {
         "notes": "Before 1.14, recipe is shaped."
@@ -9678,7 +9032,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:birch_planks"
@@ -9686,8 +9039,7 @@
     },
     "properties": {
       "version": "1.9"
-    },
-    "group": "boat"
+    }
   },
   "dark_oak_boat": {
     "result": {
@@ -9698,7 +9050,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:dark_oak_planks"
@@ -9706,8 +9057,7 @@
     },
     "properties": {
       "version": "1.9"
-    },
-    "group": "boat"
+    }
   },
   "empty_lingering_potion": {
     "result": "minecraft.lingering_potion.effect.empty",
@@ -9745,7 +9095,6 @@
       "GTG"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "T": {
         "item": "minecraft:ghast_tear"
@@ -9771,7 +9120,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:popped_chorus_fruit"
@@ -9794,7 +9142,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:end_stone"
@@ -10034,7 +9381,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:jungle_planks"
@@ -10042,8 +9388,7 @@
     },
     "properties": {
       "version": "1.9"
-    },
-    "group": "boat"
+    }
   },
   "leaping_lingering_potion": {
     "result": "minecraft.lingering_potion.effect.leaping",
@@ -10727,12 +10072,10 @@
       "item": "minecraft:chorus_fruit"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 0.1,
     "properties": {
       "version": "1.9"
-    },
-    "cookingtime": 200
+    }
   },
   "purpur_block": {
     "result": {
@@ -10744,7 +10087,6 @@
       "FF"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "F": {
         "item": "minecraft:popped_chorus_fruit"
@@ -10763,7 +10105,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:purpur_slab"
@@ -10782,7 +10123,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": [
         {
@@ -10809,7 +10149,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": [
         {
@@ -10835,11 +10174,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.9"
-    },
-    "group": "red_dye"
+    }
   },
   "regeneration_lingering_potion": {
     "result": "minecraft.lingering_potion.effect.regeneration",
@@ -10864,7 +10201,6 @@
       " W "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "W": {
         "tag": "minecraft:planks"
@@ -10902,7 +10238,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:glowstone_dust"
@@ -10987,7 +10322,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:spruce_planks"
@@ -10995,8 +10329,7 @@
     },
     "properties": {
       "version": "1.9"
-    },
-    "group": "boat"
+    }
   },
   "strength_lingering_potion": {
     "result": "minecraft.lingering_potion.effect.strength",
@@ -11950,7 +11283,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:bone_meal"
@@ -11971,11 +11303,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.10"
-    },
-    "group": "bonemeal"
+    }
   },
   "magma_block": {
     "result": {
@@ -11986,7 +11316,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:magma_cream"
@@ -12030,7 +11359,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.10"
     }
@@ -12044,7 +11372,6 @@
       "WN"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "W": {
         "item": "minecraft:nether_wart"
@@ -12092,13 +11419,11 @@
       }
     ],
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 0.1,
     "properties": {
       "animated": true,
       "version": "1.11"
-    },
-    "cookingtime": 200
+    }
   },
   "iron_ingot_from_nuggets": {
     "result": {
@@ -12110,7 +11435,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:iron_nugget"
@@ -12118,8 +11442,7 @@
     },
     "properties": {
       "version": "1.11"
-    },
-    "group": "iron_ingot"
+    }
   },
   "iron_nugget": {
     "result": {
@@ -12132,7 +11455,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.11"
     }
@@ -12184,12 +11506,10 @@
       }
     ],
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 0.1,
     "properties": {
       "version": "1.11"
-    },
-    "cookingtime": 100
+    }
   },
   "iron_nugget_from_smelting": {
     "result": "minecraft:iron_nugget",
@@ -12238,13 +11558,11 @@
       }
     ],
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 0.1,
     "properties": {
       "animated": true,
       "version": "1.11"
-    },
-    "cookingtime": 200
+    }
   },
   "observer": {
     "result": {
@@ -12256,7 +11574,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "Q": {
         "item": "minecraft:quartz"
@@ -12282,7 +11599,6 @@
       "-"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:chest"
@@ -13283,7 +12599,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:black_wool"
@@ -13295,8 +12610,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "black_bed_from_white_bed_legacy": {
     "result": {
@@ -13314,8 +12628,7 @@
     "properties": {
       "removed": "1.14",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "black_concrete_powder_legacy": {
     "result": {
@@ -13355,8 +12668,7 @@
     "properties": {
       "removed": "1.14",
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "black_glazed_terracotta": {
     "result": "minecraft:black_glazed_terracotta",
@@ -13364,12 +12676,10 @@
       "item": "minecraft:black_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "blue_bed": {
     "result": {
@@ -13380,7 +12690,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:blue_wool"
@@ -13392,8 +12701,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "blue_bed_from_white_bed_legacy": {
     "result": {
@@ -13411,8 +12719,7 @@
     "properties": {
       "removed": "1.14",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "blue_concrete_powder_legacy": {
     "result": {
@@ -13452,8 +12759,7 @@
     "properties": {
       "removed": "1.14",
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "blue_glazed_terracotta": {
     "result": "minecraft:blue_glazed_terracotta",
@@ -13461,12 +12767,10 @@
       "item": "minecraft:blue_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "brown_bed": {
     "result": {
@@ -13477,7 +12781,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:brown_wool"
@@ -13489,8 +12792,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "brown_bed_from_white_bed_legacy": {
     "result": {
@@ -13508,8 +12810,7 @@
     "properties": {
       "removed": "1.14",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "brown_concrete_powder_legacy": {
     "result": {
@@ -13549,8 +12850,7 @@
     "properties": {
       "removed": "1.14",
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "brown_glazed_terracotta": {
     "result": "minecraft:brown_glazed_terracotta",
@@ -13558,12 +12858,10 @@
       "item": "minecraft:brown_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "cyan_bed": {
     "result": {
@@ -13574,7 +12872,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:cyan_wool"
@@ -13586,8 +12883,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "cyan_bed_from_white_bed": {
     "result": {
@@ -13602,12 +12898,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "cyan_concrete_powder": {
     "result": {
@@ -13644,11 +12938,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "cyan_glazed_terracotta": {
     "result": "minecraft:cyan_glazed_terracotta",
@@ -13656,12 +12948,10 @@
       "item": "minecraft:cyan_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "gray_bed": {
     "result": {
@@ -13672,7 +12962,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:gray_wool"
@@ -13684,8 +12973,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "gray_bed_from_white_bed": {
     "result": {
@@ -13700,12 +12988,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "gray_concrete_powder": {
     "result": {
@@ -13742,11 +13028,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "gray_glazed_terracotta": {
     "result": "minecraft:gray_glazed_terracotta",
@@ -13754,12 +13038,10 @@
       "item": "minecraft:gray_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "green_bed": {
     "result": {
@@ -13770,7 +13052,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:green_wool"
@@ -13782,8 +13063,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "green_bed_from_white_bed": {
     "result": {
@@ -13798,12 +13078,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "green_concrete_powder": {
     "result": {
@@ -13840,11 +13118,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "green_glazed_terracotta": {
     "result": "minecraft:green_glazed_terracotta",
@@ -13852,12 +13128,10 @@
       "item": "minecraft:green_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "light_blue_bed": {
     "result": {
@@ -13868,7 +13142,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:light_blue_wool"
@@ -13880,8 +13153,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "light_blue_bed_from_white_bed": {
     "result": {
@@ -13896,12 +13168,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "light_blue_concrete_powder": {
     "result": {
@@ -13938,11 +13208,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "light_blue_glazed_terracotta": {
     "result": "minecraft:light_blue_glazed_terracotta",
@@ -13950,12 +13218,10 @@
       "item": "minecraft:light_blue_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "light_gray_bed": {
     "result": {
@@ -13966,7 +13232,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:light_gray_wool"
@@ -13978,8 +13243,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "light_gray_bed_from_white_bed": {
     "result": {
@@ -13994,12 +13258,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "light_gray_concrete_powder": {
     "result": {
@@ -14036,11 +13298,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "light_gray_glazed_terracotta": {
     "result": "minecraft:light_gray_glazed_terracotta",
@@ -14048,12 +13308,10 @@
       "item": "minecraft:light_gray_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "lime_bed": {
     "result": {
@@ -14064,7 +13322,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:lime_wool"
@@ -14076,8 +13333,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "lime_bed_from_white_bed": {
     "result": {
@@ -14092,12 +13348,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "lime_concrete_powder": {
     "result": {
@@ -14134,11 +13388,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "lime_glazed_terracotta": {
     "result": "minecraft:lime_glazed_terracotta",
@@ -14146,12 +13398,10 @@
       "item": "minecraft:lime_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "magenta_bed": {
     "result": {
@@ -14162,7 +13412,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:magenta_wool"
@@ -14174,8 +13423,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "magenta_bed_from_white_bed": {
     "result": {
@@ -14190,12 +13438,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "magenta_concrete_powder": {
     "result": {
@@ -14232,11 +13478,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "magenta_glazed_terracotta": {
     "result": "minecraft:magenta_glazed_terracotta",
@@ -14244,12 +13488,10 @@
       "item": "minecraft:magenta_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "orange_bed": {
     "result": {
@@ -14260,7 +13502,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:orange_wool"
@@ -14272,8 +13513,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "orange_bed_from_white_bed": {
     "result": {
@@ -14288,12 +13528,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "orange_concrete_powder": {
     "result": {
@@ -14330,11 +13568,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "orange_glazed_terracotta": {
     "result": "minecraft:orange_glazed_terracotta",
@@ -14342,12 +13578,10 @@
       "item": "minecraft:orange_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "pink_bed": {
     "result": {
@@ -14358,7 +13592,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:pink_wool"
@@ -14370,8 +13603,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "pink_bed_from_white_bed": {
     "result": {
@@ -14386,12 +13618,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "pink_concrete_powder": {
     "result": {
@@ -14428,11 +13658,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "pink_glazed_terracotta": {
     "result": "minecraft:pink_glazed_terracotta",
@@ -14440,12 +13668,10 @@
       "item": "minecraft:pink_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "purple_bed": {
     "result": {
@@ -14456,7 +13682,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:purple_wool"
@@ -14468,8 +13693,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "purple_bed_from_white_bed": {
     "result": {
@@ -14484,12 +13708,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "purple_concrete_powder": {
     "result": {
@@ -14526,11 +13748,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "purple_glazed_terracotta": {
     "result": "minecraft:purple_glazed_terracotta",
@@ -14538,12 +13758,10 @@
       "item": "minecraft:purple_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "red_bed": {
     "result": {
@@ -14554,7 +13772,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:red_wool"
@@ -14566,8 +13783,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "red_bed_from_white_bed": {
     "result": {
@@ -14582,12 +13798,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "red_concrete_powder": {
     "result": {
@@ -14624,11 +13838,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "red_glazed_terracotta": {
     "result": "minecraft:red_glazed_terracotta",
@@ -14636,12 +13848,10 @@
       "item": "minecraft:red_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "white_bed": {
     "result": {
@@ -14652,7 +13862,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_wool"
@@ -14664,8 +13873,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "white_concrete_powder_legacy": {
     "result": {
@@ -14705,8 +13913,7 @@
     "properties": {
       "removed": "1.14",
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "white_glazed_terracotta": {
     "result": "minecraft:white_glazed_terracotta",
@@ -14714,12 +13921,10 @@
       "item": "minecraft:white_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "yellow_bed": {
     "result": {
@@ -14730,7 +13935,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:yellow_wool"
@@ -14742,8 +13946,7 @@
     "properties": {
       "animated": true,
       "version": "1.12"
-    },
-    "group": "bed"
+    }
   },
   "yellow_bed_from_white_bed": {
     "result": {
@@ -14758,12 +13961,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.12"
-    },
-    "group": "dyed_bed"
+    }
   },
   "yellow_concrete_powder": {
     "result": {
@@ -14800,11 +14001,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.12"
-    },
-    "group": "concrete_powder"
+    }
   },
   "yellow_glazed_terracotta": {
     "result": "minecraft:yellow_glazed_terracotta",
@@ -14812,12 +14011,10 @@
       "item": "minecraft:yellow_terracotta"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.12"
-    },
-    "cookingtime": 200
+    }
   },
   "acacia_button": {
     "result": {
@@ -14829,11 +14026,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_button"
+    }
   },
   "acacia_pressure_plate": {
     "result": {
@@ -14843,7 +14038,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:acacia_planks"
@@ -14851,8 +14045,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_pressure_plate"
+    }
   },
   "acacia_trapdoor": {
     "result": {
@@ -14864,7 +14057,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:acacia_planks"
@@ -14872,8 +14064,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_trapdoor"
+    }
   },
   "acacia_wood": {
     "result": {
@@ -14885,7 +14076,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:acacia_log"
@@ -14893,8 +14083,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "bark"
+    }
   },
   "amplified_slowness_lingering_potion": {
     "result": "minecraft.lingering_potion.effect.slowness.iv",
@@ -15003,11 +14192,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_button"
+    }
   },
   "birch_pressure_plate": {
     "result": {
@@ -15017,7 +14204,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:birch_planks"
@@ -15025,8 +14211,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_pressure_plate"
+    }
   },
   "birch_trapdoor": {
     "result": {
@@ -15038,7 +14223,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:birch_planks"
@@ -15046,8 +14230,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_trapdoor"
+    }
   },
   "birch_wood": {
     "result": {
@@ -15059,7 +14242,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:birch_log"
@@ -15067,8 +14249,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "bark"
+    }
   },
   "blue_ice": {
     "result": {
@@ -15104,7 +14285,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.13"
     }
@@ -15119,7 +14299,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:nautilus_shell"
@@ -15142,7 +14321,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:red_sandstone"
@@ -15161,7 +14339,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:cut_red_sandstone"
@@ -15181,7 +14358,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:sandstone"
@@ -15200,7 +14376,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:cut_sandstone"
@@ -15220,11 +14395,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_button"
+    }
   },
   "dark_oak_pressure_plate": {
     "result": {
@@ -15234,7 +14407,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:dark_oak_planks"
@@ -15242,8 +14414,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_pressure_plate"
+    }
   },
   "dark_oak_trapdoor": {
     "result": {
@@ -15255,7 +14426,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:dark_oak_planks"
@@ -15263,8 +14433,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_trapdoor"
+    }
   },
   "dark_oak_wood": {
     "result": {
@@ -15276,7 +14445,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:dark_oak_log"
@@ -15284,8 +14452,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "bark"
+    }
   },
   "dark_prismarine_slab": {
     "result": {
@@ -15296,7 +14463,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:dark_prismarine"
@@ -15317,7 +14483,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:dark_prismarine"
@@ -15338,7 +14503,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.13"
     }
@@ -15353,7 +14517,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:dried_kelp"
@@ -15369,12 +14532,10 @@
       "item": "minecraft:kelp"
     },
     "type": "minecraft:campfire_cooking",
-    "category": "food",
     "experience": 0.1,
     "properties": {
       "version": "1.13"
-    },
-    "cookingtime": 600
+    }
   },
   "dried_kelp_from_smelting": {
     "result": "minecraft:dried_kelp",
@@ -15382,12 +14543,10 @@
       "item": "minecraft:kelp"
     },
     "type": "minecraft:smelting",
-    "category": "food",
     "experience": 0.1,
     "properties": {
       "version": "1.13"
-    },
-    "cookingtime": 200
+    }
   },
   "dried_kelp_from_smoking": {
     "result": "minecraft:dried_kelp",
@@ -15395,12 +14554,10 @@
       "item": "minecraft:kelp"
     },
     "type": "minecraft:smoking",
-    "category": "food",
     "experience": 0.1,
     "properties": {
       "version": "1.13"
-    },
-    "cookingtime": 100
+    }
   },
   "extended_slow_falling_lingering_potion": {
     "result": "minecraft.lingering_potion.effect.slow_falling.extended",
@@ -15490,11 +14647,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_button"
+    }
   },
   "jungle_pressure_plate": {
     "result": {
@@ -15504,7 +14659,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:jungle_planks"
@@ -15512,8 +14666,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_pressure_plate"
+    }
   },
   "jungle_trapdoor": {
     "result": {
@@ -15525,7 +14678,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:jungle_planks"
@@ -15533,8 +14685,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_trapdoor"
+    }
   },
   "jungle_wood": {
     "result": {
@@ -15546,7 +14697,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:jungle_log"
@@ -15554,8 +14704,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "bark"
+    }
   },
   "lime_dye_from_smelting": {
     "result": "minecraft:lime_dye",
@@ -15563,12 +14712,10 @@
       "item": "minecraft:sea_pickle"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 0.1,
     "properties": {
       "version": "1.13"
-    },
-    "cookingtime": 200
+    }
   },
   "lingering_amplified_slowness_potion": {
     "result": "minecraft.lingering_potion.effect.slowness.iv",
@@ -15676,7 +14823,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:oak_log"
@@ -15684,8 +14830,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "bark"
+    }
   },
   "packed_ice": {
     "result": {
@@ -15721,7 +14866,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.13"
     }
@@ -15735,7 +14879,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:prismarine_bricks"
@@ -15756,7 +14899,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:prismarine_bricks"
@@ -15775,7 +14917,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:prismarine"
@@ -15796,7 +14937,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:prismarine"
@@ -15822,7 +14962,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.13"
     }
@@ -15838,7 +14977,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.13"
     }
@@ -16054,11 +15192,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_button"
+    }
   },
   "spruce_pressure_plate": {
     "result": {
@@ -16068,7 +15204,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:spruce_planks"
@@ -16076,8 +15211,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_pressure_plate"
+    }
   },
   "spruce_trapdoor": {
     "result": {
@@ -16089,7 +15223,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:spruce_planks"
@@ -16097,8 +15230,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "wooden_trapdoor"
+    }
   },
   "spruce_wood": {
     "result": {
@@ -16110,7 +15242,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:spruce_log"
@@ -16118,8 +15249,7 @@
     },
     "properties": {
       "version": "1.13"
-    },
-    "group": "bark"
+    }
   },
   "stone_slab": {
     "result": {
@@ -16130,7 +15260,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stone"
@@ -16264,7 +15393,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "X": {
         "item": "minecraft:scute"
@@ -16324,7 +15452,6 @@
       " X "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:acacia_planks"
@@ -16335,8 +15462,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "wooden_sign"
+    }
   },
   "andesite_slab": {
     "result": {
@@ -16347,7 +15473,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:andesite"
@@ -16379,7 +15504,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:andesite"
@@ -16410,7 +15534,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:andesite"
@@ -16441,7 +15564,6 @@
       "PSP"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "P": {
         "tag": "minecraft:planks"
@@ -16466,7 +15588,6 @@
       " X "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:birch_planks"
@@ -16477,8 +15598,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "wooden_sign"
+    }
   },
   "black_bed_from_white_bed": {
     "result": {
@@ -16493,12 +15613,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "dyed_bed"
+    }
   },
   "black_carpet_from_white_carpet": {
     "result": {
@@ -16511,7 +15629,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -16523,8 +15640,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "black_concrete_powder": {
     "result": {
@@ -16561,11 +15677,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.14"
-    },
-    "group": "concrete_powder"
+    }
   },
   "black_dye": {
     "result": {
@@ -16577,11 +15691,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "black_dye"
+    }
   },
   "black_dye_from_wither_rose": {
     "result": {
@@ -16593,11 +15705,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "black_dye"
+    }
   },
   "black_stained_glass": {
     "result": {
@@ -16610,7 +15720,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -16621,8 +15730,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "stained_glass"
+    }
   },
   "black_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -16635,7 +15743,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -16646,8 +15753,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "black_terracotta": {
     "result": {
@@ -16660,7 +15766,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -16671,8 +15776,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "stained_terracotta"
+    }
   },
   "black_wool": {
     "result": {
@@ -16687,12 +15791,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "wool"
+    }
   },
   "blast_furnace": {
     "result": {
@@ -16704,7 +15806,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:smooth_stone"
@@ -16733,12 +15834,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "dyed_bed"
+    }
   },
   "blue_carpet_from_white_carpet": {
     "result": {
@@ -16751,7 +15850,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -16763,8 +15861,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "blue_concrete_powder": {
     "result": {
@@ -16801,11 +15898,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.14"
-    },
-    "group": "concrete_powder"
+    }
   },
   "blue_dye": {
     "result": {
@@ -16817,11 +15912,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "blue_dye"
+    }
   },
   "blue_dye_from_cornflower": {
     "result": {
@@ -16833,11 +15926,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "blue_dye"
+    }
   },
   "blue_stained_glass": {
     "result": {
@@ -16850,7 +15941,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -16861,8 +15951,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "stained_glass"
+    }
   },
   "blue_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -16875,7 +15964,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -16886,8 +15974,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "blue_terracotta": {
     "result": {
@@ -16900,7 +15987,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -16911,8 +15997,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "stained_terracotta"
+    }
   },
   "blue_wool": {
     "result": {
@@ -16927,12 +16012,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "wool"
+    }
   },
   "brick_slab_from_bricks_stonecutting": {
     "result": "minecraft:brick_slab",
@@ -16966,7 +16049,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:bricks"
@@ -17000,12 +16082,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "dyed_bed"
+    }
   },
   "brown_carpet_from_white_carpet": {
     "result": {
@@ -17018,7 +16098,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -17030,8 +16109,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "brown_concrete_powder": {
     "result": {
@@ -17068,11 +16146,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.14"
-    },
-    "group": "concrete_powder"
+    }
   },
   "brown_dye": {
     "result": {
@@ -17084,11 +16160,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "brown_dye"
+    }
   },
   "brown_stained_glass": {
     "result": {
@@ -17101,7 +16175,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -17112,8 +16185,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "stained_glass"
+    }
   },
   "brown_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -17126,7 +16198,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -17137,8 +16208,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "brown_terracotta": {
     "result": {
@@ -17151,7 +16221,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -17162,8 +16231,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "stained_terracotta"
+    }
   },
   "brown_wool": {
     "result": {
@@ -17178,12 +16246,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "wool"
+    }
   },
   "campfire": {
     "result": {
@@ -17195,7 +16261,6 @@
       "LLL"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "C": {
         "tag": "minecraft:coals"
@@ -17222,7 +16287,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "@": {
         "item": "minecraft:paper"
@@ -17300,7 +16364,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:cobblestone"
@@ -17414,7 +16477,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
     }
@@ -17429,7 +16491,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -17525,7 +16586,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -17537,8 +16597,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "cyan_dye": {
     "result": {
@@ -17554,11 +16613,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "cyan_dye"
+    }
   },
   "dark_oak_sign": {
     "result": {
@@ -17571,7 +16628,6 @@
       " X "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:dark_oak_planks"
@@ -17582,8 +16638,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "wooden_sign"
+    }
   },
   "dark_prismarine_slab_from_dark_prismarine_stonecutting": {
     "result": "minecraft:dark_prismarine_slab",
@@ -17616,7 +16671,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:diorite"
@@ -17648,7 +16702,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:diorite"
@@ -17679,7 +16732,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diorite"
@@ -17709,7 +16761,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:end_stone_bricks"
@@ -17752,7 +16803,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:end_stone_bricks"
@@ -17794,7 +16844,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:end_stone_bricks"
@@ -18025,7 +17074,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "@": {
         "item": "minecraft:flint"
@@ -18052,7 +17100,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
     }
@@ -18066,7 +17113,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:granite"
@@ -18098,7 +17144,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:granite"
@@ -18129,7 +17174,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:granite"
@@ -18161,7 +17205,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -18173,8 +17216,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "gray_dye": {
     "result": {
@@ -18190,7 +17232,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
     }
@@ -18206,7 +17247,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -18218,8 +17258,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "grindstone": {
     "result": {
@@ -18230,7 +17269,6 @@
       "# #"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "tag": "minecraft:planks"
@@ -18258,7 +17296,6 @@
       " X "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:jungle_planks"
@@ -18269,8 +17306,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "wooden_sign"
+    }
   },
   "lantern": {
     "result": {
@@ -18282,7 +17318,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:torch"
@@ -18305,7 +17340,6 @@
       "X X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "X": {
         "item": "minecraft:leather"
@@ -18325,7 +17359,6 @@
       " S "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "B": {
         "item": "minecraft:bookshelf"
@@ -18350,7 +17383,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -18362,8 +17394,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "light_blue_dye_from_blue_white_dye": {
     "result": {
@@ -18379,11 +17410,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "light_blue_dye"
+    }
   },
   "light_gray_carpet_from_white_carpet": {
     "result": {
@@ -18396,7 +17425,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -18408,8 +17436,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "light_gray_dye_from_black_white_dye": {
     "result": {
@@ -18428,11 +17455,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "light_gray_dye"
+    }
   },
   "light_gray_dye_from_gray_white_dye": {
     "result": {
@@ -18448,11 +17473,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "light_gray_dye"
+    }
   },
   "lime_carpet_from_white_carpet": {
     "result": {
@@ -18465,7 +17488,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -18477,8 +17499,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "lime_dye": {
     "result": {
@@ -18494,7 +17515,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
     }
@@ -18508,7 +17528,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "@": {
         "item": "minecraft:string"
@@ -18533,7 +17552,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -18545,8 +17563,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "magenta_dye_from_blue_red_pink": {
     "result": {
@@ -18565,11 +17582,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "magenta_dye"
+    }
   },
   "magenta_dye_from_blue_red_white_dye": {
     "result": {
@@ -18591,11 +17606,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "magenta_dye"
+    }
   },
   "mojang_banner_pattern": {
     "result": {
@@ -18610,7 +17623,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
     }
@@ -18624,7 +17636,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:mossy_cobblestone"
@@ -18656,7 +17667,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:mossy_cobblestone"
@@ -18687,7 +17697,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:mossy_cobblestone"
@@ -18717,7 +17726,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:mossy_stone_bricks"
@@ -18749,7 +17757,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:mossy_stone_bricks"
@@ -18780,7 +17787,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:mossy_stone_bricks"
@@ -18811,7 +17817,6 @@
       "W#W"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:nether_brick"
@@ -18856,7 +17861,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:nether_bricks"
@@ -18888,7 +17892,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -18900,8 +17903,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "pink_carpet_from_white_carpet": {
     "result": {
@@ -18914,7 +17916,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -18926,8 +17927,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "pink_dye_from_red_white_dye": {
     "result": {
@@ -18943,11 +17943,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "pink_dye"
+    }
   },
   "polished_andesite_from_andesite_stonecutting": {
     "result": "minecraft:polished_andesite",
@@ -18969,7 +17967,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_andesite"
@@ -19012,7 +18009,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_andesite"
@@ -19064,7 +18060,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_diorite"
@@ -19107,7 +18102,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_diorite"
@@ -19159,7 +18153,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_granite"
@@ -19202,7 +18195,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_granite"
@@ -19288,7 +18280,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:prismarine"
@@ -19320,7 +18311,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -19332,8 +18322,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "purple_dye": {
     "result": {
@@ -19349,7 +18338,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
     }
@@ -19431,7 +18419,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -19443,8 +18430,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "red_nether_brick_slab": {
     "result": {
@@ -19455,7 +18441,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:red_nether_bricks"
@@ -19487,7 +18472,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:red_nether_bricks"
@@ -19518,7 +18502,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:red_nether_bricks"
@@ -19571,7 +18554,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:red_sandstone"
@@ -19624,7 +18606,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:sandstone"
@@ -19656,7 +18637,6 @@
       "I I"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "I": {
         "item": "minecraft:bamboo"
@@ -19942,7 +18922,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
     }
@@ -19957,7 +18936,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "@": {
         "item": "minecraft:iron_ingot"
@@ -19981,7 +18959,6 @@
       " # "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "tag": "minecraft:logs"
@@ -20001,12 +18978,10 @@
       "item": "minecraft:quartz_block"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.14"
-    },
-    "cookingtime": 200
+    }
   },
   "smooth_quartz_slab": {
     "result": {
@@ -20017,7 +18992,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:smooth_quartz"
@@ -20049,7 +19023,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:smooth_quartz"
@@ -20079,7 +19052,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:smooth_red_sandstone"
@@ -20111,7 +19083,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:smooth_red_sandstone"
@@ -20141,7 +19112,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:smooth_sandstone"
@@ -20173,7 +19143,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:smooth_sandstone"
@@ -20200,12 +19169,10 @@
       "item": "minecraft:stone"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.14"
-    },
-    "cookingtime": 200
+    }
   },
   "smooth_stone_slab_from_smooth_stone_stonecutting": {
     "result": "minecraft:smooth_stone_slab",
@@ -20229,7 +19196,6 @@
       " X "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:spruce_planks"
@@ -20240,8 +19206,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "wooden_sign"
+    }
   },
   "stick_from_bamboo_item": {
     "result": {
@@ -20252,7 +19217,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:bamboo"
@@ -20260,8 +19224,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "sticks"
+    }
   },
   "stone_brick_slab_from_stone_bricks_stonecutting": {
     "result": "minecraft:stone_brick_slab",
@@ -20317,7 +19280,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stone_bricks"
@@ -20382,7 +19344,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stone"
@@ -20412,7 +19373,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stone"
@@ -20530,11 +19490,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.14"
-    },
-    "group": "concrete_powder"
+    }
   },
   "white_dye": {
     "result": {
@@ -20546,11 +19504,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "white_dye"
+    }
   },
   "white_dye_from_lily_of_the_valley": {
     "result": {
@@ -20562,11 +19518,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.14"
-    },
-    "group": "white_dye"
+    }
   },
   "white_stained_glass": {
     "result": {
@@ -20579,7 +19533,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:glass"
@@ -20590,8 +19543,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "stained_glass"
+    }
   },
   "white_stained_glass_pane_from_glass_pane": {
     "result": {
@@ -20604,7 +19556,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:glass_pane"
@@ -20615,8 +19566,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "stained_glass_pane"
+    }
   },
   "white_terracotta": {
     "result": {
@@ -20629,7 +19579,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:terracotta"
@@ -20640,8 +19589,7 @@
     },
     "properties": {
       "version": "1.14"
-    },
-    "group": "stained_terracotta"
+    }
   },
   "yellow_carpet_from_white_carpet": {
     "result": {
@@ -20654,7 +19602,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:white_carpet"
@@ -20666,8 +19613,7 @@
     "properties": {
       "removed": "1.20",
       "version": "1.14"
-    },
-    "group": "carpet"
+    }
   },
   "beehive": {
     "result": {
@@ -20679,7 +19625,6 @@
       "PPP"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "P": {
         "tag": "minecraft:planks"
@@ -20703,7 +19648,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "tag": "minecraft:wooden_slabs"
@@ -20724,7 +19668,6 @@
       "SSS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "S": {
         "item": "minecraft:prismarine_shard"
@@ -20746,7 +19689,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "lang": {
       "en_US": {
         "notes": "Empty bottles are left after crafting."
@@ -20784,7 +19726,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.15"
     }
@@ -20798,7 +19739,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:honeycomb"
@@ -20818,7 +19758,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stripped_acacia_log"
@@ -20826,8 +19765,7 @@
     },
     "properties": {
       "version": "1.15"
-    },
-    "group": "bark"
+    }
   },
   "stripped_birch_wood": {
     "result": {
@@ -20839,7 +19777,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stripped_birch_log"
@@ -20847,8 +19784,7 @@
     },
     "properties": {
       "version": "1.15"
-    },
-    "group": "bark"
+    }
   },
   "stripped_dark_oak_wood": {
     "result": {
@@ -20860,7 +19796,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stripped_dark_oak_log"
@@ -20868,8 +19803,7 @@
     },
     "properties": {
       "version": "1.15"
-    },
-    "group": "bark"
+    }
   },
   "stripped_jungle_wood": {
     "result": {
@@ -20881,7 +19815,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stripped_jungle_log"
@@ -20889,8 +19822,7 @@
     },
     "properties": {
       "version": "1.15"
-    },
-    "group": "bark"
+    }
   },
   "stripped_oak_wood": {
     "result": {
@@ -20902,7 +19834,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stripped_oak_log"
@@ -20910,8 +19841,7 @@
     },
     "properties": {
       "version": "1.15"
-    },
-    "group": "bark"
+    }
   },
   "stripped_spruce_wood": {
     "result": {
@@ -20923,7 +19853,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stripped_spruce_log"
@@ -20931,8 +19860,7 @@
     },
     "properties": {
       "version": "1.15"
-    },
-    "group": "bark"
+    }
   },
   "sugar_from_honey_bottle": {
     "result": {
@@ -20945,11 +19873,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.15"
-    },
-    "group": "sugar"
+    }
   },
   "blackstone_slab": {
     "result": {
@@ -20960,7 +19886,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:blackstone"
@@ -20992,7 +19917,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:blackstone"
@@ -21023,7 +19947,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:blackstone"
@@ -21054,7 +19977,6 @@
       "N"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "I": {
         "item": "minecraft:iron_ingot"
@@ -21076,7 +19998,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:nether_brick_slab"
@@ -21106,7 +20027,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_blackstone_slab"
@@ -21144,12 +20064,10 @@
       "item": "minecraft:nether_bricks"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.16"
-    },
-    "cookingtime": 200
+    }
   },
   "cracked_polished_blackstone_bricks": {
     "result": "minecraft:cracked_polished_blackstone_bricks",
@@ -21157,12 +20075,10 @@
       "item": "minecraft:polished_blackstone_bricks"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.16"
-    },
-    "cookingtime": 200
+    }
   },
   "crimson_button": {
     "result": {
@@ -21174,11 +20090,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_button"
+    }
   },
   "crimson_door": {
     "result": {
@@ -21191,7 +20105,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:crimson_planks"
@@ -21199,8 +20112,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_door"
+    }
   },
   "crimson_fence": {
     "result": {
@@ -21212,7 +20124,6 @@
       "W#W"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -21223,8 +20134,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_fence"
+    }
   },
   "crimson_fence_gate": {
     "result": {
@@ -21235,7 +20145,6 @@
       "#W#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -21246,8 +20155,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_fence_gate"
+    }
   },
   "crimson_hyphae": {
     "result": {
@@ -21259,7 +20167,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:crimson_stem"
@@ -21267,8 +20174,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "bark"
+    }
   },
   "crimson_planks": {
     "result": {
@@ -21281,12 +20187,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.16"
-    },
-    "group": "planks"
+    }
   },
   "crimson_pressure_plate": {
     "result": {
@@ -21296,7 +20200,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:crimson_planks"
@@ -21304,8 +20207,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_pressure_plate"
+    }
   },
   "crimson_sign": {
     "result": {
@@ -21318,7 +20220,6 @@
       " X "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:crimson_planks"
@@ -21329,8 +20230,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_sign"
+    }
   },
   "crimson_slab": {
     "result": {
@@ -21341,7 +20241,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:crimson_planks"
@@ -21349,8 +20248,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_slab"
+    }
   },
   "crimson_stairs": {
     "result": {
@@ -21363,7 +20261,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:crimson_planks"
@@ -21371,8 +20268,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_stairs"
+    }
   },
   "crimson_trapdoor": {
     "result": {
@@ -21384,7 +20280,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:crimson_planks"
@@ -21392,8 +20287,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_trapdoor"
+    }
   },
   "gold_ingot_from_blasting_nether_gold_ore": {
     "result": "minecraft:gold_ingot",
@@ -21401,13 +20295,10 @@
       "item": "minecraft:nether_gold_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 1,
     "properties": {
       "version": "1.16"
-    },
-    "cookingtime": 100,
-    "group": "gold_ingot"
+    }
   },
   "gold_ingot_from_smelting_nether_gold_ore": {
     "result": "minecraft:gold_ingot",
@@ -21415,13 +20306,10 @@
       "item": "minecraft:nether_gold_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 1,
     "properties": {
       "version": "1.16"
-    },
-    "cookingtime": 200,
-    "group": "gold_ingot"
+    }
   },
   "lodestone": {
     "result": {
@@ -21433,7 +20321,6 @@
       "SSS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:netherite_ingot"
@@ -21454,7 +20341,8 @@
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16"
+      "version": "1.16",
+      "removed": "1.20"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -21473,7 +20361,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:netherite_ingot"
@@ -21491,7 +20378,8 @@
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16"
+      "version": "1.16",
+      "removed": "1.20"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -21508,7 +20396,8 @@
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16"
+      "version": "1.16",
+      "removed": "1.20"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -21525,7 +20414,8 @@
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16"
+      "version": "1.16",
+      "removed": "1.20"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -21542,7 +20432,8 @@
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16"
+      "version": "1.16",
+      "removed": "1.20"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -21582,11 +20473,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.16"
-    },
-    "group": "netherite_ingot"
+    }
   },
   "netherite_ingot_from_netherite_block": {
     "result": {
@@ -21599,11 +20488,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.16"
-    },
-    "group": "netherite_ingot"
+    }
   },
   "netherite_leggings_smithing_legacy": {
     "result": {
@@ -21613,7 +20500,8 @@
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16"
+      "version": "1.16",
+      "removed": "1.20"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -21630,7 +20518,8 @@
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16"
+      "version": "1.16",
+      "removed": "1.20"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -21645,12 +20534,10 @@
       "item": "minecraft:ancient_debris"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 2,
     "properties": {
       "version": "1.16"
-    },
-    "cookingtime": 200
+    }
   },
   "netherite_scrap_from_blasting": {
     "result": "minecraft:netherite_scrap",
@@ -21658,12 +20545,10 @@
       "item": "minecraft:ancient_debris"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 2,
     "properties": {
       "version": "1.16"
-    },
-    "cookingtime": 100
+    }
   },
   "netherite_shovel_smithing_legacy": {
     "result": {
@@ -21673,7 +20558,8 @@
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16"
+      "version": "1.16",
+      "removed": "1.20"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -21690,7 +20576,8 @@
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16"
+      "version": "1.16",
+      "removed": "1.20"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -21709,7 +20596,6 @@
       "SS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "S": {
         "item": "minecraft:basalt"
@@ -21740,7 +20626,6 @@
       "SS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "S": {
         "item": "minecraft:blackstone"
@@ -21759,7 +20644,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_blackstone_bricks"
@@ -21813,7 +20697,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_blackstone_bricks"
@@ -21866,7 +20749,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:polished_blackstone_bricks"
@@ -21919,7 +20801,6 @@
       "SS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "S": {
         "item": "minecraft:polished_blackstone"
@@ -21961,7 +20842,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
     "properties": {
       "version": "1.16"
     }
@@ -21985,7 +20865,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:polished_blackstone"
@@ -22004,7 +20883,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_blackstone"
@@ -22047,7 +20925,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_blackstone"
@@ -22089,7 +20966,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:polished_blackstone"
@@ -22131,7 +21007,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:quartz_block"
@@ -22162,7 +21037,6 @@
       "OOO"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "G": {
         "item": "minecraft:glowstone"
@@ -22185,7 +21059,6 @@
       "LLL"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "tag": "minecraft:soul_fire_base_blocks"
@@ -22212,7 +21085,6 @@
       "XXX"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:soul_torch"
@@ -22236,7 +21108,6 @@
       "S"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -22268,7 +21139,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stripped_crimson_stem"
@@ -22276,8 +21146,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "bark"
+    }
   },
   "stripped_warped_hyphae": {
     "result": {
@@ -22289,7 +21158,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stripped_warped_stem"
@@ -22297,8 +21165,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "bark"
+    }
   },
   "target": {
     "result": {
@@ -22310,7 +21177,6 @@
       " R "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "R": {
         "item": "minecraft:redstone"
@@ -22333,11 +21199,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_button"
+    }
   },
   "warped_door": {
     "result": {
@@ -22350,7 +21214,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:warped_planks"
@@ -22358,8 +21221,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_door"
+    }
   },
   "warped_fence": {
     "result": {
@@ -22371,7 +21233,6 @@
       "W#W"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -22382,8 +21243,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_fence"
+    }
   },
   "warped_fence_gate": {
     "result": {
@@ -22394,7 +21254,6 @@
       "#W#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -22405,8 +21264,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_fence_gate"
+    }
   },
   "warped_fungus_on_a_stick": {
     "result": {
@@ -22417,7 +21275,6 @@
       " X"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:fishing_rod"
@@ -22440,7 +21297,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:warped_stem"
@@ -22448,8 +21304,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "bark"
+    }
   },
   "warped_planks": {
     "result": {
@@ -22462,12 +21317,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.16"
-    },
-    "group": "planks"
+    }
   },
   "warped_pressure_plate": {
     "result": {
@@ -22477,7 +21330,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:warped_planks"
@@ -22485,8 +21337,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_pressure_plate"
+    }
   },
   "warped_sign": {
     "result": {
@@ -22499,7 +21350,6 @@
       " X "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:warped_planks"
@@ -22510,8 +21360,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_sign"
+    }
   },
   "warped_slab": {
     "result": {
@@ -22522,7 +21371,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:warped_planks"
@@ -22530,8 +21378,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_slab"
+    }
   },
   "warped_stairs": {
     "result": {
@@ -22544,7 +21391,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:warped_planks"
@@ -22552,8 +21398,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_stairs"
+    }
   },
   "warped_trapdoor": {
     "result": {
@@ -22565,7 +21410,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:warped_planks"
@@ -22573,8 +21417,7 @@
     },
     "properties": {
       "version": "1.16"
-    },
-    "group": "wooden_trapdoor"
+    }
   },
   "brewing_stand_from_blackstone": {
     "result": {
@@ -22606,7 +21449,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:amethyst_shard"
@@ -22629,11 +21471,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "blue_candle": {
     "result": {
@@ -22648,11 +21488,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "brewing_stand_from_cobbled_deepslate": {
     "result": {
@@ -22688,11 +21526,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "candle": {
     "result": {
@@ -22703,7 +21539,6 @@
       "H"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "S": {
         "item": "minecraft:string"
@@ -22725,7 +21560,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:cobbled_deepslate_slab"
@@ -22752,13 +21586,10 @@
       "item": "minecraft:coal_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 0.1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "coal"
+    }
   },
   "coal_from_blasting_deepslate_coal_ore": {
     "result": "minecraft:coal",
@@ -22766,13 +21597,10 @@
       "item": "minecraft:deepslate_coal_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 0.1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "coal"
+    }
   },
   "coal_from_smelting_deepslate_coal_ore": {
     "result": "minecraft:coal",
@@ -22780,13 +21608,10 @@
       "item": "minecraft:deepslate_coal_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 0.1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200,
-    "group": "coal"
+    }
   },
   "cobbled_deepslate_slab": {
     "result": {
@@ -22797,7 +21622,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:cobbled_deepslate"
@@ -22829,7 +21653,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:cobbled_deepslate"
@@ -22860,7 +21683,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:cobbled_deepslate"
@@ -22891,7 +21713,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:copper_ingot"
@@ -22912,11 +21733,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "copper_ingot"
+    }
   },
   "copper_ingot_from_blasting_copper_ore": {
     "result": "minecraft:copper_ingot",
@@ -22924,13 +21743,10 @@
       "item": "minecraft:copper_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 0.7,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "copper_ingot"
+    }
   },
   "copper_ingot_from_blasting_deepslate_copper_ore": {
     "result": "minecraft:copper_ingot",
@@ -22938,13 +21754,10 @@
       "item": "minecraft:deepslate_copper_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 0.7,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "copper_ingot"
+    }
   },
   "copper_ingot_from_blasting_raw_copper": {
     "result": "minecraft:copper_ingot",
@@ -22952,13 +21765,10 @@
       "item": "minecraft:raw_copper"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 0.7,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "copper_ingot"
+    }
   },
   "copper_ingot_from_smelting_copper_ore": {
     "result": "minecraft:copper_ingot",
@@ -22966,13 +21776,10 @@
       "item": "minecraft:copper_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 0.7,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200,
-    "group": "copper_ingot"
+    }
   },
   "copper_ingot_from_smelting_deepslate_copper_ore": {
     "result": "minecraft:copper_ingot",
@@ -22980,13 +21787,10 @@
       "item": "minecraft:deepslate_copper_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 0.7,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200,
-    "group": "copper_ingot"
+    }
   },
   "copper_ingot_from_smelting_raw_copper": {
     "result": "minecraft:copper_ingot",
@@ -22994,13 +21798,10 @@
       "item": "minecraft:raw_copper"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 0.7,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200,
-    "group": "copper_ingot"
+    }
   },
   "copper_ingot_from_waxed_copper_block": {
     "result": {
@@ -23013,11 +21814,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "copper_ingot"
+    }
   },
   "cracked_deepslate_bricks": {
     "result": "minecraft:cracked_deepslate_bricks",
@@ -23025,12 +21824,10 @@
       "item": "minecraft:deepslate_bricks"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200
+    }
   },
   "cracked_deepslate_tiles": {
     "result": "minecraft:cracked_deepslate_tiles",
@@ -23038,12 +21835,10 @@
       "item": "minecraft:deepslate_tiles"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200
+    }
   },
   "cut_copper": {
     "result": {
@@ -23055,7 +21850,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:copper_block"
@@ -23090,7 +21884,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:cut_copper"
@@ -23138,7 +21931,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:cut_copper"
@@ -23188,11 +21980,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "deepslate": {
     "result": "minecraft:deepslate",
@@ -23200,12 +21990,10 @@
       "item": "minecraft:cobbled_deepslate"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200
+    }
   },
   "deepslate_brick_slab": {
     "result": {
@@ -23216,7 +22004,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:deepslate_bricks"
@@ -23270,7 +22057,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:deepslate_bricks"
@@ -23323,7 +22109,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:deepslate_bricks"
@@ -23376,7 +22161,6 @@
       "SS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "S": {
         "item": "minecraft:polished_deepslate"
@@ -23417,7 +22201,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:deepslate_tiles"
@@ -23482,7 +22265,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:deepslate_tiles"
@@ -23546,7 +22328,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:deepslate_tiles"
@@ -23610,7 +22391,6 @@
       "SS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "S": {
         "item": "minecraft:deepslate_bricks"
@@ -23659,13 +22439,10 @@
       "item": "minecraft:deepslate_diamond_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "diamond"
+    }
   },
   "diamond_from_smelting_deepslate_diamond_ore": {
     "result": "minecraft:diamond",
@@ -23673,13 +22450,10 @@
       "item": "minecraft:deepslate_diamond_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200,
-    "group": "diamond"
+    }
   },
   "dripstone_block": {
     "result": {
@@ -23690,7 +22464,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:pointed_dripstone"
@@ -23706,13 +22479,10 @@
       "item": "minecraft:deepslate_emerald_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "emerald"
+    }
   },
   "emerald_from_smelting_deepslate_emerald_ore": {
     "result": "minecraft:emerald",
@@ -23720,13 +22490,10 @@
       "item": "minecraft:deepslate_emerald_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200,
-    "group": "emerald"
+    }
   },
   "exposed_cut_copper": {
     "result": {
@@ -23738,7 +22505,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:exposed_copper"
@@ -23773,7 +22539,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:exposed_cut_copper"
@@ -23821,7 +22586,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:exposed_cut_copper"
@@ -23871,7 +22635,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
     }
@@ -23882,13 +22645,10 @@
       "item": "minecraft:deepslate_gold_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "gold_ingot"
+    }
   },
   "gold_ingot_from_blasting_raw_gold": {
     "result": "minecraft:gold_ingot",
@@ -23896,13 +22656,10 @@
       "item": "minecraft:raw_gold"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "gold_ingot"
+    }
   },
   "gold_ingot_from_smelting_deepslate_gold_ore": {
     "result": "minecraft:gold_ingot",
@@ -23910,13 +22667,10 @@
       "item": "minecraft:deepslate_gold_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200,
-    "group": "gold_ingot"
+    }
   },
   "gold_ingot_from_smelting_raw_gold": {
     "result": "minecraft:gold_ingot",
@@ -23924,13 +22678,10 @@
       "item": "minecraft:raw_gold"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200,
-    "group": "gold_ingot"
+    }
   },
   "gray_candle": {
     "result": {
@@ -23945,11 +22696,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "green_candle": {
     "result": {
@@ -23964,11 +22713,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "iron_ingot_from_blasting_deepslate_iron_ore": {
     "result": "minecraft:iron_ingot",
@@ -23976,13 +22723,10 @@
       "item": "minecraft:deepslate_iron_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 0.7,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "iron_ingot"
+    }
   },
   "iron_ingot_from_blasting_raw_iron": {
     "result": "minecraft:iron_ingot",
@@ -23990,13 +22734,10 @@
       "item": "minecraft:raw_iron"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 0.7,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "iron_ingot"
+    }
   },
   "iron_ingot_from_smelting_deepslate_iron_ore": {
     "result": "minecraft:iron_ingot",
@@ -24004,13 +22745,10 @@
       "item": "minecraft:deepslate_iron_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 0.7,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200,
-    "group": "iron_ingot"
+    }
   },
   "iron_ingot_from_smelting_raw_iron": {
     "result": "minecraft:iron_ingot",
@@ -24018,13 +22756,10 @@
       "item": "minecraft:raw_iron"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 0.7,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200,
-    "group": "iron_ingot"
+    }
   },
   "lapis_lazuli_from_blasting_deepslate_lapis_ore": {
     "result": "minecraft:lapis_lazuli",
@@ -24032,13 +22767,10 @@
       "item": "minecraft:deepslate_lapis_ore"
     },
     "type": "minecraft:blasting",
-    "category": "misc",
     "experience": 0.2,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "lapis_lazuli"
+    }
   },
   "lapis_lazuli_from_smelting_deepslate_lapis_ore": {
     "result": "minecraft:lapis_lazuli",
@@ -24046,13 +22778,10 @@
       "item": "minecraft:deepslate_lapis_ore"
     },
     "type": "minecraft:smelting",
-    "category": "misc",
     "experience": 0.2,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200,
-    "group": "lapis_lazuli"
+    }
   },
   "light_blue_candle": {
     "result": {
@@ -24067,11 +22796,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "light_gray_candle": {
     "result": {
@@ -24086,11 +22813,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "lightning_rod": {
     "result": {
@@ -24102,7 +22827,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:copper_ingot"
@@ -24125,11 +22849,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "magenta_candle": {
     "result": {
@@ -24144,11 +22866,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "moss_carpet": {
     "result": {
@@ -24159,7 +22879,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:moss_block"
@@ -24167,8 +22886,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "carpet"
+    }
   },
   "mossy_cobblestone_from_moss_block": {
     "result": {
@@ -24183,11 +22901,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "mossy_cobblestone"
+    }
   },
   "mossy_stone_bricks_from_moss_block": {
     "result": {
@@ -24202,11 +22918,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "mossy_stone_bricks"
+    }
   },
   "orange_candle": {
     "result": {
@@ -24221,11 +22935,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "oxidized_cut_copper": {
     "result": {
@@ -24237,7 +22949,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:oxidized_copper"
@@ -24272,7 +22983,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:oxidized_cut_copper"
@@ -24320,7 +23030,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:oxidized_cut_copper"
@@ -24370,11 +23079,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "polished_deepslate": {
     "result": {
@@ -24386,7 +23093,6 @@
       "SS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "S": {
         "item": "minecraft:cobbled_deepslate"
@@ -24416,7 +23122,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_deepslate"
@@ -24459,7 +23164,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:polished_deepslate"
@@ -24501,7 +23205,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:polished_deepslate"
@@ -24546,11 +23249,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "raw_copper": {
     "result": {
@@ -24563,7 +23264,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
     }
@@ -24578,7 +23278,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:raw_copper"
@@ -24599,7 +23298,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
     }
@@ -24614,7 +23312,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:raw_gold"
@@ -24635,7 +23332,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
     }
@@ -24650,7 +23346,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:raw_iron"
@@ -24673,11 +23368,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "redstone_from_blasting_deepslate_redstone_ore": {
     "result": "minecraft:redstone",
@@ -24685,13 +23378,10 @@
       "item": "minecraft:deepslate_redstone_ore"
     },
     "type": "minecraft:blasting",
-    "category": "blocks",
     "experience": 0.7,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 100,
-    "group": "redstone"
+    }
   },
   "redstone_from_smelting_deepslate_redstone_ore": {
     "result": "minecraft:redstone",
@@ -24699,13 +23389,10 @@
       "item": "minecraft:deepslate_redstone_ore"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.7,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200,
-    "group": "redstone"
+    }
   },
   "smooth_basalt": {
     "result": "minecraft:smooth_basalt",
@@ -24713,12 +23400,10 @@
       "item": "minecraft:basalt"
     },
     "type": "minecraft:smelting",
-    "category": "blocks",
     "experience": 0.1,
     "properties": {
       "version": "1.17"
-    },
-    "cookingtime": 200
+    }
   },
   "spyglass": {
     "result": {
@@ -24730,7 +23415,6 @@
       " X "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:amethyst_shard"
@@ -24754,7 +23438,6 @@
       " S "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "S": {
         "item": "minecraft:amethyst_shard"
@@ -24780,11 +23463,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_copper_block"
+    }
   },
   "waxed_cut_copper": {
     "result": {
@@ -24796,7 +23477,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:waxed_copper_block"
@@ -24804,8 +23484,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_cut_copper"
+    }
   },
   "waxed_cut_copper_from_honeycomb": {
     "result": {
@@ -24820,11 +23499,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_cut_copper"
+    }
   },
   "waxed_cut_copper_from_waxed_copper_block_stonecutting": {
     "result": "minecraft:waxed_cut_copper",
@@ -24851,7 +23528,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:waxed_cut_copper"
@@ -24859,8 +23535,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_cut_copper_slab"
+    }
   },
   "waxed_cut_copper_slab_from_honeycomb": {
     "result": {
@@ -24875,11 +23550,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_cut_copper_slab"
+    }
   },
   "waxed_cut_copper_slab_from_waxed_copper_block_stonecutting": {
     "result": "minecraft:waxed_cut_copper_slab",
@@ -24919,7 +23592,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:waxed_cut_copper"
@@ -24927,8 +23599,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_cut_copper_stairs"
+    }
   },
   "waxed_cut_copper_stairs_from_honeycomb": {
     "result": {
@@ -24943,11 +23614,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_cut_copper_stairs"
+    }
   },
   "waxed_cut_copper_stairs_from_waxed_copper_block_stonecutting": {
     "result": "minecraft:waxed_cut_copper_stairs",
@@ -24989,11 +23658,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_exposed_copper"
+    }
   },
   "waxed_exposed_cut_copper": {
     "result": {
@@ -25005,7 +23672,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:waxed_exposed_copper"
@@ -25013,8 +23679,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_exposed_cut_copper"
+    }
   },
   "waxed_exposed_cut_copper_from_honeycomb": {
     "result": {
@@ -25029,11 +23694,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_exposed_cut_copper"
+    }
   },
   "waxed_exposed_cut_copper_from_waxed_exposed_copper_stonecutting": {
     "result": "minecraft:waxed_exposed_cut_copper",
@@ -25060,7 +23723,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:waxed_exposed_cut_copper"
@@ -25068,8 +23730,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_exposed_cut_copper_slab"
+    }
   },
   "waxed_exposed_cut_copper_slab_from_honeycomb": {
     "result": {
@@ -25084,11 +23745,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_exposed_cut_copper_slab"
+    }
   },
   "waxed_exposed_cut_copper_slab_from_waxed_exposed_copper_stonecutting": {
     "result": "minecraft:waxed_exposed_cut_copper_slab",
@@ -25128,7 +23787,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:waxed_exposed_cut_copper"
@@ -25136,8 +23794,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_exposed_cut_copper_stairs"
+    }
   },
   "waxed_exposed_cut_copper_stairs_from_honeycomb": {
     "result": {
@@ -25152,11 +23809,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_exposed_cut_copper_stairs"
+    }
   },
   "waxed_exposed_cut_copper_stairs_from_waxed_exposed_copper_stonecutting": {
     "result": "minecraft:waxed_exposed_cut_copper_stairs",
@@ -25198,11 +23853,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_oxidized_copper"
+    }
   },
   "waxed_oxidized_cut_copper": {
     "result": {
@@ -25214,7 +23867,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:waxed_oxidized_copper"
@@ -25222,8 +23874,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_oxidized_cut_copper"
+    }
   },
   "waxed_oxidized_cut_copper_from_honeycomb": {
     "result": {
@@ -25238,11 +23889,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_oxidized_cut_copper"
+    }
   },
   "waxed_oxidized_cut_copper_from_waxed_oxidized_copper_stonecutting": {
     "result": "minecraft:waxed_oxidized_cut_copper",
@@ -25269,7 +23918,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:waxed_oxidized_cut_copper"
@@ -25277,8 +23925,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_oxidized_cut_copper_slab"
+    }
   },
   "waxed_oxidized_cut_copper_slab_from_honeycomb": {
     "result": {
@@ -25293,11 +23940,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_oxidized_cut_copper_slab"
+    }
   },
   "waxed_oxidized_cut_copper_slab_from_waxed_oxidized_copper_stonecutting": {
     "result": "minecraft:waxed_oxidized_cut_copper_slab",
@@ -25337,7 +23982,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:waxed_oxidized_cut_copper"
@@ -25345,8 +23989,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_oxidized_cut_copper_stairs"
+    }
   },
   "waxed_oxidized_cut_copper_stairs_from_honeycomb": {
     "result": {
@@ -25361,11 +24004,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_oxidized_cut_copper_stairs"
+    }
   },
   "waxed_oxidized_cut_copper_stairs_from_waxed_oxidized_copper_stonecutting": {
     "result": "minecraft:waxed_oxidized_cut_copper_stairs",
@@ -25407,11 +24048,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_weathered_copper"
+    }
   },
   "waxed_weathered_cut_copper": {
     "result": {
@@ -25423,7 +24062,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:waxed_weathered_copper"
@@ -25431,8 +24069,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_weathered_cut_copper"
+    }
   },
   "waxed_weathered_cut_copper_from_honeycomb": {
     "result": {
@@ -25447,11 +24084,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_weathered_cut_copper"
+    }
   },
   "waxed_weathered_cut_copper_from_waxed_weathered_copper_stonecutting": {
     "result": "minecraft:waxed_weathered_cut_copper",
@@ -25478,7 +24113,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:waxed_weathered_cut_copper"
@@ -25486,8 +24120,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_weathered_cut_copper_slab"
+    }
   },
   "waxed_weathered_cut_copper_slab_from_honeycomb": {
     "result": {
@@ -25502,11 +24135,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_weathered_cut_copper_slab"
+    }
   },
   "waxed_weathered_cut_copper_slab_from_waxed_weathered_copper_stonecutting": {
     "result": "minecraft:waxed_weathered_cut_copper_slab",
@@ -25546,7 +24177,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:waxed_weathered_cut_copper"
@@ -25554,8 +24184,7 @@
     },
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_weathered_cut_copper_stairs"
+    }
   },
   "waxed_weathered_cut_copper_stairs_from_honeycomb": {
     "result": {
@@ -25570,11 +24199,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.17"
-    },
-    "group": "waxed_weathered_cut_copper_stairs"
+    }
   },
   "waxed_weathered_cut_copper_stairs_from_waxed_weathered_copper_stonecutting": {
     "result": "minecraft:waxed_weathered_cut_copper_stairs",
@@ -25613,7 +24240,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:weathered_copper"
@@ -25648,7 +24274,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:weathered_cut_copper"
@@ -25696,7 +24321,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:weathered_cut_copper"
@@ -25746,11 +24370,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "yellow_candle": {
     "result": {
@@ -25765,11 +24387,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.17"
-    },
-    "group": "dyed_candle"
+    }
   },
   "acacia_chest_boat": {
     "result": {
@@ -25784,11 +24404,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.19"
-    },
-    "group": "chest_boat"
+    }
   },
   "birch_chest_boat": {
     "result": {
@@ -25803,11 +24421,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.19"
-    },
-    "group": "chest_boat"
+    }
   },
   "dark_oak_chest_boat": {
     "result": {
@@ -25822,11 +24438,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.19"
-    },
-    "group": "chest_boat"
+    }
   },
   "jungle_chest_boat": {
     "result": {
@@ -25841,11 +24455,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.19"
-    },
-    "group": "chest_boat"
+    }
   },
   "mangrove_boat": {
     "result": {
@@ -25856,7 +24468,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:mangrove_planks"
@@ -25864,8 +24475,7 @@
     },
     "properties": {
       "version": "1.19"
-    },
-    "group": "boat"
+    }
   },
   "mangrove_button": {
     "result": {
@@ -25877,11 +24487,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
     "properties": {
       "version": "1.19"
-    },
-    "group": "wooden_button"
+    }
   },
   "mangrove_chest_boat": {
     "result": {
@@ -25896,11 +24504,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.19"
-    },
-    "group": "chest_boat"
+    }
   },
   "mangrove_door": {
     "result": {
@@ -25913,7 +24519,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:mangrove_planks"
@@ -25921,8 +24526,7 @@
     },
     "properties": {
       "version": "1.19"
-    },
-    "group": "wooden_door"
+    }
   },
   "mangrove_fence": {
     "result": {
@@ -25934,7 +24538,6 @@
       "W#W"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -25945,8 +24548,7 @@
     },
     "properties": {
       "version": "1.19"
-    },
-    "group": "wooden_fence"
+    }
   },
   "mangrove_fence_gate": {
     "result": {
@@ -25957,7 +24559,6 @@
       "#W#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -25968,8 +24569,7 @@
     },
     "properties": {
       "version": "1.19"
-    },
-    "group": "wooden_fence_gate"
+    }
   },
   "mangrove_planks": {
     "result": {
@@ -25982,12 +24582,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.19"
-    },
-    "group": "planks"
+    }
   },
   "mangrove_pressure_plate": {
     "result": {
@@ -25997,7 +24595,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:mangrove_planks"
@@ -26005,8 +24602,7 @@
     },
     "properties": {
       "version": "1.19"
-    },
-    "group": "wooden_pressure_plate"
+    }
   },
   "mangrove_sign": {
     "result": {
@@ -26019,7 +24615,6 @@
       " X "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:mangrove_planks"
@@ -26030,8 +24625,7 @@
     },
     "properties": {
       "version": "1.19"
-    },
-    "group": "wooden_sign"
+    }
   },
   "mangrove_slab": {
     "result": {
@@ -26042,7 +24636,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:mangrove_planks"
@@ -26050,8 +24643,7 @@
     },
     "properties": {
       "version": "1.19"
-    },
-    "group": "wooden_slab"
+    }
   },
   "mangrove_stairs": {
     "result": {
@@ -26064,7 +24656,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:mangrove_planks"
@@ -26072,8 +24663,7 @@
     },
     "properties": {
       "version": "1.19"
-    },
-    "group": "wooden_stairs"
+    }
   },
   "mangrove_trapdoor": {
     "result": {
@@ -26085,7 +24675,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:mangrove_planks"
@@ -26093,8 +24682,7 @@
     },
     "properties": {
       "version": "1.19"
-    },
-    "group": "wooden_trapdoor"
+    }
   },
   "mangrove_wood": {
     "result": {
@@ -26106,7 +24694,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:mangrove_log"
@@ -26114,8 +24701,7 @@
     },
     "properties": {
       "version": "1.19"
-    },
-    "group": "bark"
+    }
   },
   "mud_brick_slab": {
     "result": {
@@ -26126,7 +24712,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:mud_bricks"
@@ -26158,7 +24743,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:mud_bricks"
@@ -26189,7 +24773,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:mud_bricks"
@@ -26220,7 +24803,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:packed_mud"
@@ -26243,7 +24825,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.19"
     }
@@ -26282,7 +24863,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.19"
     }
@@ -26300,11 +24880,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.19"
-    },
-    "group": "chest_boat"
+    }
   },
   "packed_mud": {
     "result": {
@@ -26319,7 +24897,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "version": "1.19"
     }
@@ -26334,7 +24911,6 @@
       "SSS"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "C": {
         "item": "minecraft:compass"
@@ -26360,11 +24936,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.19"
-    },
-    "group": "chest_boat"
+    }
   },
   "stripped_mangrove_wood": {
     "result": {
@@ -26376,7 +24950,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stripped_mangrove_log"
@@ -26384,8 +24957,7 @@
     },
     "properties": {
       "version": "1.19"
-    },
-    "group": "bark"
+    }
   },
   "bundle": {
     "result": {
@@ -26397,7 +24969,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:rabbit_hide"
@@ -26422,7 +24993,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stripped_acacia_log"
@@ -26434,8 +25004,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "hanging_sign"
+    }
   },
   "bamboo_block": {
     "result": {
@@ -26471,7 +25040,6 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
@@ -26487,12 +25055,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "wooden_button"
+    }
   },
   "bamboo_chest_raft": {
     "result": {
@@ -26507,12 +25073,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "chest_boat"
+    }
   },
   "bamboo_door": {
     "result": {
@@ -26525,7 +25089,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:bamboo_planks"
@@ -26534,8 +25097,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "wooden_door"
+    }
   },
   "bamboo_fence": {
     "result": {
@@ -26547,7 +25109,6 @@
       "W#W"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -26559,8 +25120,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "wooden_custom_fence"
+    }
   },
   "bamboo_fence_gate": {
     "result": {
@@ -26571,7 +25131,6 @@
       "#W#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -26583,8 +25142,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "wooden_custom_fence_gate"
+    }
   },
   "bamboo_hanging_sign": {
     "result": {
@@ -26597,7 +25155,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stripped_bamboo_block"
@@ -26609,8 +25166,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "hanging_sign"
+    }
   },
   "bamboo_mosaic": {
     "result": {
@@ -26621,7 +25177,6 @@
       "#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:bamboo_slab"
@@ -26641,7 +25196,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:bamboo_mosaic"
@@ -26663,7 +25217,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:bamboo_mosaic"
@@ -26685,13 +25238,11 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "feature_flag": "1.20",
       "animated": true,
       "version": "1.19.3"
-    },
-    "group": "planks"
+    }
   },
   "bamboo_pressure_plate": {
     "result": {
@@ -26701,7 +25252,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:bamboo_planks"
@@ -26710,8 +25260,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "wooden_pressure_plate"
+    }
   },
   "bamboo_raft": {
     "result": {
@@ -26722,7 +25271,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:bamboo_planks"
@@ -26731,8 +25279,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "boat"
+    }
   },
   "bamboo_sign": {
     "result": {
@@ -26745,7 +25292,6 @@
       " X "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:bamboo_planks"
@@ -26757,8 +25303,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "wooden_sign"
+    }
   },
   "bamboo_slab": {
     "result": {
@@ -26769,7 +25314,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:bamboo_planks"
@@ -26778,8 +25322,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "wooden_slab"
+    }
   },
   "bamboo_stairs": {
     "result": {
@@ -26792,7 +25335,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:bamboo_planks"
@@ -26801,8 +25343,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "wooden_stairs"
+    }
   },
   "bamboo_trapdoor": {
     "result": {
@@ -26814,7 +25355,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:bamboo_planks"
@@ -26823,8 +25363,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "wooden_trapdoor"
+    }
   },
   "birch_hanging_sign": {
     "result": {
@@ -26837,7 +25376,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stripped_birch_log"
@@ -26849,8 +25387,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "hanging_sign"
+    }
   },
   "chiseled_bookshelf": {
     "result": {
@@ -26862,7 +25399,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "tag": "minecraft:planks"
@@ -26888,7 +25424,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stripped_crimson_stem"
@@ -26900,8 +25435,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "hanging_sign"
+    }
   },
   "dark_oak_hanging_sign": {
     "result": {
@@ -26914,7 +25448,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stripped_dark_oak_log"
@@ -26926,8 +25459,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "hanging_sign"
+    }
   },
   "jungle_hanging_sign": {
     "result": {
@@ -26940,7 +25472,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stripped_jungle_log"
@@ -26952,8 +25483,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "hanging_sign"
+    }
   },
   "mangrove_hanging_sign": {
     "result": {
@@ -26966,7 +25496,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stripped_mangrove_log"
@@ -26978,8 +25507,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "hanging_sign"
+    }
   },
   "oak_hanging_sign": {
     "result": {
@@ -26992,7 +25520,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stripped_oak_log"
@@ -27004,8 +25531,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "hanging_sign"
+    }
   },
   "spruce_hanging_sign": {
     "result": {
@@ -27018,7 +25544,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stripped_spruce_log"
@@ -27030,8 +25555,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "hanging_sign"
+    }
   },
   "warped_hanging_sign": {
     "result": {
@@ -27044,7 +25568,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stripped_warped_stem"
@@ -27056,8 +25579,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.3"
-    },
-    "group": "hanging_sign"
+    }
   },
   "brush": {
     "result": {
@@ -27069,7 +25591,6 @@
       "I"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "equipment",
     "key": {
       "#": {
         "item": "minecraft:copper_ingot"
@@ -27095,7 +25616,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:cherry_planks"
@@ -27104,8 +25624,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "boat"
+    }
   },
   "cherry_button": {
     "result": {
@@ -27117,12 +25636,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "redstone",
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "wooden_button"
+    }
   },
   "cherry_chest_boat": {
     "result": {
@@ -27137,12 +25654,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "chest_boat"
+    }
   },
   "cherry_door": {
     "result": {
@@ -27155,7 +25670,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:cherry_planks"
@@ -27164,8 +25678,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "wooden_door"
+    }
   },
   "cherry_fence": {
     "result": {
@@ -27177,7 +25690,6 @@
       "W#W"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -27189,8 +25701,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "wooden_fence"
+    }
   },
   "cherry_fence_gate": {
     "result": {
@@ -27201,7 +25712,6 @@
       "#W#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:stick"
@@ -27213,8 +25723,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "wooden_fence_gate"
+    }
   },
   "cherry_hanging_sign": {
     "result": {
@@ -27227,7 +25736,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:stripped_cherry_log"
@@ -27239,8 +25747,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "hanging_sign"
+    }
   },
   "cherry_planks": {
     "result": {
@@ -27253,13 +25760,11 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "feature_flag": "1.20",
       "animated": true,
       "version": "1.19.4"
-    },
-    "group": "planks"
+    }
   },
   "cherry_pressure_plate": {
     "result": {
@@ -27269,7 +25774,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:cherry_planks"
@@ -27278,8 +25782,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "wooden_pressure_plate"
+    }
   },
   "cherry_sign": {
     "result": {
@@ -27292,7 +25795,6 @@
       " X "
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:cherry_planks"
@@ -27304,8 +25806,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "wooden_sign"
+    }
   },
   "cherry_slab": {
     "result": {
@@ -27316,7 +25817,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:cherry_planks"
@@ -27325,8 +25825,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "wooden_slab"
+    }
   },
   "cherry_stairs": {
     "result": {
@@ -27339,7 +25838,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:cherry_planks"
@@ -27348,8 +25846,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "wooden_stairs"
+    }
   },
   "cherry_trapdoor": {
     "result": {
@@ -27361,7 +25858,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:cherry_planks"
@@ -27370,8 +25866,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "wooden_trapdoor"
+    }
   },
   "cherry_wood": {
     "result": {
@@ -27383,7 +25878,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:cherry_log"
@@ -27392,8 +25886,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "bark"
+    }
   },
   "coast_armor_trim_smithing_template": {
     "result": {
@@ -27406,7 +25899,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -27433,7 +25925,6 @@
       " # "
     ],
     "type": "minecraft:crafting_decorated_pot",
-    "category": "misc",
     "key": {
       "#": {
         "tag": "minecraft:decorated_pot_ingredients"
@@ -27456,7 +25947,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -27484,7 +25974,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -27683,7 +26172,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -27710,12 +26198,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "orange_dye"
+    }
   },
   "pink_dye_from_pink_petals": {
     "result": {
@@ -27727,12 +26213,10 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "pink_dye"
+    }
   },
   "rib_armor_trim_smithing_template": {
     "result": {
@@ -27745,7 +26229,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -27773,7 +26256,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -28301,7 +26783,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -28329,7 +26810,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -28356,7 +26836,6 @@
       "##"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "building",
     "key": {
       "#": {
         "item": "minecraft:stripped_cherry_log"
@@ -28365,8 +26844,7 @@
     "properties": {
       "feature_flag": "1.20",
       "version": "1.19.4"
-    },
-    "group": "bark"
+    }
   },
   "tide_armor_trim_smithing_template": {
     "result": {
@@ -28379,7 +26857,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -28407,7 +26884,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -28435,7 +26911,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -28463,7 +26938,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -28489,7 +26963,6 @@
       "#X#"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "redstone",
     "key": {
       "#": {
         "item": "minecraft:amethyst_shard"
@@ -28513,11 +26986,9 @@
       }
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "misc",
     "properties": {
       "version": "1.20"
-    },
-    "group": "cyan_dye"
+    }
   },
   "dye_black_bed": {
     "result": {
@@ -28576,12 +27047,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_black_carpet": {
     "result": {
@@ -28640,12 +27109,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_black_wool": {
     "result": {
@@ -28704,12 +27171,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_blue_bed": {
     "result": {
@@ -28768,12 +27233,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_blue_carpet": {
     "result": {
@@ -28832,12 +27295,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_blue_wool": {
     "result": {
@@ -28896,12 +27357,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_brown_bed": {
     "result": {
@@ -28960,12 +27419,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_brown_carpet": {
     "result": {
@@ -29024,12 +27481,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_brown_wool": {
     "result": {
@@ -29088,12 +27543,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_cyan_bed": {
     "result": {
@@ -29152,12 +27605,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_cyan_carpet": {
     "result": {
@@ -29216,12 +27667,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_cyan_wool": {
     "result": {
@@ -29280,12 +27729,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_gray_bed": {
     "result": {
@@ -29344,12 +27791,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_gray_carpet": {
     "result": {
@@ -29408,12 +27853,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_gray_wool": {
     "result": {
@@ -29472,12 +27915,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_green_bed": {
     "result": {
@@ -29536,12 +27977,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_green_carpet": {
     "result": {
@@ -29600,12 +28039,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_green_wool": {
     "result": {
@@ -29664,12 +28101,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_light_blue_bed": {
     "result": {
@@ -29728,12 +28163,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_light_blue_carpet": {
     "result": {
@@ -29792,12 +28225,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_light_blue_wool": {
     "result": {
@@ -29856,12 +28287,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_light_gray_bed": {
     "result": {
@@ -29920,12 +28349,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_light_gray_carpet": {
     "result": {
@@ -29984,12 +28411,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_light_gray_wool": {
     "result": {
@@ -30048,12 +28473,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_lime_bed": {
     "result": {
@@ -30112,12 +28535,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_lime_carpet": {
     "result": {
@@ -30176,12 +28597,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_lime_wool": {
     "result": {
@@ -30240,12 +28659,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_magenta_bed": {
     "result": {
@@ -30304,12 +28721,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_magenta_carpet": {
     "result": {
@@ -30368,12 +28783,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_magenta_wool": {
     "result": {
@@ -30432,12 +28845,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_orange_bed": {
     "result": {
@@ -30496,12 +28907,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_orange_carpet": {
     "result": {
@@ -30560,12 +28969,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_orange_wool": {
     "result": {
@@ -30624,12 +29031,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_pink_bed": {
     "result": {
@@ -30688,12 +29093,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_pink_carpet": {
     "result": {
@@ -30752,12 +29155,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_pink_wool": {
     "result": {
@@ -30816,12 +29217,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_purple_bed": {
     "result": {
@@ -30880,12 +29279,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_purple_carpet": {
     "result": {
@@ -30944,12 +29341,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_purple_wool": {
     "result": {
@@ -31008,12 +29403,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_red_bed": {
     "result": {
@@ -31072,12 +29465,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_red_carpet": {
     "result": {
@@ -31136,12 +29527,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_red_wool": {
     "result": {
@@ -31200,12 +29589,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_white_bed": {
     "result": {
@@ -31264,12 +29651,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_white_carpet": {
     "result": {
@@ -31328,12 +29713,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_white_wool": {
     "result": {
@@ -31392,12 +29775,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "dye_yellow_bed": {
     "result": {
@@ -31456,12 +29837,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "bed"
+    }
   },
   "dye_yellow_carpet": {
     "result": {
@@ -31520,12 +29899,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "carpet"
+    }
   },
   "dye_yellow_wool": {
     "result": {
@@ -31584,12 +29961,10 @@
       ]
     ],
     "type": "minecraft:crafting_shapeless",
-    "category": "building",
     "properties": {
       "animated": true,
       "version": "1.20"
-    },
-    "group": "wool"
+    }
   },
   "host_armor_trim_smithing_template": {
     "result": {
@@ -31602,7 +29977,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -31629,7 +30003,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -31656,7 +30029,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -31683,7 +30055,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -31710,7 +30081,6 @@
       "###"
     ],
     "type": "minecraft:crafting_shaped",
-    "category": "misc",
     "key": {
       "#": {
         "item": "minecraft:diamond"
@@ -31724,6 +30094,2105 @@
     },
     "properties": {
       "version": "1.20"
+    }
+  },
+  "chiseled_copper": {
+    "result": {
+      "item": "minecraft:chiseled_copper"
+    },
+    "pattern": [
+      "#",
+      "#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:cut_copper_slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "chiseled_copper_from_copper_block_stonecutting": {
+    "result": "minecraft:chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:copper_block"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "chiseled_copper_from_cut_copper_stonecutting": {
+    "result": "minecraft:chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:cut_copper"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "chiseled_tuff": {
+    "result": {
+      "item": "minecraft:chiseled_tuff"
+    },
+    "pattern": [
+      "#",
+      "#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:tuff_slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "chiseled_tuff_bricks": {
+    "result": {
+      "item": "minecraft:chiseled_tuff_bricks"
+    },
+    "pattern": [
+      "#",
+      "#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:tuff_brick_slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "chiseled_tuff_bricks_from_polished_tuff_stonecutting": {
+    "result": "minecraft:chiseled_tuff_bricks",
+    "ingredient": {
+      "item": "minecraft:polished_tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "chiseled_tuff_bricks_from_tuff_bricks_stonecutting": {
+    "result": "minecraft:chiseled_tuff_bricks",
+    "ingredient": {
+      "item": "minecraft:tuff_bricks"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "chiseled_tuff_bricks_from_tuff_stonecutting": {
+    "result": "minecraft:chiseled_tuff_bricks",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "chiseled_tuff_from_tuff_stonecutting": {
+    "result": "minecraft:chiseled_tuff",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "copper_bulb": {
+    "result": {
+      "item": "minecraft:copper_bulb",
+      "count": 4
+    },
+    "pattern": [
+      " C ",
+      "CBC",
+      " R "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "B": {
+        "item": "minecraft:blaze_rod"
+      },
+      "R": {
+        "item": "minecraft:redstone"
+      },
+      "C": {
+        "item": "minecraft:copper_block"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "copper_door": {
+    "result": {
+      "item": "minecraft:copper_door",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:copper_block"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "copper_grate": {
+    "result": {
+      "item": "minecraft:copper_grate",
+      "count": 4
+    },
+    "pattern": [
+      " M ",
+      "M M",
+      " M "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "M": {
+        "item": "minecraft:copper_block"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "copper_grate_from_copper_block_stonecutting": {
+    "result": "minecraft:copper_grate",
+    "ingredient": {
+      "item": "minecraft:copper_block"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "copper_trapdoor": {
+    "result": {
+      "item": "minecraft:copper_trapdoor",
+      "count": 2
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:copper_block"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "crafter": {
+    "result": {
+      "item": "minecraft:crafter"
+    },
+    "pattern": [
+      "###",
+      "#C#",
+      "RDR"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "R": {
+        "item": "minecraft:redstone"
+      },
+      "#": {
+        "item": "minecraft:iron_ingot"
+      },
+      "C": {
+        "item": "minecraft:crafting_table"
+      },
+      "D": {
+        "item": "minecraft:dropper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "exposed_chiseled_copper": {
+    "result": {
+      "item": "minecraft:exposed_chiseled_copper"
+    },
+    "pattern": [
+      "#",
+      "#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:exposed_cut_copper_slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "exposed_chiseled_copper_from_exposed_copper_stonecutting": {
+    "result": "minecraft:exposed_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:exposed_copper"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "exposed_chiseled_copper_from_exposed_cut_copper_stonecutting": {
+    "result": "minecraft:exposed_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:exposed_cut_copper"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "exposed_copper_bulb": {
+    "result": {
+      "item": "minecraft:exposed_copper_bulb",
+      "count": 4
+    },
+    "pattern": [
+      " C ",
+      "CBC",
+      " R "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "B": {
+        "item": "minecraft:blaze_rod"
+      },
+      "R": {
+        "item": "minecraft:redstone"
+      },
+      "C": {
+        "item": "minecraft:exposed_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "exposed_copper_door": {
+    "result": {
+      "item": "minecraft:exposed_copper_door",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:exposed_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "exposed_copper_grate": {
+    "result": {
+      "item": "minecraft:exposed_copper_grate",
+      "count": 4
+    },
+    "pattern": [
+      " M ",
+      "M M",
+      " M "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "M": {
+        "item": "minecraft:exposed_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "exposed_copper_grate_from_exposed_copper_stonecutting": {
+    "result": "minecraft:exposed_copper_grate",
+    "ingredient": {
+      "item": "minecraft:exposed_copper"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "exposed_copper_trapdoor": {
+    "result": {
+      "item": "minecraft:exposed_copper_trapdoor",
+      "count": 2
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:exposed_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "oxidized_chiseled_copper": {
+    "result": {
+      "item": "minecraft:oxidized_chiseled_copper"
+    },
+    "pattern": [
+      "#",
+      "#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:oxidized_cut_copper_slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "oxidized_chiseled_copper_from_oxidized_copper_stonecutting": {
+    "result": "minecraft:oxidized_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:oxidized_copper"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "oxidized_chiseled_copper_from_oxidized_cut_copper_stonecutting": {
+    "result": "minecraft:oxidized_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:oxidized_cut_copper"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "oxidized_copper_bulb": {
+    "result": {
+      "item": "minecraft:oxidized_copper_bulb",
+      "count": 4
+    },
+    "pattern": [
+      " C ",
+      "CBC",
+      " R "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "B": {
+        "item": "minecraft:blaze_rod"
+      },
+      "R": {
+        "item": "minecraft:redstone"
+      },
+      "C": {
+        "item": "minecraft:oxidized_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "oxidized_copper_door": {
+    "result": {
+      "item": "minecraft:oxidized_copper_door",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:oxidized_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "oxidized_copper_grate": {
+    "result": {
+      "item": "minecraft:oxidized_copper_grate",
+      "count": 4
+    },
+    "pattern": [
+      " M ",
+      "M M",
+      " M "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "M": {
+        "item": "minecraft:oxidized_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "oxidized_copper_grate_from_oxidized_copper_stonecutting": {
+    "result": "minecraft:oxidized_copper_grate",
+    "ingredient": {
+      "item": "minecraft:oxidized_copper"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "oxidized_copper_trapdoor": {
+    "result": {
+      "item": "minecraft:oxidized_copper_trapdoor",
+      "count": 2
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:oxidized_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "polished_tuff": {
+    "result": {
+      "item": "minecraft:polished_tuff",
+      "count": 4
+    },
+    "pattern": [
+      "SS",
+      "SS"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "S": {
+        "item": "minecraft:tuff"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "polished_tuff_from_tuff_stonecutting": {
+    "result": "minecraft:polished_tuff",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "polished_tuff_slab": {
+    "result": {
+      "item": "minecraft:polished_tuff_slab",
+      "count": 6
+    },
+    "pattern": [
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:polished_tuff"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "polished_tuff_slab_from_polished_tuff_stonecutting": {
+    "result": "minecraft:polished_tuff_slab",
+    "ingredient": {
+      "item": "minecraft:polished_tuff"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "polished_tuff_slab_from_tuff_stonecutting": {
+    "result": "minecraft:polished_tuff_slab",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "polished_tuff_stairs": {
+    "result": {
+      "item": "minecraft:polished_tuff_stairs",
+      "count": 4
+    },
+    "pattern": [
+      "#  ",
+      "## ",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:polished_tuff"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "polished_tuff_stairs_from_polished_tuff_stonecutting": {
+    "result": "minecraft:polished_tuff_stairs",
+    "ingredient": {
+      "item": "minecraft:polished_tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "polished_tuff_stairs_from_tuff_stonecutting": {
+    "result": "minecraft:polished_tuff_stairs",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "polished_tuff_wall": {
+    "result": {
+      "item": "minecraft:polished_tuff_wall",
+      "count": 6
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:polished_tuff"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "polished_tuff_wall_from_polished_tuff_stonecutting": {
+    "result": "minecraft:polished_tuff_wall",
+    "ingredient": {
+      "item": "minecraft:polished_tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "polished_tuff_wall_from_tuff_stonecutting": {
+    "result": "minecraft:polished_tuff_wall",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_brick_slab": {
+    "result": {
+      "item": "minecraft:tuff_brick_slab",
+      "count": 6
+    },
+    "pattern": [
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:tuff_bricks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_brick_slab_from_polished_tuff_stonecutting": {
+    "result": "minecraft:tuff_brick_slab",
+    "ingredient": {
+      "item": "minecraft:polished_tuff"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_brick_slab_from_tuff_bricks_stonecutting": {
+    "result": "minecraft:tuff_brick_slab",
+    "ingredient": {
+      "item": "minecraft:tuff_bricks"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_brick_slab_from_tuff_stonecutting": {
+    "result": "minecraft:tuff_brick_slab",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_brick_stairs": {
+    "result": {
+      "item": "minecraft:tuff_brick_stairs",
+      "count": 4
+    },
+    "pattern": [
+      "#  ",
+      "## ",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:tuff_bricks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_brick_stairs_from_polished_tuff_stonecutting": {
+    "result": "minecraft:tuff_brick_stairs",
+    "ingredient": {
+      "item": "minecraft:polished_tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_brick_stairs_from_tuff_bricks_stonecutting": {
+    "result": "minecraft:tuff_brick_stairs",
+    "ingredient": {
+      "item": "minecraft:tuff_bricks"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_brick_stairs_from_tuff_stonecutting": {
+    "result": "minecraft:tuff_brick_stairs",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_brick_wall": {
+    "result": {
+      "item": "minecraft:tuff_brick_wall",
+      "count": 6
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:tuff_bricks"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_brick_wall_from_polished_tuff_stonecutting": {
+    "result": "minecraft:tuff_brick_wall",
+    "ingredient": {
+      "item": "minecraft:polished_tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_brick_wall_from_tuff_bricks_stonecutting": {
+    "result": "minecraft:tuff_brick_wall",
+    "ingredient": {
+      "item": "minecraft:tuff_bricks"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_brick_wall_from_tuff_stonecutting": {
+    "result": "minecraft:tuff_brick_wall",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_bricks": {
+    "result": {
+      "item": "minecraft:tuff_bricks",
+      "count": 4
+    },
+    "pattern": [
+      "SS",
+      "SS"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "S": {
+        "item": "minecraft:polished_tuff"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_bricks_from_polished_tuff_stonecutting": {
+    "result": "minecraft:tuff_bricks",
+    "ingredient": {
+      "item": "minecraft:polished_tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_bricks_from_tuff_stonecutting": {
+    "result": "minecraft:tuff_bricks",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_slab": {
+    "result": {
+      "item": "minecraft:tuff_slab",
+      "count": 6
+    },
+    "pattern": [
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:tuff"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_slab_from_tuff_stonecutting": {
+    "result": "minecraft:tuff_slab",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 2,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_stairs": {
+    "result": {
+      "item": "minecraft:tuff_stairs",
+      "count": 4
+    },
+    "pattern": [
+      "#  ",
+      "## ",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:tuff"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_stairs_from_tuff_stonecutting": {
+    "result": "minecraft:tuff_stairs",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_wall": {
+    "result": {
+      "item": "minecraft:tuff_wall",
+      "count": 6
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:tuff"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "tuff_wall_from_tuff_stonecutting": {
+    "result": "minecraft:tuff_wall",
+    "ingredient": {
+      "item": "minecraft:tuff"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_chiseled_copper": {
+    "result": {
+      "item": "minecraft:waxed_chiseled_copper"
+    },
+    "pattern": [
+      "#",
+      "#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:waxed_cut_copper_slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_chiseled_copper_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_chiseled_copper"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:chiseled_copper"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_chiseled_copper_from_waxed_copper_block_stonecutting": {
+    "result": "minecraft:waxed_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:waxed_copper_block"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_chiseled_copper_from_waxed_cut_copper_stonecutting": {
+    "result": "minecraft:waxed_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:waxed_cut_copper"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_copper_bulb": {
+    "result": {
+      "item": "minecraft:waxed_copper_bulb",
+      "count": 4
+    },
+    "pattern": [
+      " C ",
+      "CBC",
+      " R "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "B": {
+        "item": "minecraft:blaze_rod"
+      },
+      "R": {
+        "item": "minecraft:redstone"
+      },
+      "C": {
+        "item": "minecraft:waxed_copper_block"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_copper_bulb_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_copper_bulb"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:copper_bulb"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_copper_door": {
+    "result": {
+      "item": "minecraft:waxed_copper_door",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:waxed_copper_block"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_copper_door_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_copper_door"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:copper_door"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_copper_grate": {
+    "result": {
+      "item": "minecraft:waxed_copper_grate",
+      "count": 4
+    },
+    "pattern": [
+      " M ",
+      "M M",
+      " M "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "M": {
+        "item": "minecraft:waxed_copper_block"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_copper_grate_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_copper_grate"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:copper_grate"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_copper_grate_from_waxed_copper_block_stonecutting": {
+    "result": "minecraft:waxed_copper_grate",
+    "ingredient": {
+      "item": "minecraft:waxed_copper_block"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_copper_trapdoor": {
+    "result": {
+      "item": "minecraft:waxed_copper_trapdoor",
+      "count": 2
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:waxed_copper_block"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_copper_trapdoor_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_copper_trapdoor"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:copper_trapdoor"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_chiseled_copper": {
+    "result": {
+      "item": "minecraft:waxed_exposed_chiseled_copper"
+    },
+    "pattern": [
+      "#",
+      "#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:waxed_exposed_cut_copper_slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_chiseled_copper_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_exposed_chiseled_copper"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:exposed_chiseled_copper"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_chiseled_copper_from_waxed_exposed_copper_stonecutting": {
+    "result": "minecraft:waxed_exposed_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:waxed_exposed_copper"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_chiseled_copper_from_waxed_exposed_cut_copper_stonecutting": {
+    "result": "minecraft:waxed_exposed_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:waxed_exposed_cut_copper"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_copper_bulb": {
+    "result": {
+      "item": "minecraft:waxed_exposed_copper_bulb",
+      "count": 4
+    },
+    "pattern": [
+      " C ",
+      "CBC",
+      " R "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "B": {
+        "item": "minecraft:blaze_rod"
+      },
+      "R": {
+        "item": "minecraft:redstone"
+      },
+      "C": {
+        "item": "minecraft:waxed_exposed_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_copper_bulb_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_exposed_copper_bulb"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:exposed_copper_bulb"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_copper_door": {
+    "result": {
+      "item": "minecraft:waxed_exposed_copper_door",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:waxed_exposed_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_copper_door_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_exposed_copper_door"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:exposed_copper_door"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_copper_grate": {
+    "result": {
+      "item": "minecraft:waxed_exposed_copper_grate",
+      "count": 4
+    },
+    "pattern": [
+      " M ",
+      "M M",
+      " M "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "M": {
+        "item": "minecraft:waxed_exposed_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_copper_grate_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_exposed_copper_grate"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:exposed_copper_grate"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_copper_grate_from_waxed_exposed_copper_stonecutting": {
+    "result": "minecraft:waxed_exposed_copper_grate",
+    "ingredient": {
+      "item": "minecraft:waxed_exposed_copper"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_copper_trapdoor": {
+    "result": {
+      "item": "minecraft:waxed_exposed_copper_trapdoor",
+      "count": 2
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:waxed_exposed_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_exposed_copper_trapdoor_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_exposed_copper_trapdoor"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:exposed_copper_trapdoor"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_chiseled_copper": {
+    "result": {
+      "item": "minecraft:waxed_oxidized_chiseled_copper"
+    },
+    "pattern": [
+      "#",
+      "#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:waxed_oxidized_cut_copper_slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_chiseled_copper_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_oxidized_chiseled_copper"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:oxidized_chiseled_copper"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_chiseled_copper_from_waxed_oxidized_copper_stonecutting": {
+    "result": "minecraft:waxed_oxidized_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:waxed_oxidized_copper"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_chiseled_copper_from_waxed_oxidized_cut_copper_stonecutting": {
+    "result": "minecraft:waxed_oxidized_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:waxed_oxidized_cut_copper"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_copper_bulb": {
+    "result": {
+      "item": "minecraft:waxed_oxidized_copper_bulb",
+      "count": 4
+    },
+    "pattern": [
+      " C ",
+      "CBC",
+      " R "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "B": {
+        "item": "minecraft:blaze_rod"
+      },
+      "R": {
+        "item": "minecraft:redstone"
+      },
+      "C": {
+        "item": "minecraft:waxed_oxidized_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_copper_bulb_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_oxidized_copper_bulb"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:oxidized_copper_bulb"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_copper_door": {
+    "result": {
+      "item": "minecraft:waxed_oxidized_copper_door",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:waxed_oxidized_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_copper_door_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_oxidized_copper_door"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:oxidized_copper_door"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_copper_grate": {
+    "result": {
+      "item": "minecraft:waxed_oxidized_copper_grate",
+      "count": 4
+    },
+    "pattern": [
+      " M ",
+      "M M",
+      " M "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "M": {
+        "item": "minecraft:waxed_oxidized_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_copper_grate_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_oxidized_copper_grate"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:oxidized_copper_grate"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_copper_grate_from_waxed_oxidized_copper_stonecutting": {
+    "result": "minecraft:waxed_oxidized_copper_grate",
+    "ingredient": {
+      "item": "minecraft:waxed_oxidized_copper"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_copper_trapdoor": {
+    "result": {
+      "item": "minecraft:waxed_oxidized_copper_trapdoor",
+      "count": 2
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:waxed_oxidized_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_oxidized_copper_trapdoor_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_oxidized_copper_trapdoor"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:oxidized_copper_trapdoor"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_chiseled_copper": {
+    "result": {
+      "item": "minecraft:waxed_weathered_chiseled_copper"
+    },
+    "pattern": [
+      "#",
+      "#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:waxed_weathered_cut_copper_slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_chiseled_copper_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_weathered_chiseled_copper"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:weathered_chiseled_copper"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_chiseled_copper_from_waxed_weathered_copper_stonecutting": {
+    "result": "minecraft:waxed_weathered_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:waxed_weathered_copper"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_chiseled_copper_from_waxed_weathered_cut_copper_stonecutting": {
+    "result": "minecraft:waxed_weathered_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:waxed_weathered_cut_copper"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_copper_bulb": {
+    "result": {
+      "item": "minecraft:waxed_weathered_copper_bulb",
+      "count": 4
+    },
+    "pattern": [
+      " C ",
+      "CBC",
+      " R "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "B": {
+        "item": "minecraft:blaze_rod"
+      },
+      "R": {
+        "item": "minecraft:redstone"
+      },
+      "C": {
+        "item": "minecraft:waxed_weathered_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_copper_bulb_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_weathered_copper_bulb"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:weathered_copper_bulb"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_copper_door": {
+    "result": {
+      "item": "minecraft:waxed_weathered_copper_door",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:waxed_weathered_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_copper_door_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_weathered_copper_door"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:weathered_copper_door"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_copper_grate": {
+    "result": {
+      "item": "minecraft:waxed_weathered_copper_grate",
+      "count": 4
+    },
+    "pattern": [
+      " M ",
+      "M M",
+      " M "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "M": {
+        "item": "minecraft:waxed_weathered_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_copper_grate_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_weathered_copper_grate"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:weathered_copper_grate"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_copper_grate_from_waxed_weathered_copper_stonecutting": {
+    "result": "minecraft:waxed_weathered_copper_grate",
+    "ingredient": {
+      "item": "minecraft:waxed_weathered_copper"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_copper_trapdoor": {
+    "result": {
+      "item": "minecraft:waxed_weathered_copper_trapdoor",
+      "count": 2
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:waxed_weathered_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "waxed_weathered_copper_trapdoor_from_honeycomb": {
+    "result": {
+      "item": "minecraft:waxed_weathered_copper_trapdoor"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:weathered_copper_trapdoor"
+      },
+      {
+        "item": "minecraft:honeycomb"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "weathered_chiseled_copper": {
+    "result": {
+      "item": "minecraft:weathered_chiseled_copper"
+    },
+    "pattern": [
+      "#",
+      "#"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:weathered_cut_copper_slab"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "weathered_chiseled_copper_from_weathered_copper_stonecutting": {
+    "result": "minecraft:weathered_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:weathered_copper"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "weathered_chiseled_copper_from_weathered_cut_copper_stonecutting": {
+    "result": "minecraft:weathered_chiseled_copper",
+    "ingredient": {
+      "item": "minecraft:weathered_cut_copper"
+    },
+    "count": 1,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "weathered_copper_bulb": {
+    "result": {
+      "item": "minecraft:weathered_copper_bulb",
+      "count": 4
+    },
+    "pattern": [
+      " C ",
+      "CBC",
+      " R "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "B": {
+        "item": "minecraft:blaze_rod"
+      },
+      "R": {
+        "item": "minecraft:redstone"
+      },
+      "C": {
+        "item": "minecraft:weathered_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "weathered_copper_door": {
+    "result": {
+      "item": "minecraft:weathered_copper_door",
+      "count": 3
+    },
+    "pattern": [
+      "##",
+      "##",
+      "##"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:weathered_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "weathered_copper_grate": {
+    "result": {
+      "item": "minecraft:weathered_copper_grate",
+      "count": 4
+    },
+    "pattern": [
+      " M ",
+      "M M",
+      " M "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "M": {
+        "item": "minecraft:weathered_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "weathered_copper_grate_from_weathered_copper_stonecutting": {
+    "result": "minecraft:weathered_copper_grate",
+    "ingredient": {
+      "item": "minecraft:weathered_copper"
+    },
+    "count": 4,
+    "type": "minecraft:stonecutting",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
+    }
+  },
+  "weathered_copper_trapdoor": {
+    "result": {
+      "item": "minecraft:weathered_copper_trapdoor",
+      "count": 2
+    },
+    "pattern": [
+      "###",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:weathered_copper"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.3"
     }
   }
 }

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -237,7 +237,7 @@ public class Bot {
         shardManager.retrieveUserById(Config.getOwner()).queue(u -> ownerAvatarUrl = u.getAvatarUrl());
         bootTime = System.currentTimeMillis() - birth;
         System.out.println("Boot Time: " + DateUtils.getBootTime());
-        logger.statusLog(":white_check_mark: **Bot started!**");
+        logger.log(":white_check_mark: **Bot started!**");
         DiscordUtils.update();
         RequestUtils.sendGuilds();
 

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -45,7 +45,7 @@ public class Bot {
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
     private static final String version = "0.17.3";
-    public static final String jdaVersion = "5.0.0-beta.17";
+    public static final String jdaVersion = "5.0.0-beta.18";
     public static final Color color = Color.GREEN;
 
     public static ShardManager shardManager;

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -44,7 +44,7 @@ public class Bot {
     public static final String github = "https://github.com/Tisawesomeness/Minecord";
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
-    private static final String version = "0.17.3";
+    private static final String version = "0.17.4";
     public static final String jdaVersion = "5.0.0-beta.18";
     public static final Color color = Color.GREEN;
 

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -46,7 +46,6 @@ public class Bot {
     public static final String privacy = "https://minecord.github.io/privacy";
     private static final String version = "0.17.3";
     public static final String jdaVersion = "5.0.0-beta.17";
-    public static final String mcVersion = "1.20";
     public static final Color color = Color.GREEN;
 
     public static ShardManager shardManager;

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -37,7 +37,7 @@ public class Bot {
 
     private static final String mainClass = "com.tisawesomeness.minecord.Main";
     public static final String author = "Tis_awesomeness";
-    public static final String authorTag = "@Tis_awesomeness#8617";
+    public static final String authorTag = "@tis_awesomeness";
     public static final String invite = "https://minecord.github.io/invite";
     public static final String helpServer = "https://minecord.github.io/support";
     public static final String website = "https://minecord.github.io";

--- a/src/com/tisawesomeness/minecord/Config.java
+++ b/src/com/tisawesomeness/minecord/Config.java
@@ -2,7 +2,6 @@ package com.tisawesomeness.minecord;
 
 import com.tisawesomeness.minecord.util.ArrayUtils;
 import com.tisawesomeness.minecord.util.RequestUtils;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -22,6 +21,7 @@ public class Config {
     private static String joinLogChannel;
     private static String logWebhook;
     private static String statusWebhook;
+    private static String supportedMCVersion;
     private static boolean isSelfHosted;
     private static String author;
     private static String authorTag;
@@ -115,6 +115,7 @@ public class Config {
             joinLogChannel = settings.optString("joinLogChannel", "0");
             logWebhook = settings.optString("logWebhook", "");
             statusWebhook = settings.optString("statusWebhook", "");
+            supportedMCVersion = settings.optString("supportedMCVersion", "1.20.3");
             isSelfHosted = settings.getBoolean("isSelfHosted");
             if (isSelfHosted) {
                 author = settings.getString("author");
@@ -186,6 +187,7 @@ public class Config {
     public static String getJoinLogChannel() { return joinLogChannel; }
     public static String getLogWebhook() { return logWebhook; }
     public static String getStatusWebhook() { return statusWebhook; }
+    public static String getSupportedMCVersion() { return supportedMCVersion; }
     public static boolean isSelfHosted() { return isSelfHosted; }
     public static String getAuthor() { return author; }
     public static String getAuthorTag() { return authorTag; }

--- a/src/com/tisawesomeness/minecord/command/admin/UsageCommand.java
+++ b/src/com/tisawesomeness/minecord/command/admin/UsageCommand.java
@@ -7,7 +7,6 @@ import com.tisawesomeness.minecord.command.Module;
 import com.tisawesomeness.minecord.command.Registry;
 import com.tisawesomeness.minecord.util.DateUtils;
 import com.tisawesomeness.minecord.util.MessageUtils;
-
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 
@@ -18,29 +17,34 @@ public class UsageCommand extends LegacyCommand {
 
     public CommandInfo getInfo() {
         return new CommandInfo(
-            "usage",
-            "Shows how often commands are used.",
-            null,
-            0,
-            true,
-            true
+                "usage",
+                "Shows how often commands are used.",
+                null,
+                0,
+                true,
+                true
         );
     }
 
     public Result run(String[] args, MessageReceivedEvent e) {
         // Build usage message
         EmbedBuilder eb = new EmbedBuilder()
-            .setTitle("Command usage for " + DateUtils.getUptime())
-            .setColor(Bot.color);
+                .setTitle("Command usage for " + DateUtils.getUptime())
+                .setColor(Bot.color);
         for (Module m : Registry.modules) {
             String field = Arrays.stream(m.getCommands())
-                .filter(c -> !c.getInfo().name.isEmpty() && !c.getInfo().description.equals("Look up a color code."))
-                .map(c -> String.format("`%s%s` **-** %d", getPrefix(c, e), c.getInfo().name, Registry.getUses(c)))
-                .collect(Collectors.joining("\n"));
+                    .filter(c -> !c.getInfo().name.isEmpty())
+                    .filter(c -> !isLegacyCommandWithSlashVariant(c))
+                    .map(c -> String.format("`%s%s` **-** %d", getPrefix(c, e), c.getInfo().name, Registry.getUses(c)))
+                    .collect(Collectors.joining("\n"));
             eb.addField(String.format("**%s**", m.getName()), field, true);
         }
 
         return new Result(Outcome.SUCCESS, MessageUtils.addFooter(eb).build());
+    }
+
+    private static boolean isLegacyCommandWithSlashVariant(Command<?> c) {
+        return c instanceof LegacyCommand && Registry.getSlashCommand(c.getInfo().name).isPresent();
     }
 
     private static String getPrefix(Command<?> c, MessageReceivedEvent e) {

--- a/src/com/tisawesomeness/minecord/command/core/CreditsCommand.java
+++ b/src/com/tisawesomeness/minecord/command/core/CreditsCommand.java
@@ -61,8 +61,8 @@ public class CreditsCommand extends SlashCommand {
                 .addField("APIs Used", apis, false);
         if (Config.isSelfHosted()) {
             String selfHost = "This bot is self-hosted by **" + Config.getAuthor() + "**\n" +
-                    "Original Website - " + MarkdownUtil.maskedLink(Bot.website, Bot.website) + "\n" +
-                    "Original Help Server - " + MarkdownUtil.maskedLink(Bot.helpServer, Bot.helpServer) + "\n" +
+                    "Original Website - " + Bot.website + "\n" +
+                    "Original Help Server - " + Bot.helpServer + "\n" +
                     "Original Github - " + MarkdownUtil.maskedLink("Source Code", Bot.github);
             eb.addField("Self-Hosting", selfHost, false);
         } else {

--- a/src/com/tisawesomeness/minecord/command/utility/CoordsCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/CoordsCommand.java
@@ -18,7 +18,7 @@ public class CoordsCommand extends SlashCommand {
     public CommandInfo getInfo() {
         return new CommandInfo(
                 "coords",
-                "Convert Overworld <-> Nether coordinates and compute chunk positions",
+                "Convert Overworld <-> Nether coordinates and compute chunk positions.",
                 "<coordinate> [<dimension>]",
                 0,
                 false,

--- a/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
@@ -1,12 +1,11 @@
 package com.tisawesomeness.minecord.command.utility;
 
-import com.tisawesomeness.minecord.Bot;
+import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.ReactMenu;
 import com.tisawesomeness.minecord.ReactMenu.MenuStatus;
 import com.tisawesomeness.minecord.command.SlashCommand;
 import com.tisawesomeness.minecord.mc.item.Item;
 import com.tisawesomeness.minecord.mc.item.Recipe;
-
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
@@ -44,7 +43,7 @@ public class IngredientCommand extends SlashCommand {
     @Override
     public String getHelp() {
         return "Searches for the recipes containing an ingredient.\n" +
-                "Items and recipes are from Java Edition 1.7 to " + Bot.mcVersion + ".\n" +
+                "Items and recipes are from Java Edition 1.7 to " + Config.getSupportedMCVersion() + ".\n" +
                 "All recipe types are searchable, including brewing.\n" +
                 "\n" +
                 Item.help + "\n";
@@ -72,7 +71,7 @@ public class IngredientCommand extends SlashCommand {
         }
 
         ArrayList<String> recipes = Recipe.searchIngredient(item, "en_US");
-        if (recipes.size() == 0) {
+        if (recipes.isEmpty()) {
             String displayName = Item.getDistinctDisplayName(item, "en_US");
             return new Result(Outcome.WARNING, ":warning: " + displayName + " is not the ingredient of any recipe!");
         }

--- a/src/com/tisawesomeness/minecord/command/utility/ItemCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/ItemCommand.java
@@ -1,10 +1,9 @@
 package com.tisawesomeness.minecord.command.utility;
 
-import com.tisawesomeness.minecord.Bot;
+import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.command.SlashCommand;
 import com.tisawesomeness.minecord.mc.item.Item;
 import com.tisawesomeness.minecord.util.MessageUtils;
-
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
@@ -36,7 +35,7 @@ public class ItemCommand extends SlashCommand {
     @Override
     public String getHelp() {
         return "Searches for a Minecraft item.\n" +
-                "Items are from Java Edition 1.7 to " + Bot.mcVersion + ".\n" +
+                "Items are from Java Edition 1.7 to " + Config.getSupportedMCVersion() + ".\n" +
                 "\n" +
                 Item.help + "\n";
     }

--- a/src/com/tisawesomeness/minecord/command/utility/RandomCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/RandomCommand.java
@@ -47,8 +47,8 @@ public class RandomCommand extends SlashCommand {
     public CommandInfo getInfo() {
         return new CommandInfo(
                 "random",
-                "Generate random numbers",
-                "<type> <arguments...>",
+                "Generate random numbers.",
+                "<type> [<arguments...>]",
                 0,
                 false,
                 false

--- a/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
@@ -1,12 +1,11 @@
 package com.tisawesomeness.minecord.command.utility;
 
-import com.tisawesomeness.minecord.Bot;
+import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.ReactMenu;
 import com.tisawesomeness.minecord.ReactMenu.MenuStatus;
 import com.tisawesomeness.minecord.command.SlashCommand;
 import com.tisawesomeness.minecord.mc.item.Item;
 import com.tisawesomeness.minecord.mc.item.Recipe;
-
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
@@ -44,7 +43,7 @@ public class RecipeCommand extends SlashCommand {
     @Override
     public String getHelp() {
         return "Shows the recipes for an item.\n" +
-                "Items and recipes are from Java Edition 1.7 to " + Bot.mcVersion + ".\n" +
+                "Items and recipes are from Java Edition 1.7 to " + Config.getSupportedMCVersion() + ".\n" +
                 "All recipe types are searchable, including brewing.\n" +
                 "\n" +
                 Item.help + "\n";
@@ -72,7 +71,7 @@ public class RecipeCommand extends SlashCommand {
         }
 
         ArrayList<String> recipes = Recipe.searchOutput(item, "en_US");
-        if (recipes.size() == 0) {
+        if (recipes.isEmpty()) {
             String displayName = Item.getDistinctDisplayName(item, "en_US");
             return new Result(Outcome.SUCCESS, ":warning: " + displayName + " does not have any recipes.");
         }

--- a/src/com/tisawesomeness/minecord/command/utility/StackCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/StackCommand.java
@@ -28,7 +28,7 @@ public class StackCommand extends SlashCommand {
     public CommandInfo getInfo() {
         return new CommandInfo(
                 "stack",
-                "Convert item counts to stacks, chests, shulkers, and back",
+                "Convert item counts to stacks, chests, shulkers, and back.",
                 "<arguments...>",
                 0,
                 false,

--- a/src/com/tisawesomeness/minecord/mc/item/FeatureFlag.java
+++ b/src/com/tisawesomeness/minecord/mc/item/FeatureFlag.java
@@ -1,0 +1,29 @@
+package com.tisawesomeness.minecord.mc.item;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Getter
+@AllArgsConstructor
+public enum FeatureFlag {
+    BUNDLE("bundle", "Bundle", null),
+    UPDATE_1_20("1.20"),
+    UPDATE_1_21("1.21", "1.21", null);
+
+    private final String id;
+    private final String displayName;
+    private final String releaseVersion;
+
+    FeatureFlag(String version) {
+        this(version, version, version);
+    }
+
+    public static Optional<FeatureFlag> from(String str) {
+        return Arrays.stream(values())
+                .filter(f -> f.getId().equals(str))
+                .findFirst();
+    }
+}


### PR DESCRIPTION
- Added all 1.20.3 items and recipes.
- Added release version to previously experimental items in `/item`, `/recipe`, and `/ingredient`
- Improved searching in `/item`, `/recipe`, and `/ingredient`
- Re-ordered smithing recipes so the most recently added recipe is first
- Optimized images
- Fixed `/item stone slab` showing a cobblestone slab
- Fixed a bug in `/recipe` where a stonecutting ingredient could be selected even when no recipes can make that ingredient
- Fixed broken links in `/credits`

Self-hosting changes:
- Moved bot ready message from status log to bot log
- `@Minecord usage` now combines uses from slash and legacy commands
- Slash and legacy commands now share cooldowns
- Updated dependencies