### PR TITLE
Version 0.17.8, 0.17.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,15 @@ A robust Discord bot using the JDA library for various Minecraft functions.
 - *Join Log Channel:* The bot will send server join/leave messages to this channel. Set to 0 to disable.
 - *Log Webhook:* The webhook URL to send log messages to. Set to blank to disable.
 - *Status Webhook:* The webhook URL to send status messages to. Set to blank to disable.
-- *Supported MC Version:* The latest MC version that the bot supports. This only changes the version shown in `/help recipe` and other commands, and does not change behavior. Update if a new Minecraft version releases that does not change items or recipes.
+- *Include Spam Statuses:* Whether to include the "Disconnected" and "Resumed" statuses in the status webhook. These statuses happen very often.
+- *Supported MC Version:* The latest MC version that the bot supports. This only changes the version shown in `/help recipe` and other commands, and does not change behavior. Update this field if a new Minecraft version releases that does not change items or recipes.
 - *Is Self Hosted:* Leave as `true` if you are self-hosting the bot.
 - *Author:* The name of the person hosting the bot.
 - *Author Tag:* The Discord tag of the person hosting the bot.
 - *Invite:* The invite link to use in `/invite`.
 - *Help Server:* The help server link to use in `/invite`.
 - *Website:* The website to display in `/info`.
-- *Github:* A link to the source code currently running on the bot.
+- *GitHub:* A link to the source code currently running on the bot.
 - *Prefix:* The prefix (optionally) used for admin commands.
 - *Game:* This is the game that the bot is playing, shown under the username. `{prefix}` and `{guilds}` are available variables.
 - *Dev Mode:* Turning this on will let you reload code using `@Minecord reload` on the fly. When hosting the bot, it's best to keep this off in order to decrease memory usage.
@@ -105,6 +106,7 @@ A robust Discord bot using the JDA library for various Minecraft functions.
 - *Item Image Host:* The website hosting item images.
 - *Recipe Image Host:* The website hosting recipe images.
 - *Crafatar Host:* The URL for the Crafatar API.
+- *Reupload Crafatar Images:* Whether to download and re-upload Crafatar images as attachments as a workaround for Discord refusing to embed Crafatar images.
 
 - *Send Server Count:* Whether the bot should send the guild count to bot list websites.
 - *Pw Token:* The token to use on bots.discord.pw.
@@ -134,7 +136,8 @@ A robust Discord bot using the JDA library for various Minecraft functions.
     "joinLogChannel": "0",
     "logWebhook": "",
     "statusWebhook": "",
-    "supportedMCVersion":  "1.20.3",
+    "includeSpamStatuses" true,
+    "supportedMCVersion":  "1.20.4",
     "isSelfHosted": true,
     "author": "Tis_awesomeness",
     "authorTag": "@tis_awesomeness",
@@ -155,7 +158,8 @@ A robust Discord bot using the JDA library for various Minecraft functions.
     "recordCacheStats": false,
     "itemImageHost": "https://minecord.github.io/item/",
     "recipeImageHost": "https://minecord.github.io/recipe/",
-    "crafatarHost": "https://crafatar.com/"
+    "crafatarHost": "https://crafatar.com/",
+    "reuploadCrafatarImages": false
   },
   "botLists": {
     "sendServerCount": false,

--- a/config.json
+++ b/config.json
@@ -9,6 +9,7 @@
         "joinLogChannel": "0",
         "logWebhook": "",
         "statusWebhook": "",
+        "includeSpamStatuses": true,
         "supportedMCVersion": "1.20.4",
         "isSelfHosted": true,
         "author": "Tis_awesomeness",

--- a/config.json
+++ b/config.json
@@ -30,7 +30,8 @@
         "recordCacheStats": false,
         "itemImageHost": "https://minecord.github.io/item/",
         "recipeImageHost": "https://minecord.github.io/recipe/",
-        "crafatarHost": "https://crafatar.com/"
+        "crafatarHost": "https://crafatar.com/",
+        "reuploadCrafatarImages": false
     },
     "botLists": {
         "sendServerCount": false,

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
         "joinLogChannel": "0",
         "logWebhook": "",
         "statusWebhook": "",
-        "supportedMCVersion": "1.20.3",
+        "supportedMCVersion": "1.20.4",
         "isSelfHosted": true,
         "author": "Tis_awesomeness",
         "authorTag": "@tis_awesomeness",

--- a/items.json
+++ b/items.json
@@ -20653,7 +20653,11 @@
           "Autocrafting Table",
           "Auto Crafting Table",
           "Auto Workbench",
-          "Auto Crafting Bench"
+          "Auto Crafting Bench",
+          "Mumbo Block",
+          "Mumbo Table",
+          "Mumbo Workbench",
+          "Mumbo Crafting Bench"
         ],
         "display_name": "Crafter"
       }

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.17.8</version>
+  <version>0.17.9</version>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>5.0.0-beta.20</version>
+      <version>5.0.0-beta.21</version>
       <exclusions>
         <exclusion>
           <groupId>club.minnced</groupId>
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20231013</version>
+      <version>20240303</version>
     </dependency>
     <dependency>
       <groupId>club.minnced</groupId>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.45.0.0</version>
+      <version>3.45.2.0</version>
     </dependency>
     <dependency>
       <groupId>dnsjava</groupId>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.30</version>
+      <version>1.18.32</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.17.7</version>
+  <version>0.17.8</version>
 
   <repositories>
     <repository>

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -44,7 +44,7 @@ public class Bot {
     public static final String github = "https://github.com/Tisawesomeness/Minecord";
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
-    private static final String version = "0.17.8";
+    private static final String version = "0.17.9";
     public static final String jdaVersion = "5.0.0-beta.21";
     public static final Color color = Color.GREEN;
 

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -44,7 +44,7 @@ public class Bot {
     public static final String github = "https://github.com/Tisawesomeness/Minecord";
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
-    private static final String version = "0.17.7";
+    private static final String version = "0.17.8";
     public static final String jdaVersion = "5.0.0-beta.20";
     public static final Color color = Color.GREEN;
 

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -45,7 +45,7 @@ public class Bot {
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
     private static final String version = "0.17.8";
-    public static final String jdaVersion = "5.0.0-beta.20";
+    public static final String jdaVersion = "5.0.0-beta.21";
     public static final Color color = Color.GREEN;
 
     public static ShardManager shardManager;

--- a/src/com/tisawesomeness/minecord/Config.java
+++ b/src/com/tisawesomeness/minecord/Config.java
@@ -44,6 +44,7 @@ public class Config {
     private static String itemImageHost;
     private static String recipeImageHost;
     private static String crafatarHost;
+    private static boolean reuploadCrafatarImages;
 
     private static boolean sendServerCount;
     private static String pwToken;
@@ -150,6 +151,7 @@ public class Config {
             itemImageHost = settings.optString("itemImageHost", "https://minecord.github.io/item/");
             recipeImageHost = settings.optString("recipeImageHost", "https://minecord.github.io/recipe/");
             crafatarHost = settings.optString("crafatarHost", "https://crafatar.com/");
+            reuploadCrafatarImages = settings.optBoolean("reuploadCrafatarImages", false);
 
             JSONObject botLists = config.getJSONObject("botLists");
             if (isSelfHosted) {
@@ -210,6 +212,7 @@ public class Config {
     public static String getItemImageHost() { return itemImageHost; }
     public static String getRecipeImageHost() { return recipeImageHost; }
     public static String getCrafatarHost() { return crafatarHost; }
+    public static boolean getReuploadCrafatarImages() { return reuploadCrafatarImages; }
 
     public static boolean getSendServerCount() { return sendServerCount; }
     public static String getPwToken() { return pwToken; }

--- a/src/com/tisawesomeness/minecord/Config.java
+++ b/src/com/tisawesomeness/minecord/Config.java
@@ -21,6 +21,7 @@ public class Config {
     private static String joinLogChannel;
     private static String logWebhook;
     private static String statusWebhook;
+    private static boolean includeSpamStatuses;
     private static String supportedMCVersion;
     private static boolean isSelfHosted;
     private static String author;
@@ -116,6 +117,7 @@ public class Config {
             joinLogChannel = settings.optString("joinLogChannel", "0");
             logWebhook = settings.optString("logWebhook", "");
             statusWebhook = settings.optString("statusWebhook", "");
+            includeSpamStatuses = settings.optBoolean("includeSpamStatuses", false);
             supportedMCVersion = settings.optString("supportedMCVersion", "1.20.3");
             isSelfHosted = settings.getBoolean("isSelfHosted");
             if (isSelfHosted) {
@@ -189,6 +191,7 @@ public class Config {
     public static String getJoinLogChannel() { return joinLogChannel; }
     public static String getLogWebhook() { return logWebhook; }
     public static String getStatusWebhook() { return statusWebhook; }
+    public static boolean getIncludeSpamStatuses() { return includeSpamStatuses; }
     public static String getSupportedMCVersion() { return supportedMCVersion; }
     public static boolean isSelfHosted() { return isSelfHosted; }
     public static String getAuthor() { return author; }

--- a/src/com/tisawesomeness/minecord/StatusListener.java
+++ b/src/com/tisawesomeness/minecord/StatusListener.java
@@ -51,10 +51,16 @@ public class StatusListener extends ListenerAdapter {
                 status = "Invalidated";
                 break;
             case DISCONNECTED:
+                if (!Config.getIncludeSpamStatuses()) {
+                    return;
+                }
                 emote = ":no_mobile_phones:";
                 status = "Disconnected";
                 break;
             case RESUMED:
+                if (!Config.getIncludeSpamStatuses()) {
+                    return;
+                }
                 emote = ":arrow_forward:";
                 status = "Resumed";
                 break;

--- a/src/com/tisawesomeness/minecord/command/player/AbstractPlayerCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/AbstractPlayerCommand.java
@@ -1,13 +1,23 @@
 package com.tisawesomeness.minecord.command.player;
 
+import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.command.SlashCommand;
+import com.tisawesomeness.minecord.util.RequestUtils;
+import com.tisawesomeness.minecord.util.Utils;
 import com.tisawesomeness.minecord.util.type.FutureCallback;
-
 import lombok.SneakyThrows;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.utils.FileUpload;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 public abstract class AbstractPlayerCommand extends SlashCommand {
 
@@ -42,6 +52,51 @@ public abstract class AbstractPlayerCommand extends SlashCommand {
             System.err.println("Somehow, there was an exception processing an uncaught exception");
             ex2.printStackTrace();
         }
+    }
+
+    /**
+     * If Crafatar reuploading is enabled, images in the embed will be downloaded and sent with the embed as attachments.
+     * Otherwise, the embed will be sent as-is. If an image file fails to download, the embed will link to the image
+     * URL as normal. Assumes .png images.
+     * @param e event, a defer reply request must have been sent before
+     * @param emb the embed to send
+     */
+    protected static void uploadOrEmbedImages(SlashCommandInteractionEvent e, MessageEmbed emb) {
+        if (Config.getReuploadCrafatarImages()) {
+            EmbedBuilder eb = new EmbedBuilder(emb);
+            List<FileUpload> files = new ArrayList<>();
+
+            MessageEmbed.AuthorInfo author = emb.getAuthor();
+            if (author != null) {
+                tryDownloadImage(author.getIconUrl(),
+                        attachment -> eb.setAuthor(author.getName(), author.getUrl(), attachment)).ifPresent(files::add);
+            }
+            String imageUrl = Utils.mapNullable(emb.getImage(), MessageEmbed.ImageInfo::getUrl);
+            tryDownloadImage(imageUrl, eb::setImage).ifPresent(files::add);
+            String thumbnailUrl = Utils.mapNullable(emb.getThumbnail(), MessageEmbed.Thumbnail::getUrl);
+            tryDownloadImage(thumbnailUrl, eb::setThumbnail).ifPresent(files::add);
+
+            if (!files.isEmpty()) {
+                e.getHook().sendMessageEmbeds(eb.build()).addFiles(files).queue();
+                return;
+            }
+        }
+        e.getHook().sendMessageEmbeds(emb).queue();
+    }
+
+    private static Optional<FileUpload> tryDownloadImage(String url, Consumer<String> attachmentConsumer) {
+        if (url == null) {
+            return Optional.empty();
+        }
+        try {
+            byte[] data = RequestUtils.download(url);
+            String fileName = UUID.randomUUID() + ".png";
+            attachmentConsumer.accept("attachment://" + fileName);
+            return Optional.of(FileUpload.fromData(data, fileName));
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+        return Optional.empty();
     }
 
 }

--- a/src/com/tisawesomeness/minecord/command/player/CapeCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/CapeCommand.java
@@ -4,11 +4,10 @@ import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.mc.player.Player;
 import com.tisawesomeness.minecord.mc.player.RenderType;
 import com.tisawesomeness.minecord.util.ColorUtils;
-
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 
-import java.awt.Color;
+import java.awt.*;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Optional;
@@ -75,7 +74,7 @@ public class CapeCommand extends BasePlayerCommand {
                 .setAuthor(title, nameMcUrl, avatarUrl)
                 .setColor(color)
                 .setImage(capeUrl.toString());
-        e.getHook().sendMessageEmbeds(eb.build()).queue();
+        uploadOrEmbedImages(e, eb.build());
     }
 
 }

--- a/src/com/tisawesomeness/minecord/command/player/ProfileCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/ProfileCommand.java
@@ -95,7 +95,7 @@ public class ProfileCommand extends BasePlayerCommand {
 
         String nameHistory = "Mojang has removed the name history API, [read more here](https://help.minecraft.net/hc/en-us/articles/8969841895693). We are working on a different way to retrieve name history, stay tuned.";
         eb.addField("Name History", nameHistory, true);
-        e.getHook().sendMessageEmbeds(eb.build()).queue();
+        uploadOrEmbedImages(e, eb.build());
     }
 
     private static @NonNull String constructDescription(Player player) {

--- a/src/com/tisawesomeness/minecord/command/player/RenderCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/RenderCommand.java
@@ -7,7 +7,6 @@ import com.tisawesomeness.minecord.mc.player.RenderType;
 import com.tisawesomeness.minecord.mc.player.Username;
 import com.tisawesomeness.minecord.util.ColorUtils;
 import com.tisawesomeness.minecord.util.MessageUtils;
-
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
@@ -15,7 +14,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 
-import java.awt.Color;
+import java.awt.*;
 
 public class RenderCommand extends BaseRenderCommand {
 
@@ -92,7 +91,7 @@ public class RenderCommand extends BaseRenderCommand {
             String msg = String.format("The scale was too high, so it was set to the max, %d.", type.getMaxScale());
             eb.setDescription(msg);
         }
-        e.getHook().sendMessageEmbeds(eb.build()).queue();
+        uploadOrEmbedImages(e, eb.build());
     }
 
 }

--- a/src/com/tisawesomeness/minecord/command/player/SkinCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/SkinCommand.java
@@ -50,7 +50,7 @@ public class SkinCommand extends BasePlayerCommand {
                 .setColor(color)
                 .setDescription(description)
                 .setImage(skinUrl);
-        e.getHook().sendMessageEmbeds(eb.build()).queue();
+        uploadOrEmbedImages(e, eb.build());
     }
     private static @NonNull String constructDescription(Player player) {
         String custom = "**Custom**: " + (player.hasCustomSkin() ? "True" : "False");

--- a/src/com/tisawesomeness/minecord/command/utility/StackCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/StackCommand.java
@@ -45,8 +45,7 @@ public class StackCommand extends SlashCommand {
                 new OptionData(OptionType.INTEGER, "double-chests", "Number of double chests full of items").setMinValue(0),
                 new OptionData(OptionType.INTEGER, "chest-shulkers", "Number of chests full of shulkers").setMinValue(0),
                 new OptionData(OptionType.INTEGER, "double-chest-shulkers", "Number of double chests full of shulkers").setMinValue(0),
-                new OptionData(OptionType.INTEGER, "stack-size", "Stack size of the item")
-                        .addChoice("1", 1).addChoice("16", 16).addChoice("64", 64)
+                new OptionData(OptionType.INTEGER, "stack-size", "Stack size of the item").setRequiredRange(1, ItemCount.MAX_STACK_SIZE)
         );
     }
 

--- a/src/com/tisawesomeness/minecord/mc/item/Item.java
+++ b/src/com/tisawesomeness/minecord/mc/item/Item.java
@@ -326,9 +326,11 @@ public class Item {
         if (toParse.contains(":")) {
             String[] split = toParse.split(":");
             toParse = split[0];
-            data = parseData(split[1], lang);
-            if (data < 0) {
-                return null;
+            if (split.length > 1) {
+                data = parseData(split[1], lang);
+                if (data < 0) {
+                    return null;
+                }
             }
         }
 

--- a/src/com/tisawesomeness/minecord/mc/item/ItemCount.java
+++ b/src/com/tisawesomeness/minecord/mc/item/ItemCount.java
@@ -11,6 +11,8 @@ import java.util.List;
  */
 public class ItemCount {
 
+    public static final int MAX_STACK_SIZE = 99;
+
     private final long itemCount;
     @Getter private final int stackSize;
 
@@ -22,8 +24,8 @@ public class ItemCount {
      */
     public ItemCount(long itemCount, int stackSize) {
         this.itemCount = itemCount;
-        if (stackSize < 1 || 64 < stackSize) {
-            throw new IllegalArgumentException("stackSize must be between 1 and 64 but was " + stackSize);
+        if (stackSize < 1 || MAX_STACK_SIZE < stackSize) {
+            throw new IllegalArgumentException("stackSize must be between 1 and " + MAX_STACK_SIZE + " but was " + stackSize);
         }
         this.stackSize = stackSize;
 

--- a/src/com/tisawesomeness/minecord/util/RequestUtils.java
+++ b/src/com/tisawesomeness/minecord/util/RequestUtils.java
@@ -3,6 +3,7 @@ package com.tisawesomeness.minecord.util;
 import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.Config;
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.internal.utils.IOUtil;
 import org.discordbots.api.client.DiscordBotListAPI;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -123,6 +124,25 @@ public class RequestUtils {
             conn.setRequestProperty("Authorization", auth);
         }
         return conn;
+    }
+
+    /**
+     * Downloads a file from a URL.
+     * @param url The URL to download from.
+     * @return The file contents.
+     */
+    public static byte[] download(String url) throws IOException {
+        return download(new URL(url));
+    }
+    /**
+     * Downloads a file from a URL.
+     * @param url The URL to download from.
+     * @return The file contents.
+     */
+    public static byte[] download(URL url) throws IOException {
+        try (InputStream is = url.openStream()) {
+            return IOUtil.readFully(is);
+        }
     }
 
     /**

--- a/src/com/tisawesomeness/minecord/util/Utils.java
+++ b/src/com/tisawesomeness/minecord/util/Utils.java
@@ -1,0 +1,13 @@
+package com.tisawesomeness.minecord.util;
+
+import javax.annotation.Nullable;
+import java.util.function.Function;
+
+public final class Utils {
+    private Utils() {}
+
+    public static <T, R> @Nullable R mapNullable(@Nullable T obj, Function<? super T, ? extends R> mapper) {
+        return obj == null ? null : mapper.apply(obj);
+    }
+
+}

--- a/src/com/tisawesomeness/minecord/util/type/HumanDecimalFormat.java
+++ b/src/com/tisawesomeness/minecord/util/type/HumanDecimalFormat.java
@@ -103,7 +103,6 @@ public class HumanDecimalFormat {
             }
             return format;
         }
-
     }
 
     /**


### PR DESCRIPTION
**Minecord 0.17.8**
- Fixed exception when looking up item with trailing `:`
- Packaged release in zip file again

**Minecord 0.17.9**
- `/stack` now supports all stack sizes from 1 to 99 (may take up to 1 hour to propogate)
- Added a workaround for Discord refusing to embed player/skin render images. Self-hosters can toggle this with `reuploadCrafatarImages` in the config.
- Added an easter egg.
- (Self-hosting change) Added `includeSpamStatuses` in config to silence frequent status logs