### PR TITLE
Version 0.17.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>5.0.0-beta.18</version>
+      <version>5.0.0-beta.19</version>
       <exclusions>
         <exclusion>
           <groupId>club.minnced</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.17.5</version>
+  <version>0.17.6</version>
 
   <repositories>
     <repository>

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -44,7 +44,7 @@ public class Bot {
     public static final String github = "https://github.com/Tisawesomeness/Minecord";
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
-    private static final String version = "0.17.5";
+    private static final String version = "0.17.6";
     public static final String jdaVersion = "5.0.0-beta.19";
     public static final Color color = Color.GREEN;
 

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -45,7 +45,7 @@ public class Bot {
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
     private static final String version = "0.17.5";
-    public static final String jdaVersion = "5.0.0-beta.18";
+    public static final String jdaVersion = "5.0.0-beta.19";
     public static final Color color = Color.GREEN;
 
     public static ShardManager shardManager;

--- a/src/com/tisawesomeness/minecord/command/utility/ServerCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/ServerCommand.java
@@ -186,9 +186,6 @@ public class ServerCommand extends SlashCommand {
                                 dimensions.getWidth(), dimensions.getHeight(), Favicon.EXPECTED_SIZE, Favicon.EXPECTED_SIZE);
                     }
                 }
-                if (icon.usesNewlines()) {
-                    m += "\n:information_source: Icon data not on one line, will not work on 1.13 or later.";
-                }
                 if (!e.isFromGuild() || e.getGuild().getSelfMember().hasPermission(e.getGuildChannel(), Permission.MESSAGE_ATTACH_FILES)) {
                     MessageEmbed embed = eb.setDescription(m).setThumbnail("attachment://favicon.png").build();
                     e.getHook().sendFiles(FileUpload.fromData(icon.getData(), "favicon.png")).setEmbeds(embed).queue();


### PR DESCRIPTION
- Removed the "Icon data not on one line, will not work on 1.13 or later" warning from `/server` since latest vanilla client does handle the icon correctly
- (Self-hosting change) Updated dependencies