### PR TITLE
Version 0.17.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ A robust Discord bot using the JDA library for various Minecraft functions.
     "logWebhook": "",
     "statusWebhook": "",
     "includeSpamStatuses": true,
-    "supportedMCVersion":  "1.20.4",
+    "supportedMCVersion":  "1.20.5",
     "isSelfHosted": true,
     "author": "Tis_awesomeness",
     "authorTag": "@tis_awesomeness",

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
         "logWebhook": "",
         "statusWebhook": "",
         "includeSpamStatuses": true,
-        "supportedMCVersion": "1.20.4",
+        "supportedMCVersion": "1.20.5",
         "isSelfHosted": true,
         "author": "Tis_awesomeness",
         "authorTag": "@tis_awesomeness",

--- a/items.json
+++ b/items.json
@@ -724,7 +724,6 @@
     },
     "properties": {
       "data": 1,
-      "image_key": "Grass",
       "previous_id": "minecraft.grass",
       "id": 31,
       "conflict": true
@@ -1354,8 +1353,8 @@
     "properties": {
       "data": 1,
       "previous_id": "minecraft.stone_slab",
-      "conflict": true,
-      "id": 44
+      "id": 44,
+      "conflict": true
     }
   },
   "minecraft.petrified_oak_slab": {
@@ -1372,8 +1371,8 @@
       "data": 2,
       "image_key": "Oak Wood Slab",
       "previous_id": "minecraft.stone_slab",
-      "conflict": true,
-      "id": 44
+      "id": 44,
+      "conflict": true
     }
   },
   "minecraft.cobblestone_slab": {
@@ -1388,9 +1387,9 @@
     "properties": {
       "data": 3,
       "previous_id": "minecraft.stone_slab",
-      "conflict": true,
       "id": 44,
-      "version": "1.14"
+      "version": "1.14",
+      "conflict": true
     }
   },
   "minecraft.brick_slab": {
@@ -1405,8 +1404,8 @@
     "properties": {
       "data": 4,
       "previous_id": "minecraft.stone_slab",
-      "conflict": true,
-      "id": 44
+      "id": 44,
+      "conflict": true
     }
   },
   "minecraft.stone_brick_slab": {
@@ -1421,8 +1420,8 @@
     "properties": {
       "data": 5,
       "previous_id": "minecraft.stone_slab",
-      "conflict": true,
-      "id": 44
+      "id": 44,
+      "conflict": true
     }
   },
   "minecraft.nether_brick_slab": {
@@ -1434,8 +1433,8 @@
     "properties": {
       "data": 6,
       "previous_id": "minecraft.stone_slab",
-      "conflict": true,
-      "id": 44
+      "id": 44,
+      "conflict": true
     }
   },
   "minecraft.quartz_slab": {
@@ -1447,8 +1446,8 @@
     "properties": {
       "data": 7,
       "previous_id": "minecraft.stone_slab",
-      "conflict": true,
-      "id": 44
+      "id": 44,
+      "conflict": true
     }
   },
   "minecraft.bricks": {
@@ -8977,7 +8976,8 @@
       "en_US": {
         "search_names": [
           "Fireball",
-          "Fire Ball"
+          "Fire Ball",
+          "Blaze Charge"
         ],
         "display_name": "Fire Charge"
       }
@@ -11772,16 +11772,6 @@
       "version": "1.13"
     }
   },
-  "minecraft.scute": {
-    "lang": {
-      "en_US": {
-        "display_name": "Scute"
-      }
-    },
-    "properties": {
-      "version": "1.13"
-    }
-  },
   "minecraft.sea_pickle": {
     "lang": {
       "en_US": {
@@ -12114,7 +12104,18 @@
       }
     },
     "properties": {
-      "image_key": "Turtle Helmet",
+      "version": "1.13"
+    }
+  },
+  "minecraft.turtle_scute": {
+    "lang": {
+      "en_US": {
+        "previously": "Scute",
+        "display_name": "Turtle Scute"
+      }
+    },
+    "properties": {
+      "previous_id": "minecraft.scute",
       "version": "1.13"
     }
   },
@@ -20889,9 +20890,6 @@
   "minecraft.trial_key": {
     "lang": {
       "en_US": {
-        "search_names": [
-          "Limbo Key"
-        ],
         "display_name": "Trial Key"
       }
     },
@@ -21591,1181 +21589,361 @@
       "version": "1.20.3"
     }
   },
-  "minecraft.lingering_potion.effect.awkward": {
+  "minecraft.armadillo_scute": {
     "lang": {
       "en_US": {
-        "lore": "No effects",
-        "search_names": [
-          "Lingering Awkward Potion"
-        ],
-        "display_name": "Awkward Lingering Potion"
+        "display_name": "Armadillo Scute"
       }
     },
     "properties": {
-      "image_key": "Lingering Water Bottle",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.empty": {
+  "minecraft.armadillo_spawn_egg": {
     "lang": {
       "en_US": {
-        "lore": "No effects",
         "search_names": [
-          "Uncraftable Lingering Potion"
+          "Spawn Armadillo",
+          "Armadillo Egg"
         ],
-        "display_name": "Lingering Uncraftable Potion"
+        "display_name": "Armadillo Spawn Egg"
       }
     },
     "properties": {
-      "image_key": "Uncraftable Lingering Potion",
-      "actual_id": "minecraft.lingering_potion",
-      "version": "1.9"
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.fire_resistance": {
+  "minecraft.wolf_armor": {
     "lang": {
       "en_US": {
-        "lore": "Fire Resistance (0:45)",
         "search_names": [
-          "Fire Resistance Lingering Potion",
-          "Lingering Fire Resistance Potion"
+          "Wolf Armour"
         ],
-        "display_name": "Lingering Potion of Fire Resistance"
+        "display_name": "Wolf Armor"
       }
     },
     "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.fire_resistance.extended": {
+  "minecraft.bogged_spawn_egg": {
     "lang": {
       "en_US": {
-        "lore": "Fire Resistance (2:00)",
         "search_names": [
-          "Extended Lingering Potion of Fire Resistance",
-          "Lingering Extended Potion of Fire Resistance",
-          "Lengthened Lingering Potion of Fire Resistance",
-          "Lingering Lengthened Potion of Fire Resistance",
-          "Lingering Potion of Fire Resistance Extended",
-          "Lingering Potion of Fire Resistance Lengthened",
-          "Lingering Potion of Fire Resistance+",
-          "Lingering Potion of Fire Resistance +",
-          "Lingering Potion of Extended Fire Resistance",
-          "Lingering Potion of Lengthened Fire Resistance",
-          "Extended Fire Resistance Lingering Potion",
-          "Lingering Extended Fire Resistance Potion",
-          "Extended Lingering Fire Resistance Potion",
-          "Lengthened Fire Resistance Lingering Potion",
-          "Lingering Lengthened Fire Resistance Potion",
-          "Lengthened Lingering Fire Resistance Potion",
-          "Fire Resistance Lingering Potion Extended",
-          "Lingering Fire Resistance Potion Extended",
-          "Fire Resistance Lingering Potion Lengthened",
-          "Lingering Fire Resistance Potion Lengthened"
+          "Spawn Bogged",
+          "Bogged Egg",
+          "Poison Skeleton Spawn Egg",
+          "Spawn Poison Skeleton",
+          "Poison Skeleton Egg",
+          "Poisonous Skeleton Spawn Egg",
+          "Spawn Poisonous Skeleton",
+          "Poisonous Skeleton Egg",
+          "Mossy Skeleton Spawn Egg",
+          "Spawn Mossy Skeleton",
+          "Mossy Skeleton Egg"
         ],
-        "display_name": "Lingering Potion of Fire Resistance (extended)"
+        "display_name": "Bogged Spawn Egg"
       }
     },
     "properties": {
-      "image_key": "Lingering Potion of Fire Resistance",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.harming": {
+  "minecraft.bolt_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
-        "lore": "Instant Harming",
+        "distinct_display_name": "Bolt Smithing Template",
+        "lore": "Bolt Armor Trim",
         "search_names": [
-          "Harming Lingering Potion",
-          "Lingering Harming Potion",
-          "Instant Damage Lingering Potion",
-          "Lingering Instant Damage Potion",
-          "Lingering Potion of Instant Damage"
+          "Bolt Armor Trim Smithing Template",
+          "Bolt Armor Trim Template",
+          "Bolt Armor Trim",
+          "Bolt Trim Smithing Template",
+          "Bolt Trim Template",
+          "Bolt Trim",
+          "Bolt Template",
+          "Vault Armor Trim Smithing Template",
+          "Vault Armor Trim Template",
+          "Vault Armor Trim",
+          "Vault Trim Smithing Template",
+          "Vault Trim Template",
+          "Vault Trim",
+          "Vault Smithing Template",
+          "Vault Template"
         ],
-        "display_name": "Lingering Potion of Harming"
+        "display_name": "Smithing Template",
+        "name_conflict": true
       }
     },
     "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "image_key": "Bolt Armor Trim",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.harming.ii": {
+  "minecraft.breeze_rod": {
     "lang": {
       "en_US": {
-        "lore": "Instant Harming II",
         "search_names": [
-          "Enhanced Lingering Potion of Harming",
-          "Lingering Enhanced Potion of Harming",
-          "Amplified Lingering Potion of Harming",
-          "Lingering Amplified Potion of Harming",
-          "Lingering Potion of Harming II",
-          "Lingering Potion of Harming 2",
-          "Lingering Potion of Harming Enhanced",
-          "Lingering Potion of Harming Amplified",
-          "Lingering Potion of Enhanced Harming",
-          "Lingering Potion of Amplified Harming",
-          "Enhanced Harming Lingering Potion",
-          "Lingering Enhanced Harming Potion",
-          "Enhanced Lingering Harming Potion",
-          "Amplified Harming Lingering Potion",
-          "Lingering Amplified Harming Potion",
-          "Amplified Lingering Harming Potion",
-          "Harming Lingering Potion II",
-          "Harming Lingering Potion 2",
-          "Lingering Harming Potion II",
-          "Lingering Harming Potion 2",
-          "Harming Lingering Potion Enhanced",
-          "Lingering Harming Potion Enhanced",
-          "Harming Lingering Potion Amplified",
-          "Lingering Harming Potion Amplified",
-          "Enhanced Lingering Potion of Instant Damage",
-          "Lingering Enhanced Potion of Instant Damage",
-          "Amplified Lingering Potion of Instant Damage",
-          "Lingering Amplified Potion of Instant Damage",
-          "Lingering Potion of Instant Damage II",
-          "Lingering Potion of Instant Damage 2",
-          "Lingering Potion of Instant Damage Enhanced",
-          "Lingering Potion of Instant Damage Amplified",
-          "Lingering Potion of Enhanced Instant Damage",
-          "Lingering Potion of Amplified Instant Damage",
-          "Enhanced Instant Damage Lingering Potion",
-          "Lingering Enhanced Instant Damage Potion",
-          "Enhanced Lingering Instant Damage Potion",
-          "Amplified Instant Damage Lingering Potion",
-          "Lingering Amplified Instant Damage Potion",
-          "Amplified Lingering Instant Damage Potion",
-          "Instant Damage Lingering Potion II",
-          "Instant Damage Lingering Potion 2",
-          "Lingering Instant Damage Potion II",
-          "Lingering Instant Damage Potion 2",
-          "Instant Damage Lingering Potion Enhanced",
-          "Lingering Instant Damage Potion Enhanced",
-          "Instant Damage Lingering Potion Amplified",
-          "Lingering Instant Damage Potion Amplified"
+          "Blitz Rod"
         ],
-        "display_name": "Lingering Potion of Harming (enhanced)"
+        "display_name": "Breeze Rod"
       }
     },
     "properties": {
-      "image_key": "Lingering Potion of Harming",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.healing": {
+  "minecraft.flow_armor_trim_smithing_template": {
     "lang": {
       "en_US": {
-        "lore": "Instant Health",
+        "distinct_display_name": "Flow Smithing Template",
+        "lore": "Flow Armor Trim",
         "search_names": [
-          "Healing Lingering Potion",
-          "Lingering Healing Potion",
-          "Instant Health Lingering Potion",
-          "Lingering Instant Health Potion",
-          "Lingering Potion of Instant Health"
+          "Flow Armor Trim Smithing Template",
+          "Flow Armor Trim Template",
+          "Flow Armor Trim",
+          "Flow Trim Smithing Template",
+          "Flow Trim Template",
+          "Flow Trim",
+          "Flow Template",
+          "Ominous Vault Armor Trim Smithing Template",
+          "Ominous Vault Armor Trim Template",
+          "Ominous Vault Armor Trim",
+          "Ominous Vault Trim Smithing Template",
+          "Ominous Vault Trim Template",
+          "Ominous Vault Trim",
+          "Ominous Vault Smithing Template",
+          "Ominous Vault Template",
+          "Ominous Armor Trim Smithing Template",
+          "Ominous Armor Trim Template",
+          "Ominous Armor Trim",
+          "Ominous Trim Smithing Template",
+          "Ominous Trim Template",
+          "Ominous Trim",
+          "Ominous Smithing Template",
+          "Ominous Template"
         ],
-        "display_name": "Lingering Potion of Healing"
+        "display_name": "Smithing Template",
+        "name_conflict": true
       }
     },
     "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "image_key": "Flow Armor Trim",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.healing.ii": {
+  "minecraft.flow_banner_pattern": {
     "lang": {
       "en_US": {
-        "lore": "Instant Health II",
+        "distinct_display_name": "Flow Banner Pattern",
+        "lore": "Flow",
         "search_names": [
-          "Enhanced Lingering Potion of Healing",
-          "Lingering Enhanced Potion of Healing",
-          "Amplified Lingering Potion of Healing",
-          "Lingering Amplified Potion of Healing",
-          "Lingering Potion of Healing II",
-          "Lingering Potion of Healing 2",
-          "Lingering Potion of Healing Enhanced",
-          "Lingering Potion of Healing Amplified",
-          "Lingering Potion of Enhanced Healing",
-          "Lingering Potion of Amplified Healing",
-          "Enhanced Healing Lingering Potion",
-          "Lingering Enhanced Healing Potion",
-          "Enhanced Lingering Healing Potion",
-          "Amplified Healing Lingering Potion",
-          "Lingering Amplified Healing Potion",
-          "Amplified Lingering Healing Potion",
-          "Healing Lingering Potion II",
-          "Healing Lingering Potion 2",
-          "Lingering Healing Potion II",
-          "Lingering Healing Potion 2",
-          "Healing Lingering Potion Enhanced",
-          "Lingering Healing Potion Enhanced",
-          "Healing Lingering Potion Amplified",
-          "Lingering Healing Potion Amplified",
-          "Enhanced Lingering Potion of Instant Health",
-          "Lingering Enhanced Potion of Instant Health",
-          "Amplified Lingering Potion of Instant Health",
-          "Lingering Amplified Potion of Instant Health",
-          "Lingering Potion of Instant Health II",
-          "Lingering Potion of Instant Health Enhanced",
-          "Lingering Potion of Instant Health Amplified",
-          "Lingering Potion of Enhanced Instant Health",
-          "Lingering Potion of Amplified Instant Health",
-          "Enhanced Instant Health Lingering Potion",
-          "Lingering Enhanced Instant Health Potion",
-          "Enhanced Lingering Instant Health Potion",
-          "Amplified Instant Health Lingering Potion",
-          "Lingering Amplified Instant Health Potion",
-          "Amplified Lingering Instant Health Potion",
-          "Instant Health Lingering Potion II",
-          "Instant Health Lingering Potion 2",
-          "Lingering Instant Health Potion II",
-          "Lingering Instant Health Potion 2",
-          "Instant Health Lingering Potion Enhanced",
-          "Lingering Instant Health Potion Enhanced",
-          "Instant Health Lingering Potion Amplified",
-          "Lingering Instant Health Potion Amplified"
+          "Wind Banner Pattern",
+          "Air Banner Pattern",
+          "Flow Pattern",
+          "Wind Pattern",
+          "Air Pattern"
         ],
-        "display_name": "Lingering Potion of Healing (enhanced)"
+        "display_name": "Banner Pattern",
+        "name_conflict": true
       }
     },
     "properties": {
-      "image_key": "Lingering Potion of Healing",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.invisibility": {
+  "minecraft.flow_pottery_sherd": {
     "lang": {
       "en_US": {
-        "lore": "Invisibility (0:45)",
         "search_names": [
-          "Invisibility Lingering Potion",
-          "Lingering Invisibility Potion",
-          "Invis Lingering Potion",
-          "Lingering Invis Potion"
+          "Flow Sherd",
+          "Pottery Sherd Flow",
+          "Flow Pottery Shard",
+          "Flow Shard",
+          "Pottery Shard Flow",
+          "Wind Pottery Sherd",
+          "Wind Sherd",
+          "Pottery Sherd Wind",
+          "Wind Pottery Shard",
+          "Wind Shard",
+          "Pottery Shard Wind",
+          "Air Pottery Sherd",
+          "Air Sherd",
+          "Pottery Sherd Air",
+          "Air Pottery Shard",
+          "Air Shard",
+          "Pottery Shard Air"
         ],
-        "display_name": "Lingering Potion of Invisibility"
+        "display_name": "Flow Pottery Sherd"
       }
     },
     "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.invisibility.extended": {
+  "minecraft.guster_banner_pattern": {
     "lang": {
       "en_US": {
-        "lore": "Invisibility (2:00)",
+        "distinct_display_name": "Guster Banner Pattern",
+        "lore": "Guster",
         "search_names": [
-          "Extended Lingering Potion of Invisibility",
-          "Lingering Extended Potion of Invisibility",
-          "Lengthened Lingering Potion of Invisibility",
-          "Lingering Lengthened Potion of Invisibility",
-          "Lingering Potion of Invisibility Extended",
-          "Lingering Potion of Invisibility Lengthened",
-          "Lingering Potion of Invisibility+",
-          "Lingering Potion of Invisibility +",
-          "Lingering Potion of Extended Invisibility",
-          "Lingering Potion of Lengthened Invisibility",
-          "Extended Invisibility Lingering Potion",
-          "Lingering Extended Invisibility Potion",
-          "Extended Lingering Invisibility Potion",
-          "Lengthened Invisibility Lingering Potion",
-          "Lingering Lengthened Invisibility Potion",
-          "Lengthened Lingering Invisibility Potion",
-          "Invisibility Lingering Potion Extended",
-          "Lingering Invisibility Potion Extended",
-          "Invisibility Lingering Potion Lengthened",
-          "Lingering Invisibility Potion Lengthened",
-          "Extended Invis Lingering Potion",
-          "Lingering Extended Invis Potion",
-          "Extended Lingering Invis Potion",
-          "Lengthened Invis Lingering Potion",
-          "Lingering Lengthened Invis Potion",
-          "Lengthened Lingering Invis Potion",
-          "Invis Lingering Potion Extended",
-          "Lingering Invis Potion Extended",
-          "Invis Lingering Potion Lengthened",
-          "Lingering Invis Potion Lengthened"
+          "Breeze Banner Pattern",
+          "Guster Pattern",
+          "Breeze Pattern"
         ],
-        "display_name": "Lingering Potion of Invisibility (extended)"
+        "display_name": "Banner Pattern",
+        "name_conflict": true
       }
     },
     "properties": {
-      "image_key": "Lingering Potion of Invisibility",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.leaping": {
+  "minecraft.guster_pottery_sherd": {
     "lang": {
       "en_US": {
-        "lore": "Jump Boost (0:45)",
         "search_names": [
-          "Leaping Lingering Potion",
-          "Lingering Leaping Potion",
-          "Jump Boost Lingering Potion",
-          "Lingering Jump Boost Potion",
-          "Lingering Potion of Jump Boost"
+          "Guster Sherd",
+          "Pottery Sherd Guster",
+          "Guster Pottery Shard",
+          "Guster Shard",
+          "Pottery Shard Guster",
+          "Breeze Pottery Sherd",
+          "Breeze Sherd",
+          "Pottery Sherd Breeze",
+          "Breeze Pottery Shard",
+          "Breeze Shard",
+          "Pottery Shard Breeze"
         ],
-        "display_name": "Lingering Potion of Leaping"
+        "display_name": "Guster Pottery Sherd"
       }
     },
     "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.leaping.extended": {
+  "minecraft.heavy_core": {
     "lang": {
       "en_US": {
-        "lore": "Jump Boost (2:00)",
-        "search_names": [
-          "Extended Lingering Potion of Leaping",
-          "Lingering Extended Potion of Leaping",
-          "Lengthened Lingering Potion of Leaping",
-          "Lingering Lengthened Potion of Leaping",
-          "Lingering Potion of Leaping Extended",
-          "Lingering Potion of Leaping Lengthened",
-          "Lingering Potion of Leaping+",
-          "Lingering Potion of Leaping +",
-          "Lingering Potion of Extended Leaping",
-          "Lingering Potion of Lengthened Leaping",
-          "Extended Leaping Lingering Potion",
-          "Lingering Extended Leaping Potion",
-          "Extended Lingering Leaping Potion",
-          "Lengthened Leaping Lingering Potion",
-          "Lingering Lengthened Leaping Potion",
-          "Lengthened Lingering Leaping Potion",
-          "Leaping Lingering Potion Extended",
-          "Lingering Leaping Potion Extended",
-          "Leaping Lingering Potion Lengthened",
-          "Lingering Leaping Potion Lengthened",
-          "Extended Lingering Potion of Jump Boost",
-          "Lingering Extended Potion of Jump Boost",
-          "Lengthened Lingering Potion of Jump Boost",
-          "Lingering Lengthened Potion of Jump Boost",
-          "Lingering Potion of Jump Boost Extended",
-          "Lingering Potion of Jump Boost Lengthened",
-          "Lingering Potion of Jump Boost+",
-          "Lingering Potion of Jump Boost +",
-          "Lingering Potion of Extended Jump Boost",
-          "Lingering Potion of Lengthened Jump Boost",
-          "Extended Jump Boost Lingering Potion",
-          "Lingering Extended Jump Boost Potion",
-          "Extended Lingering Jump Boost Potion",
-          "Lengthened Jump Boost Lingering Potion",
-          "Lingering Lengthened Jump Boost Potion",
-          "Lengthened Lingering Jump Boost Potion",
-          "Jump Boost Lingering Potion Extended",
-          "Lingering Jump Boost Potion Extended",
-          "Jump Boost Lingering Potion Lengthened",
-          "Lingering Jump Boost Potion Lengthened"
-        ],
-        "display_name": "Lingering Potion of Leaping (extended)"
+        "display_name": "Heavy Core"
       }
     },
     "properties": {
-      "image_key": "Lingering Potion of Leaping",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.leaping.ii": {
+  "minecraft.mace": {
     "lang": {
       "en_US": {
-        "lore": "Jump Boost II (0:22)",
         "search_names": [
-          "Enhanced Lingering Potion of Leaping",
-          "Lingering Enhanced Potion of Leaping",
-          "Amplified Lingering Potion of Leaping",
-          "Lingering Amplified Potion of Leaping",
-          "Lingering Potion of Leaping II",
-          "Lingering Potion of Leaping 2",
-          "Lingering Potion of Leaping Enhanced",
-          "Lingering Potion of Leaping Amplified",
-          "Lingering Potion of Enhanced Leaping",
-          "Lingering Potion of Amplified Leaping",
-          "Enhanced Leaping Lingering Potion",
-          "Lingering Enhanced Leaping Potion",
-          "Enhanced Lingering Leaping Potion",
-          "Amplified Leaping Lingering Potion",
-          "Lingering Amplified Leaping Potion",
-          "Amplified Lingering Leaping Potion",
-          "Leaping Lingering Potion II",
-          "Leaping Lingering Potion 2",
-          "Lingering Leaping Potion II",
-          "Lingering Leaping Potion 2",
-          "Leaping Lingering Potion Enhanced",
-          "Lingering Leaping Potion Enhanced",
-          "Leaping Lingering Potion Amplified",
-          "Lingering Leaping Potion Amplified",
-          "Enhanced Lingering Potion of Jump Boost",
-          "Lingering Enhanced Potion of Jump Boost",
-          "Amplified Lingering Potion of Jump Boost",
-          "Lingering Amplified Potion of Jump Boost",
-          "Lingering Potion of Jump Boost II",
-          "Lingering Potion of Jump Boost 2",
-          "Lingering Potion of Jump Boost Enhanced",
-          "Lingering Potion of Jump Boost Amplified",
-          "Lingering Potion of Enhanced Jump Boost",
-          "Lingering Potion of Amplified Jump Boost",
-          "Enhanced Jump Boost Lingering Potion",
-          "Lingering Enhanced Jump Boost Potion",
-          "Enhanced Lingering Jump Boost Potion",
-          "Amplified Jump Boost Lingering Potion",
-          "Lingering Amplified Jump Boost Potion",
-          "Amplified Lingering Jump Boost Potion",
-          "Jump Boost Lingering Potion II",
-          "Jump Boost Lingering Potion 2",
-          "Lingering Jump Boost Potion II",
-          "Lingering Jump Boost Potion 2",
-          "Jump Boost Lingering Potion Enhanced",
-          "Lingering Jump Boost Potion Enhanced",
-          "Jump Boost Lingering Potion Amplified",
-          "Lingering Jump Boost Potion Amplified"
+          "Market Gardener"
         ],
-        "display_name": "Lingering Potion of Leaping (enhanced)"
+        "display_name": "Mace"
       }
     },
     "properties": {
-      "image_key": "Lingering Potion of Leaping",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.luck": {
+  "minecraft.ominous_bottle": {
     "lang": {
       "en_US": {
-        "lore": "Luck (1:15)",
         "search_names": [
-          "Luck Lingering Potion",
-          "Lingering Luck Potion"
+          "Ominous Potion",
+          "Bad Omen Bottle",
+          "Bad Omen Potion"
         ],
-        "display_name": "Lingering Potion of Luck"
+        "display_name": "Ominous Bottle"
       }
     },
     "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.mundane": {
+  "minecraft.ominous_trial_key": {
     "lang": {
       "en_US": {
-        "lore": "No effects",
         "search_names": [
-          "Lingering Mundane Potion"
+          "Ominous Key",
+          "Limbo Key"
         ],
-        "display_name": "Mundane Lingering Potion"
+        "display_name": "Ominous Trial Key"
       }
     },
     "properties": {
-      "image_key": "Lingering Water Bottle",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.mundane.extended": {
+  "minecraft.scrape_pottery_sherd": {
     "lang": {
       "en_US": {
-        "lore": "No effects",
         "search_names": [
-          "Extended Mundane Lingering Potion",
-          "Lingering Extended Mundane Potion",
-          "Extended Lingering Mundane Potion",
-          "Lengthened Mundane Lingering Potion",
-          "Lingering Lengthened Mundane Potion",
-          "Lengthened Lingering Mundane Potion",
-          "Mundane Lingering Potion Extended",
-          "Lingering Mundane Potion Extended",
-          "Mundane Lingering Potion Lengthened",
-          "Lingering Mundane Potion Lengthened"
+          "Scrape Sherd",
+          "Pottery Sherd Scrape",
+          "Scrape Pottery Shard",
+          "Scrape Shard",
+          "Pottery Shard Scrape",
+          "Axe Pottery Sherd",
+          "Axe Sherd",
+          "Pottery Sherd Axe",
+          "Axe Pottery Shard",
+          "Axe Shard",
+          "Pottery Shard Axe"
         ],
-        "display_name": "Mundane Lingering Potion (extended)"
+        "display_name": "Scrape Pottery Sherd"
       }
     },
     "properties": {
-      "image_key": "Lingering Water Bottle",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.night_vision": {
+  "minecraft.vault": {
     "lang": {
       "en_US": {
-        "lore": "Night Vision (0:45)",
         "search_names": [
-          "Night Vision Lingering Potion",
-          "Lingering Night Vision Potion"
+          "Loot Box",
+          "Lootbox",
+          "Ominous Vault"
         ],
-        "display_name": "Lingering Potion of Night Vision"
+        "display_name": "Vault"
       }
     },
     "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
-  "minecraft.lingering_potion.effect.night_vision.extended": {
+  "minecraft.wind_charge": {
     "lang": {
       "en_US": {
-        "lore": "Night Vision (2:00)",
         "search_names": [
-          "Extended Lingering Potion of Night Vision",
-          "Lingering Extended Potion of Night Vision",
-          "Lengthened Lingering Potion of Night Vision",
-          "Lingering Lengthened Potion of Night Vision",
-          "Lingering Potion of Night Vision Extended",
-          "Lingering Potion of Night Vision Lengthened",
-          "Lingering Potion of Night Vision+",
-          "Lingering Potion of Night Vision +",
-          "Lingering Potion of Extended Night Vision",
-          "Lingering Potion of Lengthened Night Vision",
-          "Extended Night Vision Lingering Potion",
-          "Lingering Extended Night Vision Potion",
-          "Extended Lingering Night Vision Potion",
-          "Lengthened Night Vision Lingering Potion",
-          "Lingering Lengthened Night Vision Potion",
-          "Lengthened Lingering Night Vision Potion",
-          "Night Vision Lingering Potion Extended",
-          "Lingering Night Vision Potion Extended",
-          "Night Vision Lingering Potion Lengthened",
-          "Lingering Night Vision Potion Lengthened"
+          "Air Charge",
+          "Breeze Charge",
+          "Rocket Jumper",
+          "Rocket Launcher",
+          "Fart",
+          "Fart Bubble",
+          "Fart Charge"
         ],
-        "display_name": "Lingering Potion of Night Vision (extended)"
+        "display_name": "Wind Charge"
       }
     },
     "properties": {
-      "image_key": "Lingering Potion of Night Vision",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.poison": {
-    "lang": {
-      "en_US": {
-        "lore": "Poison (0:11)",
-        "search_names": [
-          "Poison Lingering Potion",
-          "Lingering Poison Potion"
-        ],
-        "display_name": "Lingering Potion of Poison"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.poison.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Poison (0:22)",
-        "search_names": [
-          "Extended Lingering Potion of Poison",
-          "Lingering Extended Potion of Poison",
-          "Lengthened Lingering Potion of Poison",
-          "Lingering Lengthened Potion of Poison",
-          "Lingering Potion of Poison Extended",
-          "Lingering Potion of Poison Lengthened",
-          "Lingering Potion of Poison+",
-          "Lingering Potion of Poison +",
-          "Lingering Potion of Extended Poison",
-          "Lingering Potion of Lengthened Poison",
-          "Extended Poison Lingering Potion",
-          "Lingering Extended Poison Potion",
-          "Extended Lingering Poison Potion",
-          "Lengthened Poison Lingering Potion",
-          "Lingering Lengthened Poison Potion",
-          "Lengthened Lingering Poison Potion",
-          "Poison Lingering Potion Extended",
-          "Lingering Poison Potion Extended",
-          "Poison Lingering Potion Lengthened",
-          "Lingering Poison Potion Lengthened"
-        ],
-        "display_name": "Lingering Potion of Poison (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Poison",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.poison.ii": {
-    "lang": {
-      "en_US": {
-        "lore": "Poison II (0:05)",
-        "search_names": [
-          "Enhanced Lingering Potion of Poison",
-          "Lingering Enhanced Potion of Poison",
-          "Amplified Lingering Potion of Poison",
-          "Lingering Amplified Potion of Poison",
-          "Lingering Potion of Poison II",
-          "Lingering Potion of Poison 2",
-          "Lingering Potion of Poison Enhanced",
-          "Lingering Potion of Poison Amplified",
-          "Lingering Potion of Enhanced Poison",
-          "Lingering Potion of Amplified Poison",
-          "Enhanced Poison Lingering Potion",
-          "Lingering Enhanced Poison Potion",
-          "Enhanced Lingering Poison Potion",
-          "Amplified Poison Lingering Potion",
-          "Lingering Amplified Poison Potion",
-          "Amplified Lingering Poison Potion",
-          "Poison Lingering Potion II",
-          "Poison Lingering Potion 2",
-          "Lingering Poison Potion II",
-          "Lingering Poison Potion 2",
-          "Poison Lingering Potion Enhanced",
-          "Lingering Poison Potion Enhanced",
-          "Poison Lingering Potion Amplified",
-          "Lingering Poison Potion Amplified"
-        ],
-        "display_name": "Lingering Potion of Poison (enhanced)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Poison",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.regeneration": {
-    "lang": {
-      "en_US": {
-        "lore": "Regeneration (0:11)",
-        "search_names": [
-          "Regeneration Lingering Potion",
-          "Lingering Regeneration Potion",
-          "Regen Lingering Potion",
-          "Lingering Regen Potion",
-          "Lingering Potion of Regen"
-        ],
-        "display_name": "Lingering Potion of Regeneration"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.regeneration.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Regeneration (0:22)",
-        "search_names": [
-          "Extended Lingering Potion of Regeneration",
-          "Lingering Extended Potion of Regeneration",
-          "Lengthened Lingering Potion of Regeneration",
-          "Lingering Lengthened Potion of Regeneration",
-          "Lingering Potion of Regeneration Extended",
-          "Lingering Potion of Regeneration Lengthened",
-          "Lingering Potion of Regeneration+",
-          "Lingering Potion of Regeneration +",
-          "Lingering Potion of Extended Regeneration",
-          "Lingering Potion of Lengthened Regeneration",
-          "Extended Regeneration Lingering Potion",
-          "Lingering Extended Regeneration Potion",
-          "Extended Lingering Regeneration Potion",
-          "Lengthened Regeneration Lingering Potion",
-          "Lingering Lengthened Regeneration Potion",
-          "Lengthened Lingering Regeneration Potion",
-          "Regeneration Lingering Potion Extended",
-          "Lingering Regeneration Potion Extended",
-          "Regeneration Lingering Potion Lengthened",
-          "Lingering Regeneration Potion Lengthened",
-          "Extended Lingering Potion of Regen",
-          "Lingering Extended Potion of Regen",
-          "Lengthened Lingering Potion of Regen",
-          "Lingering Lengthened Potion of Regen",
-          "Lingering Potion of Regen Extended",
-          "Lingering Potion of Regen Lengthened",
-          "Lingering Potion of Regen+",
-          "Lingering Potion of Regen +",
-          "Lingering Potion of Extended Regen",
-          "Lingering Potion of Lengthened Regen",
-          "Extended Regen Lingering Potion",
-          "Lingering Extended Regen Potion",
-          "Extended Lingering Regen Potion",
-          "Lengthened Regen Lingering Potion",
-          "Lingering Lengthened Regen Potion",
-          "Lengthened Lingering Regen Potion",
-          "Regen Lingering Potion Extended",
-          "Lingering Regen Potion Extended",
-          "Regen Lingering Potion Lengthened",
-          "Lingering Regen Potion Lengthened"
-        ],
-        "display_name": "Lingering Potion of Regeneration (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Regeneration",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.regeneration.ii": {
-    "lang": {
-      "en_US": {
-        "lore": "Regeneration II (0:05)",
-        "search_names": [
-          "Enhanced Lingering Potion of Regeneration",
-          "Lingering Enhanced Potion of Regeneration",
-          "Amplified Lingering Potion of Regeneration",
-          "Lingering Amplified Potion of Regeneration",
-          "Lingering Potion of Regeneration II",
-          "Lingering Potion of Regeneration 2",
-          "Lingering Potion of Regeneration Enhanced",
-          "Lingering Potion of Regeneration Amplified",
-          "Lingering Potion of Enhanced Regeneration",
-          "Lingering Potion of Amplified Regeneration",
-          "Enhanced Regeneration Lingering Potion",
-          "Lingering Enhanced Regeneration Potion",
-          "Enhanced Lingering Regeneration Potion",
-          "Amplified Regeneration Lingering Potion",
-          "Lingering Amplified Regeneration Potion",
-          "Amplified Lingering Regeneration Potion",
-          "Regeneration Lingering Potion II",
-          "Regeneration Lingering Potion 2",
-          "Lingering Regeneration Potion II",
-          "Lingering Regeneration Potion 2",
-          "Regeneration Lingering Potion Enhanced",
-          "Lingering Regeneration Potion Enhanced",
-          "Regeneration Lingering Potion Amplified",
-          "Lingering Regeneration Potion Amplified",
-          "Enhanced Lingering Potion of Regen",
-          "Lingering Enhanced Potion of Regen",
-          "Amplified Lingering Potion of Regen",
-          "Lingering Amplified Potion of Regen",
-          "Lingering Potion of Regen II",
-          "Lingering Potion of Regen 2",
-          "Lingering Potion of Regen Enhanced",
-          "Lingering Potion of Regen Amplified",
-          "Lingering Potion of Enhanced Regen",
-          "Lingering Potion of Amplified Regen",
-          "Enhanced Regen Lingering Potion",
-          "Lingering Enhanced Regen Potion",
-          "Enhanced Lingering Regen Potion",
-          "Amplified Regen Lingering Potion",
-          "Lingering Amplified Regen Potion",
-          "Amplified Lingering Regen Potion",
-          "Regen Lingering Potion II",
-          "Regen Lingering Potion 2",
-          "Lingering Regen Potion II",
-          "Lingering Regen Potion 2",
-          "Regen Lingering Potion Enhanced",
-          "Lingering Regen Potion Enhanced",
-          "Regen Lingering Potion Amplified",
-          "Lingering Regen Potion Amplified"
-        ],
-        "display_name": "Lingering Potion of Regeneration (enhanced)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Regeneration",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.slow_falling": {
-    "lang": {
-      "en_US": {
-        "lore": "Slow Falling (0:22)",
-        "search_names": [
-          "Slow Falling Lingering Potion",
-          "Lingering Slow Falling Potion"
-        ],
-        "display_name": "Lingering Potion of Slow Falling"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.lingering_potion.effect.slow_falling.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Slow Falling (1:00)",
-        "search_names": [
-          "Extended Lingering Potion of Slow Falling",
-          "Lingering Extended Potion of Slow Falling",
-          "Lengthened Lingering Potion of Slow Falling",
-          "Lingering Lengthened Potion of Slow Falling",
-          "Lingering Potion of Slow Falling Extended",
-          "Lingering Potion of Slow Falling Lengthened",
-          "Lingering Potion of Slow Falling+",
-          "Lingering Potion of Slow Falling +",
-          "Lingering Potion of Extended Slow Falling",
-          "Lingering Potion of Lengthened Slow Falling",
-          "Extended Slow Falling Lingering Potion",
-          "Lingering Extended Slow Falling Potion",
-          "Extended Lingering Slow Falling Potion",
-          "Lengthened Slow Falling Lingering Potion",
-          "Lingering Lengthened Slow Falling Potion",
-          "Lengthened Lingering Slow Falling Potion",
-          "Slow Falling Lingering Potion Extended",
-          "Lingering Slow Falling Potion Extended",
-          "Slow Falling Lingering Potion Lengthened",
-          "Lingering Slow Falling Potion Lengthened"
-        ],
-        "display_name": "Lingering Potion of Slow Falling (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Slow Falling",
-      "actual_id": "minecraft.lingering_potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.lingering_potion.effect.slowness": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness (0:22)",
-        "search_names": [
-          "Slowness Lingering Potion",
-          "Lingering Slowness Potion"
-        ],
-        "display_name": "Lingering Potion of Slowness"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.slowness.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness (1:00)",
-        "search_names": [
-          "Extended Lingering Potion of Slowness",
-          "Lingering Extended Potion of Slowness",
-          "Lengthened Lingering Potion of Slowness",
-          "Lingering Lengthened Potion of Slowness",
-          "Lingering Potion of Slowness Extended",
-          "Lingering Potion of Slowness Lengthened",
-          "Lingering Potion of Slowness+",
-          "Lingering Potion of Slowness +",
-          "Lingering Potion of Extended Slowness",
-          "Lingering Potion of Lengthened Slowness",
-          "Extended Slowness Lingering Potion",
-          "Lingering Extended Slowness Potion",
-          "Extended Lingering Slowness Potion",
-          "Lengthened Slowness Lingering Potion",
-          "Lingering Lengthened Slowness Potion",
-          "Lengthened Lingering Slowness Potion",
-          "Slowness Lingering Potion Extended",
-          "Lingering Slowness Potion Extended",
-          "Slowness Lingering Potion Lengthened",
-          "Lingering Slowness Potion Lengthened"
-        ],
-        "display_name": "Lingering Potion of Slowness (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Slowness",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.slowness.iv": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness IV (0:05)",
-        "search_names": [
-          "Enhanced Lingering Potion of Slowness",
-          "Lingering Enhanced Potion of Slowness",
-          "Amplified Lingering Potion of Slowness",
-          "Lingering Amplified Potion of Slowness",
-          "Lingering Potion of Slowness IV",
-          "Lingering Potion of Slowness 4",
-          "Lingering Potion of Slowness Enhanced",
-          "Lingering Potion of Slowness Amplified",
-          "Lingering Potion of Enhanced Slowness",
-          "Lingering Potion of Amplified Slowness",
-          "Enhanced Slowness Lingering Potion",
-          "Lingering Enhanced Slowness Potion",
-          "Amplified Slowness Lingering Potion",
-          "Lingering Amplified Slowness Potion",
-          "Slowness Lingering Potion IV",
-          "Slowness Lingering Potion 4",
-          "Lingering Slowness Potion IV",
-          "Lingering Slowness Potion 4",
-          "Slowness Lingering Potion Enhanced",
-          "Lingering Slowness Potion Enhanced",
-          "Slowness Lingering Potion Amplified",
-          "Lingering Slowness Potion Amplified"
-        ],
-        "display_name": "Lingering Potion of Slowness (enhanced)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Slowness",
-      "actual_id": "minecraft.lingering_potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.lingering_potion.effect.strength": {
-    "lang": {
-      "en_US": {
-        "lore": "Strength (0:45)",
-        "search_names": [
-          "Strength Lingering Potion",
-          "Lingering Strength Potion"
-        ],
-        "display_name": "Lingering Potion of Strength"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.strength.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Strength (2:00)",
-        "search_names": [
-          "Extended Lingering Potion of Strength",
-          "Lingering Extended Potion of Strength",
-          "Lengthened Lingering Potion of Strength",
-          "Lingering Lengthened Potion of Strength",
-          "Lingering Potion of Strength Extended",
-          "Lingering Potion of Strength Lengthened",
-          "Lingering Potion of Strength+",
-          "Lingering Potion of Strength +",
-          "Lingering Potion of Extended Strength",
-          "Lingering Potion of Lengthened Strength",
-          "Extended Strength Lingering Potion",
-          "Lingering Extended Strength Potion",
-          "Extended Lingering Strength Potion",
-          "Lengthened Strength Lingering Potion",
-          "Lingering Lengthened Strength Potion",
-          "Lengthened Lingering Strength Potion",
-          "Strength Lingering Potion Extended",
-          "Lingering Strength Potion Extended",
-          "Strength Lingering Potion Lengthened",
-          "Lingering Strength Potion Lengthened"
-        ],
-        "display_name": "Lingering Potion of Strength (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Strength",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.strength.ii": {
-    "lang": {
-      "en_US": {
-        "lore": "Strength II (0:23)",
-        "search_names": [
-          "Enhanced Lingering Potion of Strength",
-          "Lingering Enhanced Potion of Strength",
-          "Amplified Lingering Potion of Strength",
-          "Lingering Amplified Potion of Strength",
-          "Lingering Potion of Strength II",
-          "Lingering Potion of Strength 2",
-          "Lingering Potion of Strength Enhanced",
-          "Lingering Potion of Strength Amplified",
-          "Lingering Potion of Enhanced Strength",
-          "Lingering Potion of Amplified Strength",
-          "Enhanced Strength Lingering Potion",
-          "Lingering Enhanced Strength Potion",
-          "Enhanced Lingering Strength Potion",
-          "Amplified Strength Lingering Potion",
-          "Lingering Amplified Strength Potion",
-          "Amplified Lingering Strength Potion",
-          "Strength Lingering Potion II",
-          "Strength Lingering Potion 2",
-          "Lingering Strength Potion II",
-          "Lingering Strength Potion 2",
-          "Strength Lingering Potion Enhanced",
-          "Lingering Strength Potion Enhanced",
-          "Strength Lingering Potion Amplified",
-          "Lingering Strength Potion Amplified"
-        ],
-        "display_name": "Lingering Potion of Strength (enhanced)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Strength",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.swiftness": {
-    "lang": {
-      "en_US": {
-        "lore": "Speed (0:45)",
-        "search_names": [
-          "Lingering Potion of Speed",
-          "Speed Lingering Potion",
-          "Lingering Speed Potion",
-          "Swiftness Lingering Potion",
-          "Lingering Swiftness Potion"
-        ],
-        "display_name": "Lingering Potion of Swiftness"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.swiftness.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Speed (2:00)",
-        "search_names": [
-          "Extended Lingering Potion of Swiftness",
-          "Lingering Extended Potion of Swiftness",
-          "Lengthened Lingering Potion of Swiftness",
-          "Lingering Lengthened Potion of Swiftness",
-          "Lingering Potion of Swiftness Extended",
-          "Lingering Potion of Swiftness Lengthened",
-          "Lingering Potion of Swiftness+",
-          "Lingering Potion of Swiftness +",
-          "Lingering Potion of Extended Swiftness",
-          "Lingering Potion of Lengthened Swiftness",
-          "Extended Swiftness Lingering Potion",
-          "Lingering Extended Swiftness Potion",
-          "Extended Lingering Swiftness Potion",
-          "Lengthened Swiftness Lingering Potion",
-          "Lingering Lengthened Swiftness Potion",
-          "Lengthened Lingering Swiftness Potion",
-          "Swiftness Lingering Potion Extended",
-          "Lingering Swiftness Potion Extended",
-          "Swiftness Lingering Potion Lengthened",
-          "Lingering Swiftness Potion Lengthened",
-          "Extended Lingering Potion of Speed",
-          "Lingering Extended Potion of Speed",
-          "Lengthened Lingering Potion of Speed",
-          "Lingering Lengthened Potion of Speed",
-          "Lingering Potion of Speed Extended",
-          "Lingering Potion of Speed Lengthened",
-          "Lingering Potion of Speed+",
-          "Lingering Potion of Speed +",
-          "Lingering Potion of Extended Speed",
-          "Lingering Potion of Lengthened Speed",
-          "Extended Speed Lingering Potion",
-          "Lingering Extended Speed Potion",
-          "Extended Lingering Speed Potion",
-          "Lengthened Speed Lingering Potion",
-          "Lingering Lengthened Speed Potion",
-          "Lengthened Lingering Speed Potion",
-          "Speed Lingering Potion Extended",
-          "Lingering Speed Potion Extended",
-          "Speed Lingering Potion Lengthened",
-          "Lingering Speed Potion Lengthened"
-        ],
-        "display_name": "Lingering Potion of Swiftness (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Swiftness",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.swiftness.ii": {
-    "lang": {
-      "en_US": {
-        "lore": "Speed II (0:22)",
-        "search_names": [
-          "Enhanced Lingering Potion of Swiftness",
-          "Lingering Enhanced Potion of Swiftness",
-          "Amplified Lingering Potion of Swiftness",
-          "Lingering Amplified Potion of Swiftness",
-          "Lingering Potion of Swiftness II",
-          "Lingering Potion of Swiftness 2",
-          "Lingering Potion of Swiftness Enhanced",
-          "Lingering Potion of Swiftness Amplified",
-          "Lingering Potion of Enhanced Swiftness",
-          "Lingering Potion of Amplified Swiftness",
-          "Enhanced Swiftness Lingering Potion",
-          "Lingering Enhanced Swiftness Potion",
-          "Enhanced Lingering Swiftness Potion",
-          "Amplified Swiftness Lingering Potion",
-          "Lingering Amplified Swiftness Potion",
-          "Amplified Lingering Swiftness Potion",
-          "Swiftness Lingering Potion II",
-          "Swiftness Lingering Potion 2",
-          "Lingering Swiftness Potion II",
-          "Lingering Swiftness Potion 2",
-          "Swiftness Lingering Potion Enhanced",
-          "Lingering Swiftness Potion Enhanced",
-          "Swiftness Lingering Potion Amplified",
-          "Lingering Swiftness Potion Amplified",
-          "Enhanced Lingering Potion of Speed",
-          "Lingering Enhanced Potion of Speed",
-          "Amplified Lingering Potion of Speed",
-          "Lingering Amplified Potion of Speed",
-          "Lingering Potion of Speed II",
-          "Lingering Potion of Speed 2",
-          "Lingering Potion of Speed Enhanced",
-          "Lingering Potion of Speed Amplified",
-          "Lingering Potion of Enhanced Speed",
-          "Lingering Potion of Amplified Speed",
-          "Enhanced Speed Lingering Potion",
-          "Lingering Enhanced Speed Potion",
-          "Enhanced Lingering Speed Potion",
-          "Amplified Speed Lingering Potion",
-          "Lingering Amplified Speed Potion",
-          "Amplified Lingering Speed Potion",
-          "Speed Lingering Potion II",
-          "Speed Lingering Potion 2",
-          "Lingering Speed Potion II",
-          "Lingering Speed Potion 2",
-          "Speed Lingering Potion Enhanced",
-          "Lingering Speed Potion Enhanced",
-          "Speed Lingering Potion Amplified",
-          "Lingering Speed Potion Amplified"
-        ],
-        "display_name": "Lingering Potion of Swiftness (enhanced)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Swiftness",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   },
   "minecraft.lingering_potion.effect.thick": {
@@ -22785,266 +21963,6 @@
       "id": 441
     }
   },
-  "minecraft.lingering_potion.effect.turtle_master": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness IV (0:05)\nResistance III (0:05)",
-        "search_names": [
-          "Turtle Master Lingering Potion",
-          "Lingering Turtle Master Potion",
-          "Turtle Lingering Potion",
-          "Lingering Turtle Potion"
-        ],
-        "display_name": "Lingering Potion of the Turtle Master"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.lingering_potion.effect.turtle_master.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness IV (0:10)\nResistance III (0:10)",
-        "search_names": [
-          "Extended Lingering Potion of the Turtle Master",
-          "Lingering Extended Potion of the Turtle Master",
-          "Lengthened Lingering Potion of the Turtle Master",
-          "Lingering Lengthened Potion of the Turtle Master",
-          "Lingering Potion of the Turtle Master Extended",
-          "Lingering Potion of the Turtle Master Lengthened",
-          "Lingering Potion of the Turtle Master+",
-          "Lingering Potion of the Turtle Master +",
-          "Extended Turtle Master Lingering Potion",
-          "Lingering Extended Turtle Master Potion",
-          "Extended Lingering Turtle Master Potion",
-          "Lengthened Turtle Master Lingering Potion",
-          "Lingering Lengthened Turtle Master Potion",
-          "Lengthened Lingering Turtle Master Potion",
-          "Turtle Master Lingering Potion Extended",
-          "Lingering Turtle Master Potion Extended",
-          "Turtle Master Lingering Potion Lengthened",
-          "Lingering Turtle Master Potion Lengthened",
-          "Extended Turtle Lingering Potion",
-          "Lingering Extended Turtle Potion",
-          "Extended Lingering Turtle Potion",
-          "Lengthened Turtle Lingering Potion",
-          "Lingering Lengthened Turtle Potion",
-          "Lengthened Lingering Turtle Potion",
-          "Turtle Lingering Potion Extended",
-          "Lingering Turtle Potion Extended",
-          "Turtle Lingering Potion Lengthened",
-          "Lingering Turtle Potion Lengthened"
-        ],
-        "display_name": "Lingering Potion of the Turtle Master (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of the Turtle Master",
-      "actual_id": "minecraft.lingering_potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.lingering_potion.effect.turtle_master.ii": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness VI (0:05)\nResistance IV (0:05)",
-        "search_names": [
-          "Enhanced Lingering Potion of the Turtle Master",
-          "Lingering Enhanced Potion of the Turtle Master",
-          "Amplified Lingering Potion of the Turtle Master",
-          "Lingering Amplified Potion of the Turtle Master",
-          "Lingering Potion of the Turtle Master II",
-          "Lingering Potion of the Turtle Master 2",
-          "Lingering Potion of the Turtle Master Enhanced",
-          "Lingering Potion of the Turtle Master Amplified",
-          "Enhanced Turtle Master Lingering Potion",
-          "Lingering Enhanced Turtle Master Potion",
-          "Enhanced Lingering Turtle Master Potion",
-          "Amplified Turtle Master Lingering Potion",
-          "Lingering Amplified Turtle Master Potion",
-          "Amplified Lingering Turtle Master Potion",
-          "Turtle Master Lingering Potion II",
-          "Turtle Master Lingering Potion 2",
-          "Lingering Turtle Master Potion II",
-          "Lingering Turtle Master Potion 2",
-          "Turtle Master Lingering Potion Enhanced",
-          "Lingering Turtle Master Potion Enhanced",
-          "Turtle Master Lingering Potion Amplified",
-          "Lingering Turtle Master Potion Amplified",
-          "Enhanced Turtle Lingering Potion",
-          "Lingering Enhanced Turtle Potion",
-          "Enhanced Lingering Turtle Potion",
-          "Amplified Turtle Lingering Potion",
-          "Lingering Amplified Turtle Potion",
-          "Amplified Lingering Turtle Potion",
-          "Turtle Lingering Potion II",
-          "Turtle Lingering Potion 2",
-          "Lingering Turtle Potion II",
-          "Lingering Turtle Potion 2",
-          "Turtle Lingering Potion Enhanced",
-          "Lingering Turtle Potion Enhanced",
-          "Turtle Lingering Potion Amplified",
-          "Lingering Turtle Potion Amplified"
-        ],
-        "display_name": "Lingering Potion of the Turtle Master (enhanced)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of the Turtle Master",
-      "actual_id": "minecraft.lingering_potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.lingering_potion.effect.water": {
-    "lang": {
-      "en_US": {
-        "lore": "No effects",
-        "search_names": [
-          "Water Lingering Potion",
-          "Lingering Water Potion",
-          "Lingering Potion of Water",
-          "Lingering Bottle of Water"
-        ],
-        "display_name": "Lingering Water Bottle"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.water_breathing": {
-    "lang": {
-      "en_US": {
-        "lore": "Water Breathing (0:45)",
-        "search_names": [
-          "Water Breathing Lingering Potion",
-          "Lingering Water Breathing Potion",
-          "Breathing Lingering Potion",
-          "Lingering Breathing Potion",
-          "Lingering Potion of Breathing"
-        ],
-        "display_name": "Lingering Potion of Water Breathing"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.water_breathing.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Water Breathing (2:00)",
-        "search_names": [
-          "Extended Lingering Potion of Water Breathing",
-          "Lingering Extended Potion of Water Breathing",
-          "Lengthened Lingering Potion of Water Breathing",
-          "Lingering Lengthened Potion of Water Breathing",
-          "Lingering Potion of Water Breathing Extended",
-          "Lingering Potion of Water Breathing Lengthened",
-          "Lingering Potion of Water Breathing+",
-          "Lingering Potion of Water Breathing +",
-          "Lingering Potion of Extended Water Breathing",
-          "Lingering Potion of Lengthened Water Breathing",
-          "Extended Water Breathing Lingering Potion",
-          "Lingering Extended Water Breathing Potion",
-          "Extended Lingering Water Breathing Potion",
-          "Lengthened Water Breathing Lingering Potion",
-          "Lingering Lengthened Water Breathing Potion",
-          "Lengthened Lingering Water Breathing Potion",
-          "Water Breathing Lingering Potion Extended",
-          "Lingering Water Breathing Potion Extended",
-          "Water Breathing Lingering Potion Lengthened",
-          "Lingering Water Breathing Potion Lengthened",
-          "Extended Lingering Potion of Breathing",
-          "Lingering Extended Potion of Breathing",
-          "Lengthened Lingering Potion of Breathing",
-          "Lingering Lengthened Potion of Breathing",
-          "Lingering Potion of Breathing Extended",
-          "Lingering Potion of Breathing Lengthened",
-          "Lingering Potion of Breathing+",
-          "Lingering Potion of Breathing +",
-          "Lingering Potion of Extended Breathing",
-          "Lingering Potion of Lengthened Breathing",
-          "Extended Breathing Lingering Potion",
-          "Lingering Extended Breathing Potion",
-          "Extended Lingering Breathing Potion",
-          "Lengthened Breathing Lingering Potion",
-          "Lingering Lengthened Breathing Potion",
-          "Lengthened Lingering Breathing Potion",
-          "Breathing Lingering Potion Extended",
-          "Lingering Breathing Potion Extended",
-          "Breathing Lingering Potion Lengthened",
-          "Lingering Breathing Potion Lengthened"
-        ],
-        "display_name": "Lingering Potion of Water Breathing (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Water Breathing",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.weakness": {
-    "lang": {
-      "en_US": {
-        "lore": "Weakness (0:22)",
-        "search_names": [
-          "Weakness Lingering Potion",
-          "Lingering Weakness Potion"
-        ],
-        "display_name": "Lingering Potion of Weakness"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
-  "minecraft.lingering_potion.effect.weakness.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Weakness (1:00)",
-        "search_names": [
-          "Extended Lingering Potion of Weakness",
-          "Lingering Extended Potion of Weakness",
-          "Lengthened Lingering Potion of Weakness",
-          "Lingering Lengthened Potion of Weakness",
-          "Lingering Potion of Weakness Extended",
-          "Lingering Potion of Weakness Lengthened",
-          "Lingering Potion of Weakness+",
-          "Lingering Potion of Weakness +",
-          "Lingering Potion of Extended Weakness",
-          "Lingering Potion of Lengthened Weakness",
-          "Extended Weakness Lingering Potion",
-          "Lingering Extended Weakness Potion",
-          "Extended Lingering Weakness Potion",
-          "Lengthened Weakness Lingering Potion",
-          "Lingering Lengthened Weakness Potion",
-          "Lengthened Lingering Weakness Potion",
-          "Weakness Lingering Potion Extended",
-          "Lingering Weakness Potion Extended",
-          "Weakness Lingering Potion Lengthened",
-          "Lingering Weakness Potion Lengthened"
-        ],
-        "display_name": "Lingering Potion of Weakness (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Lingering Potion of Weakness",
-      "actual_id": "minecraft.lingering_potion",
-      "id": 441,
-      "version": "1.9"
-    }
-  },
   "minecraft.potion.effect.awkward": {
     "lang": {
       "en_US": {
@@ -23057,18 +21975,6 @@
       "image_key": "Water Bottle",
       "actual_id": "minecraft.potion",
       "id": 373
-    }
-  },
-  "minecraft.potion.effect.empty": {
-    "lang": {
-      "en_US": {
-        "lore": "No effects",
-        "display_name": "Uncraftable Potion"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.potion",
-      "version": "1.9"
     }
   },
   "minecraft.potion.effect.fire_resistance": {
@@ -23286,126 +22192,6 @@
       "image_key": "Potion of Invisibility",
       "actual_id": "minecraft.potion",
       "id": 373
-    }
-  },
-  "minecraft.potion.effect.leaping": {
-    "lang": {
-      "en_US": {
-        "lore": "Jump Boost (3:00)",
-        "search_names": [
-          "Leaping Potion",
-          "Jump Boost Potion",
-          "Potion of Jump Boost"
-        ],
-        "display_name": "Potion of Leaping"
-      }
-    },
-    "properties": {
-      "data": 8203,
-      "actual_id": "minecraft.potion",
-      "id": 373,
-      "version": "1.8"
-    }
-  },
-  "minecraft.potion.effect.leaping.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Jump Boost (8:00)",
-        "search_names": [
-          "Extended Potion of Leaping",
-          "Lengthened Potion of Leaping",
-          "Potion of Leaping Extended",
-          "Potion of Leaping Lengthened",
-          "Potion of Leaping+",
-          "Potion of Leaping +",
-          "Potion of Extended Leaping",
-          "Potion of Lengthened Leaping",
-          "Extended Leaping Potion",
-          "Lengthened Leaping Potion",
-          "Leaping Potion Extended",
-          "Leaping Potion Lengthened",
-          "Extended Potion of Jump Boost",
-          "Lengthened Potion of Jump Boost",
-          "Potion of Jump Boost Extended",
-          "Potion of Jump Boost Lengthened",
-          "Potion of Jump Boost+",
-          "Potion of Jump Boost +",
-          "Potion of Extended Jump Boost",
-          "Potion of Lengthened Jump Boost",
-          "Extended Jump Boost Potion",
-          "Lengthened Jump Boost Potion",
-          "Jump Boost Potion Extended",
-          "Jump Boost Potion Lengthened"
-        ],
-        "display_name": "Potion of Leaping (extended)"
-      }
-    },
-    "properties": {
-      "data": 8267,
-      "image_key": "Potion of Leaping",
-      "actual_id": "minecraft.potion",
-      "id": 373,
-      "version": "1.8"
-    }
-  },
-  "minecraft.potion.effect.leaping.ii": {
-    "lang": {
-      "en_US": {
-        "lore": "Jump Boost II (1:30)",
-        "search_names": [
-          "Enhanced Potion of Leaping",
-          "Amplified Potion of Leaping",
-          "Potion of Leaping II",
-          "Potion of Leaping 2",
-          "Potion of Leaping Enhanced",
-          "Potion of Leaping Amplified",
-          "Potion of Enhanced Leaping",
-          "Potion of Amplified Leaping",
-          "Enhanced Leaping Potion",
-          "Amplified Leaping Potion",
-          "Leaping Potion II",
-          "Leaping Potion 2",
-          "Leaping Potion Enhanced",
-          "Leaping Potion Amplified",
-          "Enhanced Potion of Jump Boost",
-          "Amplified Potion of Jump Boost",
-          "Potion of Jump Boost II",
-          "Potion of Jump Boost 2",
-          "Potion of Jump Boost Enhanced",
-          "Potion of Jump Boost Amplified",
-          "Potion of Enhanced Jump Boost",
-          "Potion of Amplified Jump Boost",
-          "Enhanced Jump Boost Potion",
-          "Amplified Jump Boost Potion",
-          "Jump Boost Potion II",
-          "Jump Boost Potion 2",
-          "Jump Boost Potion Enhanced",
-          "Jump Boost Potion Amplified"
-        ],
-        "display_name": "Potion of Leaping (enhanced)"
-      }
-    },
-    "properties": {
-      "data": 8235,
-      "image_key": "Potion of Leaping",
-      "actual_id": "minecraft.potion",
-      "id": 373,
-      "version": "1.8"
-    }
-  },
-  "minecraft.potion.effect.luck": {
-    "lang": {
-      "en_US": {
-        "lore": "Luck (5:00",
-        "search_names": [
-          "Luck Potion"
-        ],
-        "display_name": "Potion of Luck"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.potion",
-      "version": "1.9"
     }
   },
   "minecraft.potion.effect.mundane": {
@@ -23662,48 +22448,6 @@
       "id": 373
     }
   },
-  "minecraft.potion.effect.slow_falling": {
-    "lang": {
-      "en_US": {
-        "lore": "Slow Falling (1:30)",
-        "search_names": [
-          "Slow Falling Potion"
-        ],
-        "display_name": "Potion of Slow Falling"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.potion.effect.slow_falling.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Slow Falling (4:00)",
-        "search_names": [
-          "Extended Potion of Slow Falling",
-          "Lengthened Potion of Slow Falling",
-          "Potion of Slow Falling Extended",
-          "Potion of Slow Falling Lengthened",
-          "Potion of Slow Falling+",
-          "Potion of Slow Falling +",
-          "Potion of Extended Slow Falling",
-          "Potion of Lengthened Slow Falling",
-          "Extended Slow Falling Potion",
-          "Lengthened Slow Falling Potion",
-          "Slow Falling Potion Extended",
-          "Slow Falling Potion Lengthened"
-        ],
-        "display_name": "Potion of Slow Falling (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Potion of Slow Falling",
-      "actual_id": "minecraft.potion",
-      "version": "1.13"
-    }
-  },
   "minecraft.potion.effect.slowness": {
     "lang": {
       "en_US": {
@@ -23746,35 +22490,6 @@
       "image_key": "Potion of Slowness",
       "actual_id": "minecraft.potion",
       "id": 373
-    }
-  },
-  "minecraft.potion.effect.slowness.iv": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness IV (0:20)",
-        "search_names": [
-          "Enhanced Potion of Slowness",
-          "Amplified Potion of Slowness",
-          "Potion of Slowness IV",
-          "Potion of Slowness 4",
-          "Potion of Slowness Enhanced",
-          "Potion of Slowness Amplified",
-          "Potion of Enhanced Slowness",
-          "Potion of Amplified Slowness",
-          "Enhanced Slowness Potion",
-          "Amplified Slowness Potion",
-          "Slowness Potion IV",
-          "Slowness Potion 4",
-          "Slowness Potion Enhanced",
-          "Slowness Potion Amplified"
-        ],
-        "display_name": "Potion of Slowness (enhanced)"
-      }
-    },
-    "properties": {
-      "image_key": "Potion of Slowness",
-      "actual_id": "minecraft.potion",
-      "version": "1.13"
     }
   },
   "minecraft.potion.effect.strength": {
@@ -23970,84 +22685,6 @@
       "id": 373
     }
   },
-  "minecraft.potion.effect.turtle_master": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness IV (0:20)\nResistance III (0:20)",
-        "search_names": [
-          "Turtle Master Potion",
-          "Turtle Potion"
-        ],
-        "display_name": "Potion of the Turtle Master"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.potion.effect.turtle_master.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness IV (0:40)\nResistance III (0:40)",
-        "search_names": [
-          "Extended Potion of the Turtle Master",
-          "Lengthened Potion of the Turtle Master",
-          "Potion of the Turtle Master Extended",
-          "Potion of the Turtle Master Lengthened",
-          "Potion of the Turtle Master+",
-          "Potion of the Turtle Master +",
-          "Extended Turtle Master Potion",
-          "Lengthened Turtle Master Potion",
-          "Turtle Master Potion Extended",
-          "Turtle Master Potion Lengthened",
-          "Extended Turtle Potion",
-          "Lengthened Turtle Potion",
-          "Turtle Potion Extended",
-          "Turtle Potion Lengthened"
-        ],
-        "display_name": "Potion of the Turtle Master (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Potion of the Turtle Master",
-      "actual_id": "minecraft.potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.potion.effect.turtle_master.ii": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness VI (0:20)\nResistance IV (0:20)",
-        "search_names": [
-          "Enhanced Potion of the Turtle Master",
-          "Amplified Potion of the Turtle Master",
-          "Potion of the Turtle Master II",
-          "Potion of the Turtle Master 2",
-          "Potion of the Turtle Master Enhanced",
-          "Potion of the Turtle Master Amplified",
-          "Enhanced Turtle Master Potion",
-          "Amplified Turtle Master Potion",
-          "Turtle Master Potion II",
-          "Turtle Master Potion 2",
-          "Turtle Master Potion Enhanced",
-          "Turtle Master Potion Amplified",
-          "Enhanced Turtle Potion",
-          "Amplified Turtle Potion",
-          "Turtle Potion II",
-          "Turtle Potion 2",
-          "Turtle Potion Enhanced",
-          "Turtle Potion Amplified"
-        ],
-        "display_name": "Potion of the Turtle Master (enhanced)"
-      }
-    },
-    "properties": {
-      "image_key": "Potion of the Turtle Master",
-      "actual_id": "minecraft.potion",
-      "version": "1.13"
-    }
-  },
   "minecraft.potion.effect.water": {
     "lang": {
       "en_US": {
@@ -24168,33 +22805,6 @@
       "id": 373
     }
   },
-  "minecraft.splash_potion.effect.awkward": {
-    "lang": {
-      "en_US": {
-        "lore": "No effects",
-        "display_name": "Awkward Splash Potion"
-      }
-    },
-    "properties": {
-      "image_key": "Splash Water Bottle",
-      "actual_id": "minecraft.splash_potion",
-      "id": 438,
-      "version": "1.9"
-    }
-  },
-  "minecraft.splash_potion.effect.empty": {
-    "lang": {
-      "en_US": {
-        "lore": "No effects",
-        "display_name": "Splash Uncraftable Potion"
-      }
-    },
-    "properties": {
-      "image_key": "Uncraftable Splash Potion",
-      "actual_id": "minecraft.splash_potion",
-      "version": "1.9"
-    }
-  },
   "minecraft.splash_potion.effect.fire_resistance": {
     "lang": {
       "en_US": {
@@ -24296,8 +22906,8 @@
           "Splash Amplified Harming Potion",
           "Amplified Splash Harming Potion",
           "Harming Splash Potion II",
-          "Harming Splash Potion 2",
           "Splash Harming Potion II",
+          "Harming Splash Potion 2",
           "Splash Harming Potion 2",
           "Harming Splash Potion Enhanced",
           "Splash Harming Potion Enhanced",
@@ -24320,8 +22930,8 @@
           "Splash Amplified Instant Damage Potion",
           "Amplified Splash Instant Damage Potion",
           "Instant Damage Splash Potion II",
-          "Instant Damage Splash Potion 2",
           "Splash Instant Damage Potion II",
+          "Instant Damage Splash Potion 2",
           "Splash Instant Damage Potion 2",
           "Instant Damage Splash Potion Enhanced",
           "Splash Instant Damage Potion Enhanced",
@@ -24384,8 +22994,8 @@
           "Splash Amplified Healing Potion",
           "Amplified Splash Healing Potion",
           "Healing Splash Potion II",
-          "Healing Splash Potion 2",
           "Splash Healing Potion II",
+          "Healing Splash Potion 2",
           "Splash Healing Potion 2",
           "Healing Splash Potion Enhanced",
           "Splash Healing Potion Enhanced",
@@ -24408,8 +23018,8 @@
           "Splash Amplified Instant Health Potion",
           "Amplified Splash Instant Health Potion",
           "Instant Health Splash Potion II",
-          "Instant Health Splash Potion 2",
           "Splash Instant Health Potion II",
+          "Instant Health Splash Potion 2",
           "Splash Instant Health Potion 2",
           "Instant Health Splash Potion Enhanced",
           "Splash Instant Health Potion Enhanced",
@@ -24495,211 +23105,6 @@
       "actual_id": "minecraft.splash_potion",
       "id": 438,
       "conflict": true
-    }
-  },
-  "minecraft.splash_potion.effect.leaping": {
-    "lang": {
-      "en_US": {
-        "lore": "Jump Boost (3:00)",
-        "search_names": [
-          "Leaping Splash Potion",
-          "Splash Leaping Potion",
-          "Jump Boost Splash Potion",
-          "Splash Jump Boost Potion",
-          "Splash Potion of Jump Boost"
-        ],
-        "display_name": "Splash Potion of Leaping"
-      }
-    },
-    "properties": {
-      "data": 16395,
-      "previous_id": "minecraft.potion",
-      "actual_id": "minecraft.splash_potion",
-      "id": 438,
-      "version": "1.8",
-      "conflict": true
-    }
-  },
-  "minecraft.splash_potion.effect.leaping.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Jump Boost (8:00)",
-        "search_names": [
-          "Extended Splash Potion of Leaping",
-          "Splash Extended Potion of Leaping",
-          "Lengthened Splash Potion of Leaping",
-          "Splash Lengthened Potion of Leaping",
-          "Splash Potion of Leaping Extended",
-          "Splash Potion of Leaping Lengthened",
-          "Splash Potion of Leaping+",
-          "Splash Potion of Leaping +",
-          "Splash Potion of Extended Leaping",
-          "Splash Potion of Lengthened Leaping",
-          "Extended Leaping Splash Potion",
-          "Splash Extended Leaping Potion",
-          "Extended Splash Leaping Potion",
-          "Lengthened Leaping Splash Potion",
-          "Splash Lengthened Leaping Potion",
-          "Lengthened Splash Leaping Potion",
-          "Leaping Splash Potion Extended",
-          "Splash Leaping Potion Extended",
-          "Leaping Splash Potion Lengthened",
-          "Splash Leaping Potion Lengthened",
-          "Extended Splash Potion of Jump Boost",
-          "Splash Extended Potion of Jump Boost",
-          "Lengthened Splash Potion of Jump Boost",
-          "Splash Lengthened Potion of Jump Boost",
-          "Splash Potion of Jump Boost Extended",
-          "Splash Potion of Jump Boost Lengthened",
-          "Splash Potion of Jump Boost+",
-          "Splash Potion of Jump Boost +",
-          "Splash Potion of Extended Jump Boost",
-          "Splash Potion of Lengthened Jump Boost",
-          "Extended Jump Boost Splash Potion",
-          "Splash Extended Jump Boost Potion",
-          "Extended Splash Jump Boost Potion",
-          "Lengthened Jump Boost Splash Potion",
-          "Splash Lengthened Jump Boost Potion",
-          "Lengthened Splash Jump Boost Potion",
-          "Jump Boost Splash Potion Extended",
-          "Splash Jump Boost Potion Extended",
-          "Jump Boost Splash Potion Lengthened",
-          "Splash Jump Boost Potion Lengthened"
-        ],
-        "display_name": "Splash Potion of Leaping (extended)"
-      }
-    },
-    "properties": {
-      "data": 16459,
-      "image_key": "Splash Potion of Leaping",
-      "previous_id": "minecraft.potion",
-      "actual_id": "minecraft.splash_potion",
-      "id": 438,
-      "version": "1.8",
-      "conflict": true
-    }
-  },
-  "minecraft.splash_potion.effect.leaping.ii": {
-    "lang": {
-      "en_US": {
-        "lore": "Jump Boost II (1:30)",
-        "search_names": [
-          "Enhanced Splash Potion of Leaping",
-          "Splash Enhanced Potion of Leaping",
-          "Amplified Splash Potion of Leaping",
-          "Splash Amplified Potion of Leaping",
-          "Splash Potion of Leaping II",
-          "Splash Potion of Leaping 2",
-          "Splash Potion of Leaping Enhanced",
-          "Splash Potion of Leaping Amplified",
-          "Splash Potion of Enhanced Leaping",
-          "Splash Potion of Amplified Leaping",
-          "Enhanced Leaping Splash Potion",
-          "Splash Enhanced Leaping Potion",
-          "Enhanced Splash Leaping Potion",
-          "Amplified Leaping Splash Potion",
-          "Splash Amplified Leaping Potion",
-          "Amplified Splash Leaping Potion",
-          "Leaping Splash Potion II",
-          "Leaping Splash Potion 2",
-          "Splash Leaping Potion II",
-          "Splash Leaping Potion 2",
-          "Leaping Splash Potion Enhanced",
-          "Splash Leaping Potion Enhanced",
-          "Leaping Splash Potion Amplified",
-          "Splash Leaping Potion Amplified",
-          "Enhanced Splash Potion of Jump Boost",
-          "Splash Enhanced Potion of Jump Boost",
-          "Amplified Splash Potion of Jump Boost",
-          "Splash Amplified Potion of Jump Boost",
-          "Splash Potion of Jump Boost II",
-          "Splash Potion of Jump Boost 2",
-          "Splash Potion of Jump Boost Enhanced",
-          "Splash Potion of Jump Boost Amplified",
-          "Splash Potion of Enhanced Jump Boost",
-          "Splash Potion of Amplified Jump Boost",
-          "Enhanced Jump Boost Splash Potion",
-          "Splash Enhanced Jump Boost Potion",
-          "Enhanced Splash Jump Boost Potion",
-          "Amplified Jump Boost Splash Potion",
-          "Splash Amplified Jump Boost Potion",
-          "Amplified Splash Jump Boost Potion",
-          "Jump Boost Splash Potion II",
-          "Jump Boost Splash Potion 2",
-          "Splash Jump Boost Potion II",
-          "Splash Jump Boost Potion 2",
-          "Jump Boost Splash Potion Enhanced",
-          "Splash Jump Boost Potion Enhanced",
-          "Jump Boost Splash Potion Amplified",
-          "Splash Jump Boost Potion Amplified"
-        ],
-        "display_name": "Splash Potion of Leaping (enhanced)"
-      }
-    },
-    "properties": {
-      "data": 16427,
-      "image_key": "Splash Potion of Leaping",
-      "previous_id": "minecraft.potion",
-      "actual_id": "minecraft.splash_potion",
-      "id": 438,
-      "version": "1.8",
-      "conflict": true
-    }
-  },
-  "minecraft.splash_potion.effect.luck": {
-    "lang": {
-      "en_US": {
-        "lore": "Luck (5:00",
-        "search_names": [
-          "Luck Splash Potion",
-          "Splash Luck Potion"
-        ],
-        "display_name": "Splash Potion of Luck"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.splash_potion",
-      "version": "1.9"
-    }
-  },
-  "minecraft.splash_potion.effect.mundane": {
-    "lang": {
-      "en_US": {
-        "lore": "No effects",
-        "display_name": "Mundane Splash Potion"
-      }
-    },
-    "properties": {
-      "image_key": "Splash Water Bottle",
-      "actual_id": "minecraft.splash_potion",
-      "id": 438,
-      "version": "1.9"
-    }
-  },
-  "minecraft.splash_potion.effect.mundane.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "No effects",
-        "search_names": [
-          "Extended Mundane Splash Potion",
-          "Splash Extended Mundane Potion",
-          "Extended Splash Mundane Potion",
-          "Lengthened Mundane Splash Potion",
-          "Splash Lengthened Mundane Potion",
-          "Lengthened Splash Mundane Potion",
-          "Mundane Splash Potion Extended",
-          "Splash Mundane Potion Extended",
-          "Mundane Splash Potion Lengthened",
-          "Splash Mundane Potion Lengthened"
-        ],
-        "display_name": "Mundane Splash Potion (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Splash Water Bottle",
-      "actual_id": "minecraft.splash_potion",
-      "id": 438,
-      "version": "1.9"
     }
   },
   "minecraft.splash_potion.effect.night_vision": {
@@ -24838,8 +23243,8 @@
           "Splash Amplified Poison Potion",
           "Amplified Splash Poison Potion",
           "Poison Splash Potion II",
-          "Poison Splash Potion 2",
           "Splash Poison Potion II",
+          "Poison Splash Potion 2",
           "Splash Poison Potion 2",
           "Poison Splash Potion Enhanced",
           "Splash Poison Potion Enhanced",
@@ -24960,8 +23365,8 @@
           "Splash Amplified Regeneration Potion",
           "Amplified Splash Regeneration Potion",
           "Regeneration Splash Potion II",
-          "Regeneration Splash Potion 2",
           "Splash Regeneration Potion II",
+          "Regeneration Splash Potion 2",
           "Splash Regeneration Potion 2",
           "Regeneration Splash Potion Enhanced",
           "Splash Regeneration Potion Enhanced",
@@ -24984,8 +23389,8 @@
           "Splash Amplified Regen Potion",
           "Amplified Splash Regen Potion",
           "Regen Splash Potion II",
-          "Regen Splash Potion 2",
           "Splash Regen Potion II",
+          "Regen Splash Potion 2",
           "Splash Regen Potion 2",
           "Regen Splash Potion Enhanced",
           "Splash Regen Potion Enhanced",
@@ -25002,57 +23407,6 @@
       "actual_id": "minecraft.splash_potion",
       "id": 438,
       "conflict": true
-    }
-  },
-  "minecraft.splash_potion.effect.slow_falling": {
-    "lang": {
-      "en_US": {
-        "lore": "Slow Falling (1:30)",
-        "search_names": [
-          "Slow Falling Splash Potion",
-          "Splash Slow Falling Potion"
-        ],
-        "display_name": "Splash Potion of Slow Falling"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.splash_potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.splash_potion.effect.slow_falling.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Slow Falling (4:00)",
-        "search_names": [
-          "Extended Splash Potion of Slow Falling",
-          "Splash Extended Potion of Slow Falling",
-          "Lengthened Splash Potion of Slow Falling",
-          "Splash Lengthened Potion of Slow Falling",
-          "Splash Potion of Slow Falling Extended",
-          "Splash Potion of Slow Falling Lengthened",
-          "Splash Potion of Slow Falling+",
-          "Splash Potion of Slow Falling +",
-          "Splash Potion of Extended Slow Falling",
-          "Splash Potion of Lengthened Slow Falling",
-          "Extended Slow Falling Splash Potion",
-          "Splash Extended Slow Falling Potion",
-          "Extended Splash Slow Falling Potion",
-          "Lengthened Slow Falling Splash Potion",
-          "Splash Lengthened Slow Falling Potion",
-          "Lengthened Splash Slow Falling Potion",
-          "Slow Falling Splash Potion Extended",
-          "Splash Slow Falling Potion Extended",
-          "Slow Falling Splash Potion Lengthened",
-          "Splash Slow Falling Potion Lengthened"
-        ],
-        "display_name": "Splash Potion of Slow Falling (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Splash Potion of Slow Falling",
-      "actual_id": "minecraft.splash_potion",
-      "version": "1.13"
     }
   },
   "minecraft.splash_potion.effect.slowness": {
@@ -25110,43 +23464,6 @@
       "actual_id": "minecraft.splash_potion",
       "id": 438,
       "conflict": true
-    }
-  },
-  "minecraft.splash_potion.effect.slowness.iv": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness IV (0:20)",
-        "search_names": [
-          "Enhanced Splash Potion of Slowness",
-          "Splash Enhanced Potion of Slowness",
-          "Amplified Splash Potion of Slowness",
-          "Splash Amplified Potion of Slowness",
-          "Splash Potion of Slowness IV",
-          "Splash Potion of Slowness 4",
-          "Splash Potion of Slowness Enhanced",
-          "Splash Potion of Slowness Amplified",
-          "Splash Potion of Enhanced Slowness",
-          "Splash Potion of Amplified Slowness",
-          "Enhanced Slowness Splash Potion",
-          "Splash Enhanced Slowness Potion",
-          "Amplified Slowness Splash Potion",
-          "Splash Amplified Slowness Potion",
-          "Slowness Splash Potion IV",
-          "Slowness Splash Potion 4",
-          "Splash Slowness Potion IV",
-          "Splash Slowness Potion 4",
-          "Slowness Splash Potion Enhanced",
-          "Splash Slowness Potion Enhanced",
-          "Slowness Splash Potion Amplified",
-          "Splash Slowness Potion Amplified"
-        ],
-        "display_name": "Splash Potion of Slowness (enhanced)"
-      }
-    },
-    "properties": {
-      "image_key": "Splash Potion of Slowness",
-      "actual_id": "minecraft.splash_potion",
-      "version": "1.13"
     }
   },
   "minecraft.splash_potion.effect.strength": {
@@ -25228,8 +23545,8 @@
           "Splash Amplified Strength Potion",
           "Amplified Splash Strength Potion",
           "Strength Splash Potion II",
-          "Strength Splash Potion 2",
           "Splash Strength Potion II",
+          "Strength Splash Potion 2",
           "Splash Strength Potion 2",
           "Strength Splash Potion Enhanced",
           "Splash Strength Potion Enhanced",
@@ -25350,8 +23667,8 @@
           "Splash Amplified Swiftness Potion",
           "Amplified Splash Swiftness Potion",
           "Swiftness Splash Potion II",
-          "Swiftness Splash Potion 2",
           "Splash Swiftness Potion II",
+          "Swiftness Splash Potion 2",
           "Splash Swiftness Potion 2",
           "Swiftness Splash Potion Enhanced",
           "Splash Swiftness Potion Enhanced",
@@ -25374,8 +23691,8 @@
           "Splash Amplified Speed Potion",
           "Amplified Splash Speed Potion",
           "Speed Splash Potion II",
-          "Speed Splash Potion 2",
           "Splash Speed Potion II",
+          "Speed Splash Potion 2",
           "Splash Speed Potion 2",
           "Speed Splash Potion Enhanced",
           "Splash Speed Potion Enhanced",
@@ -25392,156 +23709,6 @@
       "actual_id": "minecraft.splash_potion",
       "id": 438,
       "conflict": true
-    }
-  },
-  "minecraft.splash_potion.effect.thick": {
-    "lang": {
-      "en_US": {
-        "lore": "No effects",
-        "search_names": [
-          "Thicc Splash Potion",
-          "Splash Thicc Potion"
-        ],
-        "display_name": "Thick Splash Potion"
-      }
-    },
-    "properties": {
-      "image_key": "Splash Water Bottle",
-      "actual_id": "minecraft.splash_potion",
-      "id": 438,
-      "version": "1.9"
-    }
-  },
-  "minecraft.splash_potion.effect.turtle_master": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness IV (0:20)\nResistance III (0:20)",
-        "search_names": [
-          "Turtle Master Splash Potion",
-          "Splash Turtle Master Potion",
-          "Turtle Splash Potion",
-          "Splash Turtle Potion"
-        ],
-        "display_name": "Splash Potion of the Turtle Master"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.splash_potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.splash_potion.effect.turtle_master.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness IV (0:40)\nResistance III (0:40)",
-        "search_names": [
-          "Extended Splash Potion of the Turtle Master",
-          "Splash Extended Potion of the Turtle Master",
-          "Lengthened Splash Potion of the Turtle Master",
-          "Splash Lengthened Potion of the Turtle Master",
-          "Splash Potion of the Turtle Master Extended",
-          "Splash Potion of the Turtle Master Lengthened",
-          "Splash Potion of the Turtle Master+",
-          "Splash Potion of the Turtle Master +",
-          "Extended Turtle Master Splash Potion",
-          "Splash Extended Turtle Master Potion",
-          "Extended Splash Turtle Master Potion",
-          "Lengthened Turtle Master Splash Potion",
-          "Splash Lengthened Turtle Master Potion",
-          "Lengthened Splash Turtle Master Potion",
-          "Turtle Master Splash Potion Extended",
-          "Splash Turtle Master Potion Extended",
-          "Turtle Master Splash Potion Lengthened",
-          "Splash Turtle Master Potion Lengthened",
-          "Extended Turtle Splash Potion",
-          "Splash Extended Turtle Potion",
-          "Extended Splash Turtle Potion",
-          "Lengthened Turtle Splash Potion",
-          "Splash Lengthened Turtle Potion",
-          "Lengthened Splash Turtle Potion",
-          "Turtle Splash Potion Extended",
-          "Splash Turtle Potion Extended",
-          "Turtle Splash Potion Lengthened",
-          "Splash Turtle Potion Lengthened"
-        ],
-        "display_name": "Splash Potion of the Turtle Master (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Splash Potion of the Turtle Master",
-      "actual_id": "minecraft.splash_potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.splash_potion.effect.turtle_master.ii": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness VI (0:20)\nResistance IV (0:20)",
-        "search_names": [
-          "Enhanced Splash Potion of the Turtle Master",
-          "Splash Enhanced Potion of the Turtle Master",
-          "Amplified Splash Potion of the Turtle Master",
-          "Splash Amplified Potion of the Turtle Master",
-          "Splash Potion of the Turtle Master II",
-          "Splash Potion of the Turtle Master 2",
-          "Splash Potion of the Turtle Master Enhanced",
-          "Splash Potion of the Turtle Master Amplified",
-          "Enhanced Turtle Master Splash Potion",
-          "Splash Enhanced Turtle Master Potion",
-          "Enhanced Splash Turtle Master Potion",
-          "Amplified Turtle Master Splash Potion",
-          "Splash Amplified Turtle Master Potion",
-          "Amplified Splash Turtle Master Potion",
-          "Turtle Master Splash Potion II",
-          "Turtle Master Splash Potion 2",
-          "Splash Turtle Master Potion II",
-          "Splash Turtle Master Potion 2",
-          "Turtle Master Splash Potion Enhanced",
-          "Splash Turtle Master Potion Enhanced",
-          "Turtle Master Splash Potion Amplified",
-          "Splash Turtle Master Potion Amplified",
-          "Enhanced Turtle Splash Potion",
-          "Splash Enhanced Turtle Potion",
-          "Enhanced Splash Turtle Potion",
-          "Amplified Turtle Splash Potion",
-          "Splash Amplified Turtle Potion",
-          "Amplified Splash Turtle Potion",
-          "Turtle Splash Potion II",
-          "Turtle Splash Potion 2",
-          "Splash Turtle Potion II",
-          "Splash Turtle Potion 2",
-          "Turtle Splash Potion Enhanced",
-          "Splash Turtle Potion Enhanced",
-          "Turtle Splash Potion Amplified",
-          "Splash Turtle Potion Amplified"
-        ],
-        "display_name": "Splash Potion of the Turtle Master (enhanced)"
-      }
-    },
-    "properties": {
-      "image_key": "Splash Potion of the Turtle Master",
-      "actual_id": "minecraft.splash_potion",
-      "version": "1.13"
-    }
-  },
-  "minecraft.splash_potion.effect.water": {
-    "lang": {
-      "en_US": {
-        "lore": "No effects",
-        "search_names": [
-          "Water Splash Potion",
-          "Splash Water Potion",
-          "Splash Potion of Water",
-          "Splash Potion of Splashing",
-          "Splash Bottle of Water"
-        ],
-        "display_name": "Splash Water Bottle"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.splash_potion",
-      "id": 438,
-      "version": "1.9"
     }
   },
   "minecraft.splash_potion.effect.water_breathing": {
@@ -25681,6 +23848,1668 @@
       "conflict": true
     }
   },
+  "minecraft.tipped_arrow.effect.thick": {
+    "lang": {
+      "en_US": {
+        "distinct_display_name": "Thick Tipped Arrow",
+        "lore": "No effects",
+        "search_names": [
+          "Thicc Tipped Arrow",
+          "Thicc Arrow",
+          "Tipped Thicc Arrow",
+          "Thick Arrow",
+          "Tipped Thick Arrow"
+        ],
+        "display_name": "Tipped Arrow",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Arrow of Splashing",
+      "actual_id": "minecraft.tipped_arrow",
+      "id": 440
+    }
+  },
+  "minecraft.potion.effect.leaping": {
+    "lang": {
+      "en_US": {
+        "lore": "Jump Boost (3:00)",
+        "search_names": [
+          "Leaping Potion",
+          "Jump Boost Potion",
+          "Potion of Jump Boost"
+        ],
+        "display_name": "Potion of Leaping"
+      }
+    },
+    "properties": {
+      "data": 8203,
+      "actual_id": "minecraft.potion",
+      "id": 373,
+      "version": "1.8"
+    }
+  },
+  "minecraft.potion.effect.leaping.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Jump Boost (8:00)",
+        "search_names": [
+          "Extended Potion of Leaping",
+          "Lengthened Potion of Leaping",
+          "Potion of Leaping Extended",
+          "Potion of Leaping Lengthened",
+          "Potion of Leaping+",
+          "Potion of Leaping +",
+          "Potion of Extended Leaping",
+          "Potion of Lengthened Leaping",
+          "Extended Leaping Potion",
+          "Lengthened Leaping Potion",
+          "Leaping Potion Extended",
+          "Leaping Potion Lengthened",
+          "Extended Potion of Jump Boost",
+          "Lengthened Potion of Jump Boost",
+          "Potion of Jump Boost Extended",
+          "Potion of Jump Boost Lengthened",
+          "Potion of Jump Boost+",
+          "Potion of Jump Boost +",
+          "Potion of Extended Jump Boost",
+          "Potion of Lengthened Jump Boost",
+          "Extended Jump Boost Potion",
+          "Lengthened Jump Boost Potion",
+          "Jump Boost Potion Extended",
+          "Jump Boost Potion Lengthened"
+        ],
+        "display_name": "Potion of Leaping (extended)"
+      }
+    },
+    "properties": {
+      "data": 8267,
+      "image_key": "Potion of Leaping",
+      "actual_id": "minecraft.potion",
+      "id": 373,
+      "version": "1.8"
+    }
+  },
+  "minecraft.potion.effect.leaping.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Jump Boost II (1:30)",
+        "search_names": [
+          "Enhanced Potion of Leaping",
+          "Amplified Potion of Leaping",
+          "Potion of Leaping II",
+          "Potion of Leaping 2",
+          "Potion of Leaping Enhanced",
+          "Potion of Leaping Amplified",
+          "Potion of Enhanced Leaping",
+          "Potion of Amplified Leaping",
+          "Enhanced Leaping Potion",
+          "Amplified Leaping Potion",
+          "Leaping Potion II",
+          "Leaping Potion 2",
+          "Leaping Potion Enhanced",
+          "Leaping Potion Amplified",
+          "Enhanced Potion of Jump Boost",
+          "Amplified Potion of Jump Boost",
+          "Potion of Jump Boost II",
+          "Potion of Jump Boost 2",
+          "Potion of Jump Boost Enhanced",
+          "Potion of Jump Boost Amplified",
+          "Potion of Enhanced Jump Boost",
+          "Potion of Amplified Jump Boost",
+          "Enhanced Jump Boost Potion",
+          "Amplified Jump Boost Potion",
+          "Jump Boost Potion II",
+          "Jump Boost Potion 2",
+          "Jump Boost Potion Enhanced",
+          "Jump Boost Potion Amplified"
+        ],
+        "display_name": "Potion of Leaping (enhanced)"
+      }
+    },
+    "properties": {
+      "data": 8235,
+      "image_key": "Potion of Leaping",
+      "actual_id": "minecraft.potion",
+      "id": 373,
+      "version": "1.8"
+    }
+  },
+  "minecraft.splash_potion.effect.leaping": {
+    "lang": {
+      "en_US": {
+        "lore": "Jump Boost (3:00)",
+        "search_names": [
+          "Leaping Splash Potion",
+          "Splash Leaping Potion",
+          "Jump Boost Splash Potion",
+          "Splash Jump Boost Potion",
+          "Splash Potion of Jump Boost"
+        ],
+        "display_name": "Splash Potion of Leaping"
+      }
+    },
+    "properties": {
+      "data": 16395,
+      "previous_id": "minecraft.potion",
+      "actual_id": "minecraft.splash_potion",
+      "id": 438,
+      "version": "1.8",
+      "conflict": true
+    }
+  },
+  "minecraft.splash_potion.effect.leaping.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Jump Boost (8:00)",
+        "search_names": [
+          "Extended Splash Potion of Leaping",
+          "Splash Extended Potion of Leaping",
+          "Lengthened Splash Potion of Leaping",
+          "Splash Lengthened Potion of Leaping",
+          "Splash Potion of Leaping Extended",
+          "Splash Potion of Leaping Lengthened",
+          "Splash Potion of Leaping+",
+          "Splash Potion of Leaping +",
+          "Splash Potion of Extended Leaping",
+          "Splash Potion of Lengthened Leaping",
+          "Extended Leaping Splash Potion",
+          "Splash Extended Leaping Potion",
+          "Extended Splash Leaping Potion",
+          "Lengthened Leaping Splash Potion",
+          "Splash Lengthened Leaping Potion",
+          "Lengthened Splash Leaping Potion",
+          "Leaping Splash Potion Extended",
+          "Splash Leaping Potion Extended",
+          "Leaping Splash Potion Lengthened",
+          "Splash Leaping Potion Lengthened",
+          "Extended Splash Potion of Jump Boost",
+          "Splash Extended Potion of Jump Boost",
+          "Lengthened Splash Potion of Jump Boost",
+          "Splash Lengthened Potion of Jump Boost",
+          "Splash Potion of Jump Boost Extended",
+          "Splash Potion of Jump Boost Lengthened",
+          "Splash Potion of Jump Boost+",
+          "Splash Potion of Jump Boost +",
+          "Splash Potion of Extended Jump Boost",
+          "Splash Potion of Lengthened Jump Boost",
+          "Extended Jump Boost Splash Potion",
+          "Splash Extended Jump Boost Potion",
+          "Extended Splash Jump Boost Potion",
+          "Lengthened Jump Boost Splash Potion",
+          "Splash Lengthened Jump Boost Potion",
+          "Lengthened Splash Jump Boost Potion",
+          "Jump Boost Splash Potion Extended",
+          "Splash Jump Boost Potion Extended",
+          "Jump Boost Splash Potion Lengthened",
+          "Splash Jump Boost Potion Lengthened"
+        ],
+        "display_name": "Splash Potion of Leaping (extended)"
+      }
+    },
+    "properties": {
+      "data": 16459,
+      "image_key": "Splash Potion of Leaping",
+      "previous_id": "minecraft.potion",
+      "actual_id": "minecraft.splash_potion",
+      "id": 438,
+      "version": "1.8",
+      "conflict": true
+    }
+  },
+  "minecraft.splash_potion.effect.leaping.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Jump Boost II (1:30)",
+        "search_names": [
+          "Enhanced Splash Potion of Leaping",
+          "Splash Enhanced Potion of Leaping",
+          "Amplified Splash Potion of Leaping",
+          "Splash Amplified Potion of Leaping",
+          "Splash Potion of Leaping II",
+          "Splash Potion of Leaping 2",
+          "Splash Potion of Leaping Enhanced",
+          "Splash Potion of Leaping Amplified",
+          "Splash Potion of Enhanced Leaping",
+          "Splash Potion of Amplified Leaping",
+          "Enhanced Leaping Splash Potion",
+          "Splash Enhanced Leaping Potion",
+          "Enhanced Splash Leaping Potion",
+          "Amplified Leaping Splash Potion",
+          "Splash Amplified Leaping Potion",
+          "Amplified Splash Leaping Potion",
+          "Leaping Splash Potion II",
+          "Splash Leaping Potion II",
+          "Leaping Splash Potion 2",
+          "Splash Leaping Potion 2",
+          "Leaping Splash Potion Enhanced",
+          "Splash Leaping Potion Enhanced",
+          "Leaping Splash Potion Amplified",
+          "Splash Leaping Potion Amplified",
+          "Enhanced Splash Potion of Jump Boost",
+          "Splash Enhanced Potion of Jump Boost",
+          "Amplified Splash Potion of Jump Boost",
+          "Splash Amplified Potion of Jump Boost",
+          "Splash Potion of Jump Boost II",
+          "Splash Potion of Jump Boost 2",
+          "Splash Potion of Jump Boost Enhanced",
+          "Splash Potion of Jump Boost Amplified",
+          "Splash Potion of Enhanced Jump Boost",
+          "Splash Potion of Amplified Jump Boost",
+          "Enhanced Jump Boost Splash Potion",
+          "Splash Enhanced Jump Boost Potion",
+          "Enhanced Splash Jump Boost Potion",
+          "Amplified Jump Boost Splash Potion",
+          "Splash Amplified Jump Boost Potion",
+          "Amplified Splash Jump Boost Potion",
+          "Jump Boost Splash Potion II",
+          "Splash Jump Boost Potion II",
+          "Jump Boost Splash Potion 2",
+          "Splash Jump Boost Potion 2",
+          "Jump Boost Splash Potion Enhanced",
+          "Splash Jump Boost Potion Enhanced",
+          "Jump Boost Splash Potion Amplified",
+          "Splash Jump Boost Potion Amplified"
+        ],
+        "display_name": "Splash Potion of Leaping (enhanced)"
+      }
+    },
+    "properties": {
+      "data": 16427,
+      "image_key": "Splash Potion of Leaping",
+      "previous_id": "minecraft.potion",
+      "actual_id": "minecraft.splash_potion",
+      "id": 438,
+      "version": "1.8",
+      "conflict": true
+    }
+  },
+  "minecraft.lingering_potion.effect.awkward": {
+    "lang": {
+      "en_US": {
+        "lore": "No effects",
+        "search_names": [
+          "Lingering Awkward Potion"
+        ],
+        "display_name": "Awkward Lingering Potion"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Water Bottle",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.empty": {
+    "lang": {
+      "en_US": {
+        "lore": "No effects",
+        "search_names": [
+          "Uncraftable Lingering Potion"
+        ],
+        "display_name": "Lingering Uncraftable Potion"
+      }
+    },
+    "properties": {
+      "image_key": "Uncraftable Lingering Potion",
+      "actual_id": "minecraft.lingering_potion",
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.fire_resistance": {
+    "lang": {
+      "en_US": {
+        "lore": "Fire Resistance (0:45)",
+        "search_names": [
+          "Fire Resistance Lingering Potion",
+          "Lingering Fire Resistance Potion"
+        ],
+        "display_name": "Lingering Potion of Fire Resistance"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.fire_resistance.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Fire Resistance (2:00)",
+        "search_names": [
+          "Extended Lingering Potion of Fire Resistance",
+          "Lingering Extended Potion of Fire Resistance",
+          "Lengthened Lingering Potion of Fire Resistance",
+          "Lingering Lengthened Potion of Fire Resistance",
+          "Lingering Potion of Fire Resistance Extended",
+          "Lingering Potion of Fire Resistance Lengthened",
+          "Lingering Potion of Fire Resistance+",
+          "Lingering Potion of Fire Resistance +",
+          "Lingering Potion of Extended Fire Resistance",
+          "Lingering Potion of Lengthened Fire Resistance",
+          "Extended Fire Resistance Lingering Potion",
+          "Lingering Extended Fire Resistance Potion",
+          "Extended Lingering Fire Resistance Potion",
+          "Lengthened Fire Resistance Lingering Potion",
+          "Lingering Lengthened Fire Resistance Potion",
+          "Lengthened Lingering Fire Resistance Potion",
+          "Fire Resistance Lingering Potion Extended",
+          "Lingering Fire Resistance Potion Extended",
+          "Fire Resistance Lingering Potion Lengthened",
+          "Lingering Fire Resistance Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of Fire Resistance (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Fire Resistance",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.harming": {
+    "lang": {
+      "en_US": {
+        "lore": "Instant Harming",
+        "search_names": [
+          "Harming Lingering Potion",
+          "Lingering Harming Potion",
+          "Instant Damage Lingering Potion",
+          "Lingering Instant Damage Potion",
+          "Lingering Potion of Instant Damage"
+        ],
+        "display_name": "Lingering Potion of Harming"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.harming.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Instant Harming II",
+        "search_names": [
+          "Enhanced Lingering Potion of Harming",
+          "Lingering Enhanced Potion of Harming",
+          "Amplified Lingering Potion of Harming",
+          "Lingering Amplified Potion of Harming",
+          "Lingering Potion of Harming II",
+          "Lingering Potion of Harming 2",
+          "Lingering Potion of Harming Enhanced",
+          "Lingering Potion of Harming Amplified",
+          "Lingering Potion of Enhanced Harming",
+          "Lingering Potion of Amplified Harming",
+          "Enhanced Harming Lingering Potion",
+          "Lingering Enhanced Harming Potion",
+          "Enhanced Lingering Harming Potion",
+          "Amplified Harming Lingering Potion",
+          "Lingering Amplified Harming Potion",
+          "Amplified Lingering Harming Potion",
+          "Harming Lingering Potion II",
+          "Lingering Harming Potion II",
+          "Harming Lingering Potion 2",
+          "Lingering Harming Potion 2",
+          "Harming Lingering Potion Enhanced",
+          "Lingering Harming Potion Enhanced",
+          "Harming Lingering Potion Amplified",
+          "Lingering Harming Potion Amplified",
+          "Enhanced Lingering Potion of Instant Damage",
+          "Lingering Enhanced Potion of Instant Damage",
+          "Amplified Lingering Potion of Instant Damage",
+          "Lingering Amplified Potion of Instant Damage",
+          "Lingering Potion of Instant Damage II",
+          "Lingering Potion of Instant Damage 2",
+          "Lingering Potion of Instant Damage Enhanced",
+          "Lingering Potion of Instant Damage Amplified",
+          "Lingering Potion of Enhanced Instant Damage",
+          "Lingering Potion of Amplified Instant Damage",
+          "Enhanced Instant Damage Lingering Potion",
+          "Lingering Enhanced Instant Damage Potion",
+          "Enhanced Lingering Instant Damage Potion",
+          "Amplified Instant Damage Lingering Potion",
+          "Lingering Amplified Instant Damage Potion",
+          "Amplified Lingering Instant Damage Potion",
+          "Instant Damage Lingering Potion II",
+          "Lingering Instant Damage Potion II",
+          "Instant Damage Lingering Potion 2",
+          "Lingering Instant Damage Potion 2",
+          "Instant Damage Lingering Potion Enhanced",
+          "Lingering Instant Damage Potion Enhanced",
+          "Instant Damage Lingering Potion Amplified",
+          "Lingering Instant Damage Potion Amplified"
+        ],
+        "display_name": "Lingering Potion of Harming (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Harming",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.healing": {
+    "lang": {
+      "en_US": {
+        "lore": "Instant Health",
+        "search_names": [
+          "Healing Lingering Potion",
+          "Lingering Healing Potion",
+          "Instant Health Lingering Potion",
+          "Lingering Instant Health Potion",
+          "Lingering Potion of Instant Health"
+        ],
+        "display_name": "Lingering Potion of Healing"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.healing.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Instant Health II",
+        "search_names": [
+          "Enhanced Lingering Potion of Healing",
+          "Lingering Enhanced Potion of Healing",
+          "Amplified Lingering Potion of Healing",
+          "Lingering Amplified Potion of Healing",
+          "Lingering Potion of Healing II",
+          "Lingering Potion of Healing 2",
+          "Lingering Potion of Healing Enhanced",
+          "Lingering Potion of Healing Amplified",
+          "Lingering Potion of Enhanced Healing",
+          "Lingering Potion of Amplified Healing",
+          "Enhanced Healing Lingering Potion",
+          "Lingering Enhanced Healing Potion",
+          "Enhanced Lingering Healing Potion",
+          "Amplified Healing Lingering Potion",
+          "Lingering Amplified Healing Potion",
+          "Amplified Lingering Healing Potion",
+          "Healing Lingering Potion II",
+          "Lingering Healing Potion II",
+          "Healing Lingering Potion 2",
+          "Lingering Healing Potion 2",
+          "Healing Lingering Potion Enhanced",
+          "Lingering Healing Potion Enhanced",
+          "Healing Lingering Potion Amplified",
+          "Lingering Healing Potion Amplified",
+          "Enhanced Lingering Potion of Instant Health",
+          "Lingering Enhanced Potion of Instant Health",
+          "Amplified Lingering Potion of Instant Health",
+          "Lingering Amplified Potion of Instant Health",
+          "Lingering Potion of Instant Health II",
+          "Lingering Potion of Instant Health 2",
+          "Lingering Potion of Instant Health Enhanced",
+          "Lingering Potion of Instant Health Amplified",
+          "Lingering Potion of Enhanced Instant Health",
+          "Lingering Potion of Amplified Instant Health",
+          "Enhanced Instant Health Lingering Potion",
+          "Lingering Enhanced Instant Health Potion",
+          "Enhanced Lingering Instant Health Potion",
+          "Amplified Instant Health Lingering Potion",
+          "Lingering Amplified Instant Health Potion",
+          "Amplified Lingering Instant Health Potion",
+          "Instant Health Lingering Potion II",
+          "Lingering Instant Health Potion II",
+          "Instant Health Lingering Potion 2",
+          "Lingering Instant Health Potion 2",
+          "Instant Health Lingering Potion Enhanced",
+          "Lingering Instant Health Potion Enhanced",
+          "Instant Health Lingering Potion Amplified",
+          "Lingering Instant Health Potion Amplified"
+        ],
+        "display_name": "Lingering Potion of Healing (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Healing",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.invisibility": {
+    "lang": {
+      "en_US": {
+        "lore": "Invisibility (0:45)",
+        "search_names": [
+          "Invisibility Lingering Potion",
+          "Lingering Invisibility Potion",
+          "Invis Lingering Potion",
+          "Lingering Invis Potion"
+        ],
+        "display_name": "Lingering Potion of Invisibility"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.invisibility.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Invisibility (2:00)",
+        "search_names": [
+          "Extended Lingering Potion of Invisibility",
+          "Lingering Extended Potion of Invisibility",
+          "Lengthened Lingering Potion of Invisibility",
+          "Lingering Lengthened Potion of Invisibility",
+          "Lingering Potion of Invisibility Extended",
+          "Lingering Potion of Invisibility Lengthened",
+          "Lingering Potion of Invisibility+",
+          "Lingering Potion of Invisibility +",
+          "Lingering Potion of Extended Invisibility",
+          "Lingering Potion of Lengthened Invisibility",
+          "Extended Invisibility Lingering Potion",
+          "Lingering Extended Invisibility Potion",
+          "Extended Lingering Invisibility Potion",
+          "Lengthened Invisibility Lingering Potion",
+          "Lingering Lengthened Invisibility Potion",
+          "Lengthened Lingering Invisibility Potion",
+          "Invisibility Lingering Potion Extended",
+          "Lingering Invisibility Potion Extended",
+          "Invisibility Lingering Potion Lengthened",
+          "Lingering Invisibility Potion Lengthened",
+          "Extended Invis Lingering Potion",
+          "Lingering Extended Invis Potion",
+          "Extended Lingering Invis Potion",
+          "Lengthened Invis Lingering Potion",
+          "Lingering Lengthened Invis Potion",
+          "Lengthened Lingering Invis Potion",
+          "Invis Lingering Potion Extended",
+          "Lingering Invis Potion Extended",
+          "Invis Lingering Potion Lengthened",
+          "Lingering Invis Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of Invisibility (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Invisibility",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.leaping": {
+    "lang": {
+      "en_US": {
+        "lore": "Jump Boost (0:45)",
+        "search_names": [
+          "Leaping Lingering Potion",
+          "Lingering Leaping Potion",
+          "Jump Boost Lingering Potion",
+          "Lingering Jump Boost Potion",
+          "Lingering Potion of Jump Boost"
+        ],
+        "display_name": "Lingering Potion of Leaping"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.leaping.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Jump Boost (2:00)",
+        "search_names": [
+          "Extended Lingering Potion of Leaping",
+          "Lingering Extended Potion of Leaping",
+          "Lengthened Lingering Potion of Leaping",
+          "Lingering Lengthened Potion of Leaping",
+          "Lingering Potion of Leaping Extended",
+          "Lingering Potion of Leaping Lengthened",
+          "Lingering Potion of Leaping+",
+          "Lingering Potion of Leaping +",
+          "Lingering Potion of Extended Leaping",
+          "Lingering Potion of Lengthened Leaping",
+          "Extended Leaping Lingering Potion",
+          "Lingering Extended Leaping Potion",
+          "Extended Lingering Leaping Potion",
+          "Lengthened Leaping Lingering Potion",
+          "Lingering Lengthened Leaping Potion",
+          "Lengthened Lingering Leaping Potion",
+          "Leaping Lingering Potion Extended",
+          "Lingering Leaping Potion Extended",
+          "Leaping Lingering Potion Lengthened",
+          "Lingering Leaping Potion Lengthened",
+          "Extended Lingering Potion of Jump Boost",
+          "Lingering Extended Potion of Jump Boost",
+          "Lengthened Lingering Potion of Jump Boost",
+          "Lingering Lengthened Potion of Jump Boost",
+          "Lingering Potion of Jump Boost Extended",
+          "Lingering Potion of Jump Boost Lengthened",
+          "Lingering Potion of Jump Boost+",
+          "Lingering Potion of Jump Boost +",
+          "Lingering Potion of Extended Jump Boost",
+          "Lingering Potion of Lengthened Jump Boost",
+          "Extended Jump Boost Lingering Potion",
+          "Lingering Extended Jump Boost Potion",
+          "Extended Lingering Jump Boost Potion",
+          "Lengthened Jump Boost Lingering Potion",
+          "Lingering Lengthened Jump Boost Potion",
+          "Lengthened Lingering Jump Boost Potion",
+          "Jump Boost Lingering Potion Extended",
+          "Lingering Jump Boost Potion Extended",
+          "Jump Boost Lingering Potion Lengthened",
+          "Lingering Jump Boost Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of Leaping (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Leaping",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.leaping.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Jump Boost II (0:22)",
+        "search_names": [
+          "Enhanced Lingering Potion of Leaping",
+          "Lingering Enhanced Potion of Leaping",
+          "Amplified Lingering Potion of Leaping",
+          "Lingering Amplified Potion of Leaping",
+          "Lingering Potion of Leaping II",
+          "Lingering Potion of Leaping 2",
+          "Lingering Potion of Leaping Enhanced",
+          "Lingering Potion of Leaping Amplified",
+          "Lingering Potion of Enhanced Leaping",
+          "Lingering Potion of Amplified Leaping",
+          "Enhanced Leaping Lingering Potion",
+          "Lingering Enhanced Leaping Potion",
+          "Enhanced Lingering Leaping Potion",
+          "Amplified Leaping Lingering Potion",
+          "Lingering Amplified Leaping Potion",
+          "Amplified Lingering Leaping Potion",
+          "Leaping Lingering Potion II",
+          "Lingering Leaping Potion II",
+          "Leaping Lingering Potion 2",
+          "Lingering Leaping Potion 2",
+          "Leaping Lingering Potion Enhanced",
+          "Lingering Leaping Potion Enhanced",
+          "Leaping Lingering Potion Amplified",
+          "Lingering Leaping Potion Amplified",
+          "Enhanced Lingering Potion of Jump Boost",
+          "Lingering Enhanced Potion of Jump Boost",
+          "Amplified Lingering Potion of Jump Boost",
+          "Lingering Amplified Potion of Jump Boost",
+          "Lingering Potion of Jump Boost II",
+          "Lingering Potion of Jump Boost 2",
+          "Lingering Potion of Jump Boost Enhanced",
+          "Lingering Potion of Jump Boost Amplified",
+          "Lingering Potion of Enhanced Jump Boost",
+          "Lingering Potion of Amplified Jump Boost",
+          "Enhanced Jump Boost Lingering Potion",
+          "Lingering Enhanced Jump Boost Potion",
+          "Enhanced Lingering Jump Boost Potion",
+          "Amplified Jump Boost Lingering Potion",
+          "Lingering Amplified Jump Boost Potion",
+          "Amplified Lingering Jump Boost Potion",
+          "Jump Boost Lingering Potion II",
+          "Lingering Jump Boost Potion II",
+          "Jump Boost Lingering Potion 2",
+          "Lingering Jump Boost Potion 2",
+          "Jump Boost Lingering Potion Enhanced",
+          "Lingering Jump Boost Potion Enhanced",
+          "Jump Boost Lingering Potion Amplified",
+          "Lingering Jump Boost Potion Amplified"
+        ],
+        "display_name": "Lingering Potion of Leaping (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Leaping",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.luck": {
+    "lang": {
+      "en_US": {
+        "lore": "Luck (1:15)",
+        "search_names": [
+          "Luck Lingering Potion",
+          "Lingering Luck Potion"
+        ],
+        "display_name": "Lingering Potion of Luck"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.mundane": {
+    "lang": {
+      "en_US": {
+        "lore": "No effects",
+        "search_names": [
+          "Lingering Mundane Potion"
+        ],
+        "display_name": "Mundane Lingering Potion"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Water Bottle",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.mundane.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "No effects",
+        "search_names": [
+          "Extended Mundane Lingering Potion",
+          "Lingering Extended Mundane Potion",
+          "Extended Lingering Mundane Potion",
+          "Lengthened Mundane Lingering Potion",
+          "Lingering Lengthened Mundane Potion",
+          "Lengthened Lingering Mundane Potion",
+          "Mundane Lingering Potion Extended",
+          "Lingering Mundane Potion Extended",
+          "Mundane Lingering Potion Lengthened",
+          "Lingering Mundane Potion Lengthened"
+        ],
+        "display_name": "Mundane Lingering Potion (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Water Bottle",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.night_vision": {
+    "lang": {
+      "en_US": {
+        "lore": "Night Vision (0:45)",
+        "search_names": [
+          "Night Vision Lingering Potion",
+          "Lingering Night Vision Potion"
+        ],
+        "display_name": "Lingering Potion of Night Vision"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.night_vision.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Night Vision (2:00)",
+        "search_names": [
+          "Extended Lingering Potion of Night Vision",
+          "Lingering Extended Potion of Night Vision",
+          "Lengthened Lingering Potion of Night Vision",
+          "Lingering Lengthened Potion of Night Vision",
+          "Lingering Potion of Night Vision Extended",
+          "Lingering Potion of Night Vision Lengthened",
+          "Lingering Potion of Night Vision+",
+          "Lingering Potion of Night Vision +",
+          "Lingering Potion of Extended Night Vision",
+          "Lingering Potion of Lengthened Night Vision",
+          "Extended Night Vision Lingering Potion",
+          "Lingering Extended Night Vision Potion",
+          "Extended Lingering Night Vision Potion",
+          "Lengthened Night Vision Lingering Potion",
+          "Lingering Lengthened Night Vision Potion",
+          "Lengthened Lingering Night Vision Potion",
+          "Night Vision Lingering Potion Extended",
+          "Lingering Night Vision Potion Extended",
+          "Night Vision Lingering Potion Lengthened",
+          "Lingering Night Vision Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of Night Vision (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Night Vision",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.poison": {
+    "lang": {
+      "en_US": {
+        "lore": "Poison (0:11)",
+        "search_names": [
+          "Poison Lingering Potion",
+          "Lingering Poison Potion"
+        ],
+        "display_name": "Lingering Potion of Poison"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.poison.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Poison (0:22)",
+        "search_names": [
+          "Extended Lingering Potion of Poison",
+          "Lingering Extended Potion of Poison",
+          "Lengthened Lingering Potion of Poison",
+          "Lingering Lengthened Potion of Poison",
+          "Lingering Potion of Poison Extended",
+          "Lingering Potion of Poison Lengthened",
+          "Lingering Potion of Poison+",
+          "Lingering Potion of Poison +",
+          "Lingering Potion of Extended Poison",
+          "Lingering Potion of Lengthened Poison",
+          "Extended Poison Lingering Potion",
+          "Lingering Extended Poison Potion",
+          "Extended Lingering Poison Potion",
+          "Lengthened Poison Lingering Potion",
+          "Lingering Lengthened Poison Potion",
+          "Lengthened Lingering Poison Potion",
+          "Poison Lingering Potion Extended",
+          "Lingering Poison Potion Extended",
+          "Poison Lingering Potion Lengthened",
+          "Lingering Poison Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of Poison (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Poison",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.poison.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Poison II (0:05)",
+        "search_names": [
+          "Enhanced Lingering Potion of Poison",
+          "Lingering Enhanced Potion of Poison",
+          "Amplified Lingering Potion of Poison",
+          "Lingering Amplified Potion of Poison",
+          "Lingering Potion of Poison II",
+          "Lingering Potion of Poison 2",
+          "Lingering Potion of Poison Enhanced",
+          "Lingering Potion of Poison Amplified",
+          "Lingering Potion of Enhanced Poison",
+          "Lingering Potion of Amplified Poison",
+          "Enhanced Poison Lingering Potion",
+          "Lingering Enhanced Poison Potion",
+          "Enhanced Lingering Poison Potion",
+          "Amplified Poison Lingering Potion",
+          "Lingering Amplified Poison Potion",
+          "Amplified Lingering Poison Potion",
+          "Poison Lingering Potion II",
+          "Lingering Poison Potion II",
+          "Poison Lingering Potion 2",
+          "Lingering Poison Potion 2",
+          "Poison Lingering Potion Enhanced",
+          "Lingering Poison Potion Enhanced",
+          "Poison Lingering Potion Amplified",
+          "Lingering Poison Potion Amplified"
+        ],
+        "display_name": "Lingering Potion of Poison (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Poison",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.regeneration": {
+    "lang": {
+      "en_US": {
+        "lore": "Regeneration (0:11)",
+        "search_names": [
+          "Regeneration Lingering Potion",
+          "Lingering Regeneration Potion",
+          "Regen Lingering Potion",
+          "Lingering Regen Potion",
+          "Lingering Potion of Regen"
+        ],
+        "display_name": "Lingering Potion of Regeneration"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.regeneration.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Regeneration (0:22)",
+        "search_names": [
+          "Extended Lingering Potion of Regeneration",
+          "Lingering Extended Potion of Regeneration",
+          "Lengthened Lingering Potion of Regeneration",
+          "Lingering Lengthened Potion of Regeneration",
+          "Lingering Potion of Regeneration Extended",
+          "Lingering Potion of Regeneration Lengthened",
+          "Lingering Potion of Regeneration+",
+          "Lingering Potion of Regeneration +",
+          "Lingering Potion of Extended Regeneration",
+          "Lingering Potion of Lengthened Regeneration",
+          "Extended Regeneration Lingering Potion",
+          "Lingering Extended Regeneration Potion",
+          "Extended Lingering Regeneration Potion",
+          "Lengthened Regeneration Lingering Potion",
+          "Lingering Lengthened Regeneration Potion",
+          "Lengthened Lingering Regeneration Potion",
+          "Regeneration Lingering Potion Extended",
+          "Lingering Regeneration Potion Extended",
+          "Regeneration Lingering Potion Lengthened",
+          "Lingering Regeneration Potion Lengthened",
+          "Extended Lingering Potion of Regen",
+          "Lingering Extended Potion of Regen",
+          "Lengthened Lingering Potion of Regen",
+          "Lingering Lengthened Potion of Regen",
+          "Lingering Potion of Regen Extended",
+          "Lingering Potion of Regen Lengthened",
+          "Lingering Potion of Regen+",
+          "Lingering Potion of Regen +",
+          "Lingering Potion of Extended Regen",
+          "Lingering Potion of Lengthened Regen",
+          "Extended Regen Lingering Potion",
+          "Lingering Extended Regen Potion",
+          "Extended Lingering Regen Potion",
+          "Lengthened Regen Lingering Potion",
+          "Lingering Lengthened Regen Potion",
+          "Lengthened Lingering Regen Potion",
+          "Regen Lingering Potion Extended",
+          "Lingering Regen Potion Extended",
+          "Regen Lingering Potion Lengthened",
+          "Lingering Regen Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of Regeneration (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Regeneration",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.regeneration.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Regeneration II (0:05)",
+        "search_names": [
+          "Enhanced Lingering Potion of Regeneration",
+          "Lingering Enhanced Potion of Regeneration",
+          "Amplified Lingering Potion of Regeneration",
+          "Lingering Amplified Potion of Regeneration",
+          "Lingering Potion of Regeneration II",
+          "Lingering Potion of Regeneration 2",
+          "Lingering Potion of Regeneration Enhanced",
+          "Lingering Potion of Regeneration Amplified",
+          "Lingering Potion of Enhanced Regeneration",
+          "Lingering Potion of Amplified Regeneration",
+          "Enhanced Regeneration Lingering Potion",
+          "Lingering Enhanced Regeneration Potion",
+          "Enhanced Lingering Regeneration Potion",
+          "Amplified Regeneration Lingering Potion",
+          "Lingering Amplified Regeneration Potion",
+          "Amplified Lingering Regeneration Potion",
+          "Regeneration Lingering Potion II",
+          "Lingering Regeneration Potion II",
+          "Regeneration Lingering Potion 2",
+          "Lingering Regeneration Potion 2",
+          "Regeneration Lingering Potion Enhanced",
+          "Lingering Regeneration Potion Enhanced",
+          "Regeneration Lingering Potion Amplified",
+          "Lingering Regeneration Potion Amplified",
+          "Enhanced Lingering Potion of Regen",
+          "Lingering Enhanced Potion of Regen",
+          "Amplified Lingering Potion of Regen",
+          "Lingering Amplified Potion of Regen",
+          "Lingering Potion of Regen II",
+          "Lingering Potion of Regen 2",
+          "Lingering Potion of Regen Enhanced",
+          "Lingering Potion of Regen Amplified",
+          "Lingering Potion of Enhanced Regen",
+          "Lingering Potion of Amplified Regen",
+          "Enhanced Regen Lingering Potion",
+          "Lingering Enhanced Regen Potion",
+          "Enhanced Lingering Regen Potion",
+          "Amplified Regen Lingering Potion",
+          "Lingering Amplified Regen Potion",
+          "Amplified Lingering Regen Potion",
+          "Regen Lingering Potion II",
+          "Lingering Regen Potion II",
+          "Regen Lingering Potion 2",
+          "Lingering Regen Potion 2",
+          "Regen Lingering Potion Enhanced",
+          "Lingering Regen Potion Enhanced",
+          "Regen Lingering Potion Amplified",
+          "Lingering Regen Potion Amplified"
+        ],
+        "display_name": "Lingering Potion of Regeneration (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Regeneration",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.slowness": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness (0:22)",
+        "search_names": [
+          "Slowness Lingering Potion",
+          "Lingering Slowness Potion"
+        ],
+        "display_name": "Lingering Potion of Slowness"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.slowness.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness (1:00)",
+        "search_names": [
+          "Extended Lingering Potion of Slowness",
+          "Lingering Extended Potion of Slowness",
+          "Lengthened Lingering Potion of Slowness",
+          "Lingering Lengthened Potion of Slowness",
+          "Lingering Potion of Slowness Extended",
+          "Lingering Potion of Slowness Lengthened",
+          "Lingering Potion of Slowness+",
+          "Lingering Potion of Slowness +",
+          "Lingering Potion of Extended Slowness",
+          "Lingering Potion of Lengthened Slowness",
+          "Extended Slowness Lingering Potion",
+          "Lingering Extended Slowness Potion",
+          "Extended Lingering Slowness Potion",
+          "Lengthened Slowness Lingering Potion",
+          "Lingering Lengthened Slowness Potion",
+          "Lengthened Lingering Slowness Potion",
+          "Slowness Lingering Potion Extended",
+          "Lingering Slowness Potion Extended",
+          "Slowness Lingering Potion Lengthened",
+          "Lingering Slowness Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of Slowness (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Slowness",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.strength": {
+    "lang": {
+      "en_US": {
+        "lore": "Strength (0:45)",
+        "search_names": [
+          "Strength Lingering Potion",
+          "Lingering Strength Potion"
+        ],
+        "display_name": "Lingering Potion of Strength"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.strength.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Strength (2:00)",
+        "search_names": [
+          "Extended Lingering Potion of Strength",
+          "Lingering Extended Potion of Strength",
+          "Lengthened Lingering Potion of Strength",
+          "Lingering Lengthened Potion of Strength",
+          "Lingering Potion of Strength Extended",
+          "Lingering Potion of Strength Lengthened",
+          "Lingering Potion of Strength+",
+          "Lingering Potion of Strength +",
+          "Lingering Potion of Extended Strength",
+          "Lingering Potion of Lengthened Strength",
+          "Extended Strength Lingering Potion",
+          "Lingering Extended Strength Potion",
+          "Extended Lingering Strength Potion",
+          "Lengthened Strength Lingering Potion",
+          "Lingering Lengthened Strength Potion",
+          "Lengthened Lingering Strength Potion",
+          "Strength Lingering Potion Extended",
+          "Lingering Strength Potion Extended",
+          "Strength Lingering Potion Lengthened",
+          "Lingering Strength Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of Strength (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Strength",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.strength.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Strength II (0:23)",
+        "search_names": [
+          "Enhanced Lingering Potion of Strength",
+          "Lingering Enhanced Potion of Strength",
+          "Amplified Lingering Potion of Strength",
+          "Lingering Amplified Potion of Strength",
+          "Lingering Potion of Strength II",
+          "Lingering Potion of Strength 2",
+          "Lingering Potion of Strength Enhanced",
+          "Lingering Potion of Strength Amplified",
+          "Lingering Potion of Enhanced Strength",
+          "Lingering Potion of Amplified Strength",
+          "Enhanced Strength Lingering Potion",
+          "Lingering Enhanced Strength Potion",
+          "Enhanced Lingering Strength Potion",
+          "Amplified Strength Lingering Potion",
+          "Lingering Amplified Strength Potion",
+          "Amplified Lingering Strength Potion",
+          "Strength Lingering Potion II",
+          "Lingering Strength Potion II",
+          "Strength Lingering Potion 2",
+          "Lingering Strength Potion 2",
+          "Strength Lingering Potion Enhanced",
+          "Lingering Strength Potion Enhanced",
+          "Strength Lingering Potion Amplified",
+          "Lingering Strength Potion Amplified"
+        ],
+        "display_name": "Lingering Potion of Strength (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Strength",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.swiftness": {
+    "lang": {
+      "en_US": {
+        "lore": "Speed (0:45)",
+        "search_names": [
+          "Lingering Potion of Speed",
+          "Speed Lingering Potion",
+          "Lingering Speed Potion",
+          "Swiftness Lingering Potion",
+          "Lingering Swiftness Potion"
+        ],
+        "display_name": "Lingering Potion of Swiftness"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.swiftness.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Speed (2:00)",
+        "search_names": [
+          "Extended Lingering Potion of Swiftness",
+          "Lingering Extended Potion of Swiftness",
+          "Lengthened Lingering Potion of Swiftness",
+          "Lingering Lengthened Potion of Swiftness",
+          "Lingering Potion of Swiftness Extended",
+          "Lingering Potion of Swiftness Lengthened",
+          "Lingering Potion of Swiftness+",
+          "Lingering Potion of Swiftness +",
+          "Lingering Potion of Extended Swiftness",
+          "Lingering Potion of Lengthened Swiftness",
+          "Extended Swiftness Lingering Potion",
+          "Lingering Extended Swiftness Potion",
+          "Extended Lingering Swiftness Potion",
+          "Lengthened Swiftness Lingering Potion",
+          "Lingering Lengthened Swiftness Potion",
+          "Lengthened Lingering Swiftness Potion",
+          "Swiftness Lingering Potion Extended",
+          "Lingering Swiftness Potion Extended",
+          "Swiftness Lingering Potion Lengthened",
+          "Lingering Swiftness Potion Lengthened",
+          "Extended Lingering Potion of Speed",
+          "Lingering Extended Potion of Speed",
+          "Lengthened Lingering Potion of Speed",
+          "Lingering Lengthened Potion of Speed",
+          "Lingering Potion of Speed Extended",
+          "Lingering Potion of Speed Lengthened",
+          "Lingering Potion of Speed+",
+          "Lingering Potion of Speed +",
+          "Lingering Potion of Extended Speed",
+          "Lingering Potion of Lengthened Speed",
+          "Extended Speed Lingering Potion",
+          "Lingering Extended Speed Potion",
+          "Extended Lingering Speed Potion",
+          "Lengthened Speed Lingering Potion",
+          "Lingering Lengthened Speed Potion",
+          "Lengthened Lingering Speed Potion",
+          "Speed Lingering Potion Extended",
+          "Lingering Speed Potion Extended",
+          "Speed Lingering Potion Lengthened",
+          "Lingering Speed Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of Swiftness (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Swiftness",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.swiftness.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Speed II (0:22)",
+        "search_names": [
+          "Enhanced Lingering Potion of Swiftness",
+          "Lingering Enhanced Potion of Swiftness",
+          "Amplified Lingering Potion of Swiftness",
+          "Lingering Amplified Potion of Swiftness",
+          "Lingering Potion of Swiftness II",
+          "Lingering Potion of Swiftness 2",
+          "Lingering Potion of Swiftness Enhanced",
+          "Lingering Potion of Swiftness Amplified",
+          "Lingering Potion of Enhanced Swiftness",
+          "Lingering Potion of Amplified Swiftness",
+          "Enhanced Swiftness Lingering Potion",
+          "Lingering Enhanced Swiftness Potion",
+          "Enhanced Lingering Swiftness Potion",
+          "Amplified Swiftness Lingering Potion",
+          "Lingering Amplified Swiftness Potion",
+          "Amplified Lingering Swiftness Potion",
+          "Swiftness Lingering Potion II",
+          "Lingering Swiftness Potion II",
+          "Swiftness Lingering Potion 2",
+          "Lingering Swiftness Potion 2",
+          "Swiftness Lingering Potion Enhanced",
+          "Lingering Swiftness Potion Enhanced",
+          "Swiftness Lingering Potion Amplified",
+          "Lingering Swiftness Potion Amplified",
+          "Enhanced Lingering Potion of Speed",
+          "Lingering Enhanced Potion of Speed",
+          "Amplified Lingering Potion of Speed",
+          "Lingering Amplified Potion of Speed",
+          "Lingering Potion of Speed II",
+          "Lingering Potion of Speed 2",
+          "Lingering Potion of Speed Enhanced",
+          "Lingering Potion of Speed Amplified",
+          "Lingering Potion of Enhanced Speed",
+          "Lingering Potion of Amplified Speed",
+          "Enhanced Speed Lingering Potion",
+          "Lingering Enhanced Speed Potion",
+          "Enhanced Lingering Speed Potion",
+          "Amplified Speed Lingering Potion",
+          "Lingering Amplified Speed Potion",
+          "Amplified Lingering Speed Potion",
+          "Speed Lingering Potion II",
+          "Lingering Speed Potion II",
+          "Speed Lingering Potion 2",
+          "Lingering Speed Potion 2",
+          "Speed Lingering Potion Enhanced",
+          "Lingering Speed Potion Enhanced",
+          "Speed Lingering Potion Amplified",
+          "Lingering Speed Potion Amplified"
+        ],
+        "display_name": "Lingering Potion of Swiftness (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Swiftness",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.water": {
+    "lang": {
+      "en_US": {
+        "lore": "No effects",
+        "search_names": [
+          "Water Lingering Potion",
+          "Lingering Water Potion",
+          "Lingering Potion of Water",
+          "Lingering Bottle of Water"
+        ],
+        "display_name": "Lingering Water Bottle"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.water_breathing": {
+    "lang": {
+      "en_US": {
+        "lore": "Water Breathing (0:45)",
+        "search_names": [
+          "Water Breathing Lingering Potion",
+          "Lingering Water Breathing Potion",
+          "Breathing Lingering Potion",
+          "Lingering Breathing Potion",
+          "Lingering Potion of Breathing"
+        ],
+        "display_name": "Lingering Potion of Water Breathing"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.water_breathing.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Water Breathing (2:00)",
+        "search_names": [
+          "Extended Lingering Potion of Water Breathing",
+          "Lingering Extended Potion of Water Breathing",
+          "Lengthened Lingering Potion of Water Breathing",
+          "Lingering Lengthened Potion of Water Breathing",
+          "Lingering Potion of Water Breathing Extended",
+          "Lingering Potion of Water Breathing Lengthened",
+          "Lingering Potion of Water Breathing+",
+          "Lingering Potion of Water Breathing +",
+          "Lingering Potion of Extended Water Breathing",
+          "Lingering Potion of Lengthened Water Breathing",
+          "Extended Water Breathing Lingering Potion",
+          "Lingering Extended Water Breathing Potion",
+          "Extended Lingering Water Breathing Potion",
+          "Lengthened Water Breathing Lingering Potion",
+          "Lingering Lengthened Water Breathing Potion",
+          "Lengthened Lingering Water Breathing Potion",
+          "Water Breathing Lingering Potion Extended",
+          "Lingering Water Breathing Potion Extended",
+          "Water Breathing Lingering Potion Lengthened",
+          "Lingering Water Breathing Potion Lengthened",
+          "Extended Lingering Potion of Breathing",
+          "Lingering Extended Potion of Breathing",
+          "Lengthened Lingering Potion of Breathing",
+          "Lingering Lengthened Potion of Breathing",
+          "Lingering Potion of Breathing Extended",
+          "Lingering Potion of Breathing Lengthened",
+          "Lingering Potion of Breathing+",
+          "Lingering Potion of Breathing +",
+          "Lingering Potion of Extended Breathing",
+          "Lingering Potion of Lengthened Breathing",
+          "Extended Breathing Lingering Potion",
+          "Lingering Extended Breathing Potion",
+          "Extended Lingering Breathing Potion",
+          "Lengthened Breathing Lingering Potion",
+          "Lingering Lengthened Breathing Potion",
+          "Lengthened Lingering Breathing Potion",
+          "Breathing Lingering Potion Extended",
+          "Lingering Breathing Potion Extended",
+          "Breathing Lingering Potion Lengthened",
+          "Lingering Breathing Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of Water Breathing (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Water Breathing",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.weakness": {
+    "lang": {
+      "en_US": {
+        "lore": "Weakness (0:22)",
+        "search_names": [
+          "Weakness Lingering Potion",
+          "Lingering Weakness Potion"
+        ],
+        "display_name": "Lingering Potion of Weakness"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.weakness.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Weakness (1:00)",
+        "search_names": [
+          "Extended Lingering Potion of Weakness",
+          "Lingering Extended Potion of Weakness",
+          "Lengthened Lingering Potion of Weakness",
+          "Lingering Lengthened Potion of Weakness",
+          "Lingering Potion of Weakness Extended",
+          "Lingering Potion of Weakness Lengthened",
+          "Lingering Potion of Weakness+",
+          "Lingering Potion of Weakness +",
+          "Lingering Potion of Extended Weakness",
+          "Lingering Potion of Lengthened Weakness",
+          "Extended Weakness Lingering Potion",
+          "Lingering Extended Weakness Potion",
+          "Extended Lingering Weakness Potion",
+          "Lengthened Weakness Lingering Potion",
+          "Lingering Lengthened Weakness Potion",
+          "Lengthened Lingering Weakness Potion",
+          "Weakness Lingering Potion Extended",
+          "Lingering Weakness Potion Extended",
+          "Weakness Lingering Potion Lengthened",
+          "Lingering Weakness Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of Weakness (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Weakness",
+      "actual_id": "minecraft.lingering_potion",
+      "id": 441,
+      "version": "1.9"
+    }
+  },
+  "minecraft.potion.effect.empty": {
+    "lang": {
+      "en_US": {
+        "lore": "No effects",
+        "display_name": "Uncraftable Potion"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.potion",
+      "version": "1.9"
+    }
+  },
+  "minecraft.potion.effect.luck": {
+    "lang": {
+      "en_US": {
+        "lore": "Luck (5:00",
+        "search_names": [
+          "Luck Potion"
+        ],
+        "display_name": "Potion of Luck"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.potion",
+      "version": "1.9"
+    }
+  },
+  "minecraft.splash_potion.effect.awkward": {
+    "lang": {
+      "en_US": {
+        "lore": "No effects",
+        "display_name": "Awkward Splash Potion"
+      }
+    },
+    "properties": {
+      "image_key": "Splash Water Bottle",
+      "actual_id": "minecraft.splash_potion",
+      "id": 438,
+      "version": "1.9"
+    }
+  },
+  "minecraft.splash_potion.effect.empty": {
+    "lang": {
+      "en_US": {
+        "lore": "No effects",
+        "display_name": "Splash Uncraftable Potion"
+      }
+    },
+    "properties": {
+      "image_key": "Uncraftable Splash Potion",
+      "actual_id": "minecraft.splash_potion",
+      "version": "1.9"
+    }
+  },
+  "minecraft.splash_potion.effect.luck": {
+    "lang": {
+      "en_US": {
+        "lore": "Luck (5:00",
+        "search_names": [
+          "Luck Splash Potion",
+          "Splash Luck Potion"
+        ],
+        "display_name": "Splash Potion of Luck"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.splash_potion",
+      "version": "1.9"
+    }
+  },
+  "minecraft.splash_potion.effect.mundane": {
+    "lang": {
+      "en_US": {
+        "lore": "No effects",
+        "display_name": "Mundane Splash Potion"
+      }
+    },
+    "properties": {
+      "image_key": "Splash Water Bottle",
+      "actual_id": "minecraft.splash_potion",
+      "id": 438,
+      "version": "1.9"
+    }
+  },
+  "minecraft.splash_potion.effect.mundane.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "No effects",
+        "search_names": [
+          "Extended Mundane Splash Potion",
+          "Splash Extended Mundane Potion",
+          "Extended Splash Mundane Potion",
+          "Lengthened Mundane Splash Potion",
+          "Splash Lengthened Mundane Potion",
+          "Lengthened Splash Mundane Potion",
+          "Mundane Splash Potion Extended",
+          "Splash Mundane Potion Extended",
+          "Mundane Splash Potion Lengthened",
+          "Splash Mundane Potion Lengthened"
+        ],
+        "display_name": "Mundane Splash Potion (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Splash Water Bottle",
+      "actual_id": "minecraft.splash_potion",
+      "id": 438,
+      "version": "1.9"
+    }
+  },
+  "minecraft.splash_potion.effect.thick": {
+    "lang": {
+      "en_US": {
+        "lore": "No effects",
+        "search_names": [
+          "Thicc Splash Potion",
+          "Splash Thicc Potion"
+        ],
+        "display_name": "Thick Splash Potion"
+      }
+    },
+    "properties": {
+      "image_key": "Splash Water Bottle",
+      "actual_id": "minecraft.splash_potion",
+      "id": 438,
+      "version": "1.9"
+    }
+  },
+  "minecraft.splash_potion.effect.water": {
+    "lang": {
+      "en_US": {
+        "lore": "No effects",
+        "search_names": [
+          "Water Splash Potion",
+          "Splash Water Potion",
+          "Splash Potion of Water",
+          "Splash Potion of Splashing",
+          "Splash Bottle of Water"
+        ],
+        "display_name": "Splash Water Bottle"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.splash_potion",
+      "id": 438,
+      "version": "1.9"
+    }
+  },
   "minecraft.tipped_arrow.effect.awkward": {
     "lang": {
       "en_US": {
@@ -25807,8 +25636,8 @@
           "Amplified Tipped Arrow of Harming",
           "Amplified Arrow of Harming",
           "Tipped Arrow of Harming II",
-          "Tipped Arrow of Harming 2",
           "Arrow of Harming II",
+          "Tipped Arrow of Harming 2",
           "Arrow of Harming 2",
           "Tipped Arrow of Harming Enhanced",
           "Arrow of Harming Enhanced",
@@ -25823,8 +25652,8 @@
           "Amplified Harming Tipped Arrow",
           "Amplified Harming Arrow",
           "Harming Tipped Arrow II",
-          "Harming Tipped Arrow 2",
           "Harming Arrow II",
+          "Harming Tipped Arrow 2",
           "Harming Arrow 2",
           "Harming Tipped Arrow Enhanced",
           "Harming Arrow Enhanced",
@@ -25835,8 +25664,8 @@
           "Amplified Tipped Arrow of Instant Damage",
           "Amplified Arrow of Instant Damage",
           "Tipped Arrow of Instant Damage II",
-          "Tipped Arrow of Instant Damage 2",
           "Arrow of Instant Damage II",
+          "Tipped Arrow of Instant Damage 2",
           "Arrow of Instant Damage 2",
           "Tipped Arrow of Instant Damage Enhanced",
           "Arrow of Instant Damage Enhanced",
@@ -25851,8 +25680,8 @@
           "Amplified Instant Damage Tipped Arrow",
           "Amplified Instant Damage Arrow",
           "Instant Damage Tipped Arrow II",
-          "Instant Damage Tipped Arrow 2",
           "Instant Damage Arrow II",
+          "Instant Damage Tipped Arrow 2",
           "Instant Damage Arrow 2",
           "Instant Damage Tipped Arrow Enhanced",
           "Instant Damage Arrow Enhanced",
@@ -25901,8 +25730,8 @@
           "Amplified Tipped Arrow of Healing",
           "Amplified Arrow of Healing",
           "Tipped Arrow of Healing II",
-          "Tipped Arrow of Healing 2",
           "Arrow of Healing II",
+          "Tipped Arrow of Healing 2",
           "Arrow of Healing 2",
           "Tipped Arrow of Healing Enhanced",
           "Arrow of Healing Enhanced",
@@ -25917,8 +25746,8 @@
           "Amplified Healing Tipped Arrow",
           "Amplified Healing Arrow",
           "Healing Tipped Arrow II",
-          "Healing Tipped Arrow 2",
           "Healing Arrow II",
+          "Healing Tipped Arrow 2",
           "Healing Arrow 2",
           "Healing Tipped Arrow Enhanced",
           "Healing Arrow Enhanced",
@@ -25929,8 +25758,8 @@
           "Amplified Tipped Arrow of Instant Health",
           "Amplified Arrow of Instant Health",
           "Tipped Arrow of Instant Health II",
-          "Tipped Arrow of Instant Health 2",
           "Arrow of Instant Health II",
+          "Tipped Arrow of Instant Health 2",
           "Arrow of Instant Health 2",
           "Tipped Arrow of Instant Health Enhanced",
           "Arrow of Instant Health Enhanced",
@@ -25945,8 +25774,8 @@
           "Amplified Instant Health Tipped Arrow",
           "Amplified Instant Health Arrow",
           "Instant Health Tipped Arrow II",
-          "Instant Health Tipped Arrow 2",
           "Instant Health Arrow II",
+          "Instant Health Tipped Arrow 2",
           "Instant Health Arrow 2",
           "Instant Health Tipped Arrow Enhanced",
           "Instant Health Arrow Enhanced",
@@ -26127,8 +25956,8 @@
           "Amplified Tipped Arrow of Leaping",
           "Amplified Arrow of Leaping",
           "Tipped Arrow of Leaping II",
-          "Tipped Arrow of Leaping 2",
           "Arrow of Leaping II",
+          "Tipped Arrow of Leaping 2",
           "Arrow of Leaping 2",
           "Tipped Arrow of Leaping Enhanced",
           "Arrow of Leaping Enhanced",
@@ -26143,8 +25972,8 @@
           "Amplified Leaping Tipped Arrow",
           "Amplified Leaping Arrow",
           "Leaping Tipped Arrow II",
-          "Leaping Tipped Arrow 2",
           "Leaping Arrow II",
+          "Leaping Tipped Arrow 2",
           "Leaping Arrow 2",
           "Leaping Tipped Arrow Enhanced",
           "Leaping Arrow Enhanced",
@@ -26155,8 +25984,8 @@
           "Amplified Tipped Arrow of Jump Boost",
           "Amplified Arrow of Jump Boost",
           "Tipped Arrow of Jump Boost II",
-          "Tipped Arrow of Jump Boost 2",
           "Arrow of Jump Boost II",
+          "Tipped Arrow of Jump Boost 2",
           "Arrow of Jump Boost 2",
           "Tipped Arrow of Jump Boost Enhanced",
           "Arrow of Jump Boost Enhanced",
@@ -26171,8 +26000,8 @@
           "Amplified Jump Boost Tipped Arrow",
           "Amplified Jump Boost Arrow",
           "Jump Boost Tipped Arrow II",
-          "Jump Boost Tipped Arrow 2",
           "Jump Boost Arrow II",
+          "Jump Boost Tipped Arrow 2",
           "Jump Boost Arrow 2",
           "Jump Boost Tipped Arrow Enhanced",
           "Jump Boost Arrow Enhanced",
@@ -26376,8 +26205,8 @@
           "Amplified Tipped Arrow of Poison",
           "Amplified Arrow of Poison",
           "Tipped Arrow of Poison II",
-          "Tipped Arrow of Poison 2",
           "Arrow of Poison II",
+          "Tipped Arrow of Poison 2",
           "Arrow of Poison 2",
           "Tipped Arrow of Poison Enhanced",
           "Arrow of Poison Enhanced",
@@ -26392,8 +26221,8 @@
           "Amplified Poison Tipped Arrow",
           "Amplified Poison Arrow",
           "Poison Tipped Arrow II",
-          "Poison Tipped Arrow 2",
           "Poison Arrow II",
+          "Poison Tipped Arrow 2",
           "Poison Arrow 2",
           "Poison Tipped Arrow Enhanced",
           "Poison Arrow Enhanced",
@@ -26506,8 +26335,8 @@
           "Amplified Tipped Arrow of Regeneration",
           "Amplified Arrow of Regeneration",
           "Tipped Arrow of Regeneration II",
-          "Tipped Arrow of Regeneration 2",
           "Arrow of Regeneration II",
+          "Tipped Arrow of Regeneration 2",
           "Arrow of Regeneration 2",
           "Tipped Arrow of Regeneration Enhanced",
           "Arrow of Regeneration Enhanced",
@@ -26522,8 +26351,8 @@
           "Amplified Regeneration Tipped Arrow",
           "Amplified Regeneration Arrow",
           "Regeneration Tipped Arrow II",
-          "Regeneration Tipped Arrow 2",
           "Regeneration Arrow II",
+          "Regeneration Tipped Arrow 2",
           "Regeneration Arrow 2",
           "Regeneration Tipped Arrow Enhanced",
           "Regeneration Arrow Enhanced",
@@ -26534,8 +26363,8 @@
           "Amplified Tipped Arrow of Regen",
           "Amplified Arrow of Regen",
           "Tipped Arrow of Regen II",
-          "Tipped Arrow of Regen 2",
           "Arrow of Regen II",
+          "Tipped Arrow of Regen 2",
           "Arrow of Regen 2",
           "Tipped Arrow of Regen Enhanced",
           "Arrow of Regen Enhanced",
@@ -26550,8 +26379,8 @@
           "Amplified Regen Tipped Arrow",
           "Amplified Regen Arrow",
           "Regen Tipped Arrow II",
-          "Regen Tipped Arrow 2",
           "Regen Arrow II",
+          "Regen Tipped Arrow 2",
           "Regen Arrow 2",
           "Regen Tipped Arrow Enhanced",
           "Regen Arrow Enhanced",
@@ -26566,62 +26395,6 @@
       "actual_id": "minecraft.tipped_arrow",
       "id": 440,
       "version": "1.9"
-    }
-  },
-  "minecraft.tipped_arrow.effect.slow_falling": {
-    "lang": {
-      "en_US": {
-        "lore": "Slow Falling (0:11)",
-        "search_names": [
-          "Slow Falling Tipped Arrow",
-          "Slow Falling Arrow",
-          "Tipped Arrow of Slow Falling"
-        ],
-        "display_name": "Arrow of Slow Falling"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.tipped_arrow",
-      "version": "1.13"
-    }
-  },
-  "minecraft.tipped_arrow.effect.slow_falling.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Slow Falling (0:30)",
-        "search_names": [
-          "Extended Tipped Arrow of Slow Falling",
-          "Extended Arrow of Slow Falling",
-          "Lengthened Tipped Arrow of Slow Falling",
-          "Lengthened Arrow of Slow Falling",
-          "Tipped Arrow of Slow Falling Extended",
-          "Arrow of Slow Falling Extended",
-          "Tipped Arrow of Slow Falling Lengthened",
-          "Arrow of Slow Falling Lengthened",
-          "Tipped Arrow of Slow Falling+",
-          "Arrow of Slow Falling+",
-          "Tipped Arrow of Slow Falling +",
-          "Arrow of Slow Falling +",
-          "Tipped Arrow of Extended Slow Falling",
-          "Arrow of Extended Slow Falling",
-          "Tipped Arrow of Lengthened Slow Falling",
-          "Arrow of Lengthened Slow Falling",
-          "Extended Slow Falling Tipped Arrow",
-          "Extended Slow Falling Arrow",
-          "Lengthened Slow Falling Tipped Arrow",
-          "Lengthened Slow Falling Arrow",
-          "Slow Falling Tipped Arrow Extended",
-          "Slow Falling Arrow Extended",
-          "Slow Falling Tipped Arrow Lengthened",
-          "Slow Falling Arrow Lengthened"
-        ],
-        "display_name": "Arrow of Slow Falling (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Arrow of Slow Falling",
-      "actual_id": "minecraft.tipped_arrow",
-      "version": "1.13"
     }
   },
   "minecraft.tipped_arrow.effect.slowness": {
@@ -26680,50 +26453,6 @@
       "actual_id": "minecraft.tipped_arrow",
       "id": 440,
       "version": "1.9"
-    }
-  },
-  "minecraft.tipped_arrow.effect.slowness.iv": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness IV (0:02)",
-        "search_names": [
-          "Enhanced Tipped Arrow of Slowness",
-          "Enhanced Arrow of Slowness",
-          "Amplified Tipped Arrow of Slowness",
-          "Amplified Arrow of Slowness",
-          "Tipped Arrow of Slowness IV",
-          "Tipped Arrow of Slowness 4",
-          "Arrow of Slowness IV",
-          "Arrow of Slowness 4",
-          "Tipped Arrow of Slowness Enhanced",
-          "Arrow of Slowness Enhanced",
-          "Tipped Arrow of Slowness Amplified",
-          "Arrow of Slowness Amplified",
-          "Tipped Arrow of Enhanced Slowness",
-          "Arrow of Enhanced Slowness",
-          "Tipped Arrow of Amplified Slowness",
-          "Arrow of Amplified Slowness",
-          "Enhanced Slowness Tipped Arrow",
-          "Enhanced Slowness Arrow",
-          "Amplified Slowness Tipped Arrow",
-          "Amplified Slowness Arrow",
-          "Slowness Tipped Arrow IV",
-          "Slowness Tipped Arrow 4",
-          "Slowness Arrow IV",
-          "Slowness Arrow 4",
-          "Slowness Tipped Arrow Enhanced",
-          "Slowness Arrow Enhanced",
-          "Slowness Tipped Arrow Amplified",
-          "Slowness Arrow Amplified",
-          "Tipped Arrow of Slowness (enhanced)"
-        ],
-        "display_name": "Arrow of Slowness (enhanced)"
-      }
-    },
-    "properties": {
-      "image_key": "Arrow of Slowness",
-      "actual_id": "minecraft.tipped_arrow",
-      "version": "1.13"
     }
   },
   "minecraft.tipped_arrow.effect.strength": {
@@ -26794,8 +26523,8 @@
           "Amplified Tipped Arrow of Strength",
           "Amplified Arrow of Strength",
           "Tipped Arrow of Strength II",
-          "Tipped Arrow of Strength 2",
           "Arrow of Strength II",
+          "Tipped Arrow of Strength 2",
           "Arrow of Strength 2",
           "Tipped Arrow of Strength Enhanced",
           "Arrow of Strength Enhanced",
@@ -26810,8 +26539,8 @@
           "Amplified Strength Tipped Arrow",
           "Amplified Strength Arrow",
           "Strength Tipped Arrow II",
-          "Strength Tipped Arrow 2",
           "Strength Arrow II",
+          "Strength Tipped Arrow 2",
           "Strength Arrow 2",
           "Strength Tipped Arrow Enhanced",
           "Strength Arrow Enhanced",
@@ -26924,8 +26653,8 @@
           "Amplified Tipped Arrow of Swiftness",
           "Amplified Arrow of Swiftness",
           "Tipped Arrow of Swiftness II",
-          "Tipped Arrow of Swiftness 2",
           "Arrow of Swiftness II",
+          "Tipped Arrow of Swiftness 2",
           "Arrow of Swiftness 2",
           "Tipped Arrow of Swiftness Enhanced",
           "Arrow of Swiftness Enhanced",
@@ -26940,8 +26669,8 @@
           "Amplified Swiftness Tipped Arrow",
           "Amplified Swiftness Arrow",
           "Swiftness Tipped Arrow II",
-          "Swiftness Tipped Arrow 2",
           "Swiftness Arrow II",
+          "Swiftness Tipped Arrow 2",
           "Swiftness Arrow 2",
           "Swiftness Tipped Arrow Enhanced",
           "Swiftness Arrow Enhanced",
@@ -26952,8 +26681,8 @@
           "Amplified Tipped Arrow of Speed",
           "Amplified Arrow of Speed",
           "Tipped Arrow of Speed II",
-          "Tipped Arrow of Speed 2",
           "Arrow of Speed II",
+          "Tipped Arrow of Speed 2",
           "Arrow of Speed 2",
           "Tipped Arrow of Speed Enhanced",
           "Arrow of Speed Enhanced",
@@ -26968,8 +26697,8 @@
           "Amplified Speed Tipped Arrow",
           "Amplified Speed Arrow",
           "Speed Tipped Arrow II",
-          "Speed Tipped Arrow 2",
           "Speed Arrow II",
+          "Speed Tipped Arrow 2",
           "Speed Arrow 2",
           "Speed Tipped Arrow Enhanced",
           "Speed Arrow Enhanced",
@@ -26984,141 +26713,6 @@
       "actual_id": "minecraft.tipped_arrow",
       "id": 440,
       "version": "1.9"
-    }
-  },
-  "minecraft.tipped_arrow.effect.thick": {
-    "lang": {
-      "en_US": {
-        "distinct_display_name": "Thick Tipped Arrow",
-        "lore": "No effects",
-        "search_names": [
-          "Thicc Tipped Arrow",
-          "Thicc Arrow",
-          "Tipped Thicc Arrow",
-          "Thick Arrow",
-          "Tipped Thick Arrow"
-        ],
-        "display_name": "Tipped Arrow",
-        "name_conflict": true
-      }
-    },
-    "properties": {
-      "image_key": "Arrow of Splashing",
-      "actual_id": "minecraft.tipped_arrow",
-      "id": 440
-    }
-  },
-  "minecraft.tipped_arrow.effect.turtle_master": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness IV (0:02)\nResistance III (0:02)",
-        "search_names": [
-          "Turtle Master Tipped Arrow",
-          "Turtle Master Arrow",
-          "Turtle Tipped Arrow",
-          "Turtle Arrow",
-          "Tipped Arrow of the Turtle Master"
-        ],
-        "display_name": "Arrow of the Turtle Master"
-      }
-    },
-    "properties": {
-      "actual_id": "minecraft.tipped_arrow",
-      "version": "1.13"
-    }
-  },
-  "minecraft.tipped_arrow.effect.turtle_master.extended": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness IV (0:05)\nResistance III (0:05)",
-        "search_names": [
-          "Extended Tipped Arrow of the Turtle Master",
-          "Extended Arrow of the Turtle Master",
-          "Lengthened Tipped Arrow of the Turtle Master",
-          "Lengthened Arrow of the Turtle Master",
-          "Tipped Arrow of the Turtle Master Extended",
-          "Arrow of the Turtle Master Extended",
-          "Tipped Arrow of the Turtle Master Lengthened",
-          "Arrow of the Turtle Master Lengthened",
-          "Tipped Arrow of the Turtle Master+",
-          "Arrow of the Turtle Master+",
-          "Tipped Arrow of the Turtle Master +",
-          "Arrow of the Turtle Master +",
-          "Extended Turtle Master Tipped Arrow",
-          "Extended Turtle Master Arrow",
-          "Lengthened Turtle Master Tipped Arrow",
-          "Lengthened Turtle Master Arrow",
-          "Turtle Master Tipped Arrow Extended",
-          "Turtle Master Arrow Extended",
-          "Turtle Master Tipped Arrow Lengthened",
-          "Turtle Master Arrow Lengthened",
-          "Extended Turtle Tipped Arrow",
-          "Extended Turtle Arrow",
-          "Lengthened Turtle Tipped Arrow",
-          "Lengthened Turtle Arrow",
-          "Turtle Tipped Arrow Extended",
-          "Turtle Arrow Extended",
-          "Turtle Tipped Arrow Lengthened",
-          "Turtle Arrow Lengthened"
-        ],
-        "display_name": "Arrow of the Turtle Master (extended)"
-      }
-    },
-    "properties": {
-      "image_key": "Arrow of the Turtle Master",
-      "actual_id": "minecraft.tipped_arrow",
-      "version": "1.13"
-    }
-  },
-  "minecraft.tipped_arrow.effect.turtle_master.ii": {
-    "lang": {
-      "en_US": {
-        "lore": "Slowness VI (0:02)\nResistance IV (0:02)",
-        "search_names": [
-          "Enhanced Tipped Arrow of the Turtle Master",
-          "Enhanced Arrow of the Turtle Master",
-          "Amplified Tipped Arrow of the Turtle Master",
-          "Amplified Arrow of the Turtle Master",
-          "Tipped Arrow of the Turtle Master II",
-          "Tipped Arrow of the Turtle Master 2",
-          "Arrow of the Turtle Master II",
-          "Arrow of the Turtle Master 2",
-          "Tipped Arrow of the Turtle Master Enhanced",
-          "Arrow of the Turtle Master Enhanced",
-          "Tipped Arrow of the Turtle Master Amplified",
-          "Arrow of the Turtle Master Amplified",
-          "Enhanced Turtle Master Tipped Arrow",
-          "Enhanced Turtle Master Arrow",
-          "Amplified Turtle Master Tipped Arrow",
-          "Amplified Turtle Master Arrow",
-          "Turtle Master Tipped Arrow II",
-          "Turtle Master Tipped Arrow 2",
-          "Turtle Master Arrow II",
-          "Turtle Master Arrow 2",
-          "Turtle Master Tipped Arrow Enhanced",
-          "Turtle Master Arrow Enhanced",
-          "Turtle Master Tipped Arrow Amplified",
-          "Turtle Master Arrow Amplified",
-          "Enhanced Turtle Tipped Arrow",
-          "Enhanced Turtle Arrow",
-          "Amplified Turtle Tipped Arrow",
-          "Amplified Turtle Arrow",
-          "Turtle Tipped Arrow II",
-          "Turtle Tipped Arrow 2",
-          "Turtle Arrow II",
-          "Turtle Arrow 2",
-          "Turtle Tipped Arrow Enhanced",
-          "Turtle Arrow Enhanced",
-          "Turtle Tipped Arrow Amplified",
-          "Turtle Arrow Amplified"
-        ],
-        "display_name": "Arrow of the Turtle Master (enhanced)"
-      }
-    },
-    "properties": {
-      "image_key": "Arrow of the Turtle Master",
-      "actual_id": "minecraft.tipped_arrow",
-      "version": "1.13"
     }
   },
   "minecraft.tipped_arrow.effect.water": {
@@ -27283,6 +26877,1137 @@
       "actual_id": "minecraft.tipped_arrow",
       "id": 440,
       "version": "1.9"
+    }
+  },
+  "minecraft.lingering_potion.effect.slow_falling": {
+    "lang": {
+      "en_US": {
+        "lore": "Slow Falling (0:22)",
+        "search_names": [
+          "Slow Falling Lingering Potion",
+          "Lingering Slow Falling Potion"
+        ],
+        "display_name": "Lingering Potion of Slow Falling"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.lingering_potion.effect.slow_falling.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Slow Falling (1:00)",
+        "search_names": [
+          "Extended Lingering Potion of Slow Falling",
+          "Lingering Extended Potion of Slow Falling",
+          "Lengthened Lingering Potion of Slow Falling",
+          "Lingering Lengthened Potion of Slow Falling",
+          "Lingering Potion of Slow Falling Extended",
+          "Lingering Potion of Slow Falling Lengthened",
+          "Lingering Potion of Slow Falling+",
+          "Lingering Potion of Slow Falling +",
+          "Lingering Potion of Extended Slow Falling",
+          "Lingering Potion of Lengthened Slow Falling",
+          "Extended Slow Falling Lingering Potion",
+          "Lingering Extended Slow Falling Potion",
+          "Extended Lingering Slow Falling Potion",
+          "Lengthened Slow Falling Lingering Potion",
+          "Lingering Lengthened Slow Falling Potion",
+          "Lengthened Lingering Slow Falling Potion",
+          "Slow Falling Lingering Potion Extended",
+          "Lingering Slow Falling Potion Extended",
+          "Slow Falling Lingering Potion Lengthened",
+          "Lingering Slow Falling Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of Slow Falling (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Slow Falling",
+      "actual_id": "minecraft.lingering_potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.lingering_potion.effect.slowness.iv": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness IV (0:05)",
+        "search_names": [
+          "Enhanced Lingering Potion of Slowness",
+          "Lingering Enhanced Potion of Slowness",
+          "Amplified Lingering Potion of Slowness",
+          "Lingering Amplified Potion of Slowness",
+          "Lingering Potion of Slowness IV",
+          "Lingering Potion of Slowness 4",
+          "Lingering Potion of Slowness Enhanced",
+          "Lingering Potion of Slowness Amplified",
+          "Lingering Potion of Enhanced Slowness",
+          "Lingering Potion of Amplified Slowness",
+          "Enhanced Slowness Lingering Potion",
+          "Lingering Enhanced Slowness Potion",
+          "Amplified Slowness Lingering Potion",
+          "Lingering Amplified Slowness Potion",
+          "Slowness Lingering Potion IV",
+          "Lingering Slowness Potion IV",
+          "Slowness Lingering Potion 4",
+          "Lingering Slowness Potion 4",
+          "Slowness Lingering Potion Enhanced",
+          "Lingering Slowness Potion Enhanced",
+          "Slowness Lingering Potion Amplified",
+          "Lingering Slowness Potion Amplified"
+        ],
+        "display_name": "Lingering Potion of Slowness (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of Slowness",
+      "actual_id": "minecraft.lingering_potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.lingering_potion.effect.turtle_master": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness IV (0:05)\nResistance III (0:05)",
+        "search_names": [
+          "Turtle Master Lingering Potion",
+          "Lingering Turtle Master Potion",
+          "Turtle Lingering Potion",
+          "Lingering Turtle Potion"
+        ],
+        "display_name": "Lingering Potion of the Turtle Master"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.lingering_potion.effect.turtle_master.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness IV (0:10)\nResistance III (0:10)",
+        "search_names": [
+          "Extended Lingering Potion of the Turtle Master",
+          "Lingering Extended Potion of the Turtle Master",
+          "Lengthened Lingering Potion of the Turtle Master",
+          "Lingering Lengthened Potion of the Turtle Master",
+          "Lingering Potion of the Turtle Master Extended",
+          "Lingering Potion of the Turtle Master Lengthened",
+          "Lingering Potion of the Turtle Master+",
+          "Lingering Potion of the Turtle Master +",
+          "Extended Turtle Master Lingering Potion",
+          "Lingering Extended Turtle Master Potion",
+          "Extended Lingering Turtle Master Potion",
+          "Lengthened Turtle Master Lingering Potion",
+          "Lingering Lengthened Turtle Master Potion",
+          "Lengthened Lingering Turtle Master Potion",
+          "Turtle Master Lingering Potion Extended",
+          "Lingering Turtle Master Potion Extended",
+          "Turtle Master Lingering Potion Lengthened",
+          "Lingering Turtle Master Potion Lengthened",
+          "Extended Turtle Lingering Potion",
+          "Lingering Extended Turtle Potion",
+          "Extended Lingering Turtle Potion",
+          "Lengthened Turtle Lingering Potion",
+          "Lingering Lengthened Turtle Potion",
+          "Lengthened Lingering Turtle Potion",
+          "Turtle Lingering Potion Extended",
+          "Lingering Turtle Potion Extended",
+          "Turtle Lingering Potion Lengthened",
+          "Lingering Turtle Potion Lengthened"
+        ],
+        "display_name": "Lingering Potion of the Turtle Master (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of the Turtle Master",
+      "actual_id": "minecraft.lingering_potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.lingering_potion.effect.turtle_master.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness VI (0:05)\nResistance IV (0:05)",
+        "search_names": [
+          "Enhanced Lingering Potion of the Turtle Master",
+          "Lingering Enhanced Potion of the Turtle Master",
+          "Amplified Lingering Potion of the Turtle Master",
+          "Lingering Amplified Potion of the Turtle Master",
+          "Lingering Potion of the Turtle Master II",
+          "Lingering Potion of the Turtle Master 2",
+          "Lingering Potion of the Turtle Master Enhanced",
+          "Lingering Potion of the Turtle Master Amplified",
+          "Enhanced Turtle Master Lingering Potion",
+          "Lingering Enhanced Turtle Master Potion",
+          "Enhanced Lingering Turtle Master Potion",
+          "Amplified Turtle Master Lingering Potion",
+          "Lingering Amplified Turtle Master Potion",
+          "Amplified Lingering Turtle Master Potion",
+          "Turtle Master Lingering Potion II",
+          "Lingering Turtle Master Potion II",
+          "Turtle Master Lingering Potion 2",
+          "Lingering Turtle Master Potion 2",
+          "Turtle Master Lingering Potion Enhanced",
+          "Lingering Turtle Master Potion Enhanced",
+          "Turtle Master Lingering Potion Amplified",
+          "Lingering Turtle Master Potion Amplified",
+          "Enhanced Turtle Lingering Potion",
+          "Lingering Enhanced Turtle Potion",
+          "Enhanced Lingering Turtle Potion",
+          "Amplified Turtle Lingering Potion",
+          "Lingering Amplified Turtle Potion",
+          "Amplified Lingering Turtle Potion",
+          "Turtle Lingering Potion II",
+          "Lingering Turtle Potion II",
+          "Turtle Lingering Potion 2",
+          "Lingering Turtle Potion 2",
+          "Turtle Lingering Potion Enhanced",
+          "Lingering Turtle Potion Enhanced",
+          "Turtle Lingering Potion Amplified",
+          "Lingering Turtle Potion Amplified"
+        ],
+        "display_name": "Lingering Potion of the Turtle Master (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Lingering Potion of the Turtle Master",
+      "actual_id": "minecraft.lingering_potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.potion.effect.slow_falling": {
+    "lang": {
+      "en_US": {
+        "lore": "Slow Falling (1:30)",
+        "search_names": [
+          "Slow Falling Potion"
+        ],
+        "display_name": "Potion of Slow Falling"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.potion.effect.slow_falling.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Slow Falling (4:00)",
+        "search_names": [
+          "Extended Potion of Slow Falling",
+          "Lengthened Potion of Slow Falling",
+          "Potion of Slow Falling Extended",
+          "Potion of Slow Falling Lengthened",
+          "Potion of Slow Falling+",
+          "Potion of Slow Falling +",
+          "Potion of Extended Slow Falling",
+          "Potion of Lengthened Slow Falling",
+          "Extended Slow Falling Potion",
+          "Lengthened Slow Falling Potion",
+          "Slow Falling Potion Extended",
+          "Slow Falling Potion Lengthened"
+        ],
+        "display_name": "Potion of Slow Falling (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Potion of Slow Falling",
+      "actual_id": "minecraft.potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.potion.effect.slowness.iv": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness IV (0:20)",
+        "search_names": [
+          "Enhanced Potion of Slowness",
+          "Amplified Potion of Slowness",
+          "Potion of Slowness IV",
+          "Potion of Slowness 4",
+          "Potion of Slowness Enhanced",
+          "Potion of Slowness Amplified",
+          "Potion of Enhanced Slowness",
+          "Potion of Amplified Slowness",
+          "Enhanced Slowness Potion",
+          "Amplified Slowness Potion",
+          "Slowness Potion IV",
+          "Slowness Potion 4",
+          "Slowness Potion Enhanced",
+          "Slowness Potion Amplified"
+        ],
+        "display_name": "Potion of Slowness (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Potion of Slowness",
+      "actual_id": "minecraft.potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.potion.effect.turtle_master": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness IV (0:20)\nResistance III (0:20)",
+        "search_names": [
+          "Turtle Master Potion",
+          "Turtle Potion"
+        ],
+        "display_name": "Potion of the Turtle Master"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.potion.effect.turtle_master.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness IV (0:40)\nResistance III (0:40)",
+        "search_names": [
+          "Extended Potion of the Turtle Master",
+          "Lengthened Potion of the Turtle Master",
+          "Potion of the Turtle Master Extended",
+          "Potion of the Turtle Master Lengthened",
+          "Potion of the Turtle Master+",
+          "Potion of the Turtle Master +",
+          "Extended Turtle Master Potion",
+          "Lengthened Turtle Master Potion",
+          "Turtle Master Potion Extended",
+          "Turtle Master Potion Lengthened",
+          "Extended Turtle Potion",
+          "Lengthened Turtle Potion",
+          "Turtle Potion Extended",
+          "Turtle Potion Lengthened"
+        ],
+        "display_name": "Potion of the Turtle Master (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Potion of the Turtle Master",
+      "actual_id": "minecraft.potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.potion.effect.turtle_master.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness VI (0:20)\nResistance IV (0:20)",
+        "search_names": [
+          "Enhanced Potion of the Turtle Master",
+          "Amplified Potion of the Turtle Master",
+          "Potion of the Turtle Master II",
+          "Potion of the Turtle Master 2",
+          "Potion of the Turtle Master Enhanced",
+          "Potion of the Turtle Master Amplified",
+          "Enhanced Turtle Master Potion",
+          "Amplified Turtle Master Potion",
+          "Turtle Master Potion II",
+          "Turtle Master Potion 2",
+          "Turtle Master Potion Enhanced",
+          "Turtle Master Potion Amplified",
+          "Enhanced Turtle Potion",
+          "Amplified Turtle Potion",
+          "Turtle Potion II",
+          "Turtle Potion 2",
+          "Turtle Potion Enhanced",
+          "Turtle Potion Amplified"
+        ],
+        "display_name": "Potion of the Turtle Master (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Potion of the Turtle Master",
+      "actual_id": "minecraft.potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.splash_potion.effect.slow_falling": {
+    "lang": {
+      "en_US": {
+        "lore": "Slow Falling (1:30)",
+        "search_names": [
+          "Slow Falling Splash Potion",
+          "Splash Slow Falling Potion"
+        ],
+        "display_name": "Splash Potion of Slow Falling"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.splash_potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.splash_potion.effect.slow_falling.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Slow Falling (4:00)",
+        "search_names": [
+          "Extended Splash Potion of Slow Falling",
+          "Splash Extended Potion of Slow Falling",
+          "Lengthened Splash Potion of Slow Falling",
+          "Splash Lengthened Potion of Slow Falling",
+          "Splash Potion of Slow Falling Extended",
+          "Splash Potion of Slow Falling Lengthened",
+          "Splash Potion of Slow Falling+",
+          "Splash Potion of Slow Falling +",
+          "Splash Potion of Extended Slow Falling",
+          "Splash Potion of Lengthened Slow Falling",
+          "Extended Slow Falling Splash Potion",
+          "Splash Extended Slow Falling Potion",
+          "Extended Splash Slow Falling Potion",
+          "Lengthened Slow Falling Splash Potion",
+          "Splash Lengthened Slow Falling Potion",
+          "Lengthened Splash Slow Falling Potion",
+          "Slow Falling Splash Potion Extended",
+          "Splash Slow Falling Potion Extended",
+          "Slow Falling Splash Potion Lengthened",
+          "Splash Slow Falling Potion Lengthened"
+        ],
+        "display_name": "Splash Potion of Slow Falling (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Splash Potion of Slow Falling",
+      "actual_id": "minecraft.splash_potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.splash_potion.effect.slowness.iv": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness IV (0:20)",
+        "search_names": [
+          "Enhanced Splash Potion of Slowness",
+          "Splash Enhanced Potion of Slowness",
+          "Amplified Splash Potion of Slowness",
+          "Splash Amplified Potion of Slowness",
+          "Splash Potion of Slowness IV",
+          "Splash Potion of Slowness 4",
+          "Splash Potion of Slowness Enhanced",
+          "Splash Potion of Slowness Amplified",
+          "Splash Potion of Enhanced Slowness",
+          "Splash Potion of Amplified Slowness",
+          "Enhanced Slowness Splash Potion",
+          "Splash Enhanced Slowness Potion",
+          "Amplified Slowness Splash Potion",
+          "Splash Amplified Slowness Potion",
+          "Slowness Splash Potion IV",
+          "Splash Slowness Potion IV",
+          "Slowness Splash Potion 4",
+          "Splash Slowness Potion 4",
+          "Slowness Splash Potion Enhanced",
+          "Splash Slowness Potion Enhanced",
+          "Slowness Splash Potion Amplified",
+          "Splash Slowness Potion Amplified"
+        ],
+        "display_name": "Splash Potion of Slowness (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Splash Potion of Slowness",
+      "actual_id": "minecraft.splash_potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.splash_potion.effect.turtle_master": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness IV (0:20)\nResistance III (0:20)",
+        "search_names": [
+          "Turtle Master Splash Potion",
+          "Splash Turtle Master Potion",
+          "Turtle Splash Potion",
+          "Splash Turtle Potion"
+        ],
+        "display_name": "Splash Potion of the Turtle Master"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.splash_potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.splash_potion.effect.turtle_master.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness IV (0:40)\nResistance III (0:40)",
+        "search_names": [
+          "Extended Splash Potion of the Turtle Master",
+          "Splash Extended Potion of the Turtle Master",
+          "Lengthened Splash Potion of the Turtle Master",
+          "Splash Lengthened Potion of the Turtle Master",
+          "Splash Potion of the Turtle Master Extended",
+          "Splash Potion of the Turtle Master Lengthened",
+          "Splash Potion of the Turtle Master+",
+          "Splash Potion of the Turtle Master +",
+          "Extended Turtle Master Splash Potion",
+          "Splash Extended Turtle Master Potion",
+          "Extended Splash Turtle Master Potion",
+          "Lengthened Turtle Master Splash Potion",
+          "Splash Lengthened Turtle Master Potion",
+          "Lengthened Splash Turtle Master Potion",
+          "Turtle Master Splash Potion Extended",
+          "Splash Turtle Master Potion Extended",
+          "Turtle Master Splash Potion Lengthened",
+          "Splash Turtle Master Potion Lengthened",
+          "Extended Turtle Splash Potion",
+          "Splash Extended Turtle Potion",
+          "Extended Splash Turtle Potion",
+          "Lengthened Turtle Splash Potion",
+          "Splash Lengthened Turtle Potion",
+          "Lengthened Splash Turtle Potion",
+          "Turtle Splash Potion Extended",
+          "Splash Turtle Potion Extended",
+          "Turtle Splash Potion Lengthened",
+          "Splash Turtle Potion Lengthened"
+        ],
+        "display_name": "Splash Potion of the Turtle Master (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Splash Potion of the Turtle Master",
+      "actual_id": "minecraft.splash_potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.splash_potion.effect.turtle_master.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness VI (0:20)\nResistance IV (0:20)",
+        "search_names": [
+          "Enhanced Splash Potion of the Turtle Master",
+          "Splash Enhanced Potion of the Turtle Master",
+          "Amplified Splash Potion of the Turtle Master",
+          "Splash Amplified Potion of the Turtle Master",
+          "Splash Potion of the Turtle Master II",
+          "Splash Potion of the Turtle Master 2",
+          "Splash Potion of the Turtle Master Enhanced",
+          "Splash Potion of the Turtle Master Amplified",
+          "Enhanced Turtle Master Splash Potion",
+          "Splash Enhanced Turtle Master Potion",
+          "Enhanced Splash Turtle Master Potion",
+          "Amplified Turtle Master Splash Potion",
+          "Splash Amplified Turtle Master Potion",
+          "Amplified Splash Turtle Master Potion",
+          "Turtle Master Splash Potion II",
+          "Splash Turtle Master Potion II",
+          "Turtle Master Splash Potion 2",
+          "Splash Turtle Master Potion 2",
+          "Turtle Master Splash Potion Enhanced",
+          "Splash Turtle Master Potion Enhanced",
+          "Turtle Master Splash Potion Amplified",
+          "Splash Turtle Master Potion Amplified",
+          "Enhanced Turtle Splash Potion",
+          "Splash Enhanced Turtle Potion",
+          "Enhanced Splash Turtle Potion",
+          "Amplified Turtle Splash Potion",
+          "Splash Amplified Turtle Potion",
+          "Amplified Splash Turtle Potion",
+          "Turtle Splash Potion II",
+          "Splash Turtle Potion II",
+          "Turtle Splash Potion 2",
+          "Splash Turtle Potion 2",
+          "Turtle Splash Potion Enhanced",
+          "Splash Turtle Potion Enhanced",
+          "Turtle Splash Potion Amplified",
+          "Splash Turtle Potion Amplified"
+        ],
+        "display_name": "Splash Potion of the Turtle Master (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Splash Potion of the Turtle Master",
+      "actual_id": "minecraft.splash_potion",
+      "version": "1.13"
+    }
+  },
+  "minecraft.tipped_arrow.effect.slow_falling": {
+    "lang": {
+      "en_US": {
+        "lore": "Slow Falling (0:11)",
+        "search_names": [
+          "Slow Falling Tipped Arrow",
+          "Slow Falling Arrow",
+          "Tipped Arrow of Slow Falling"
+        ],
+        "display_name": "Arrow of Slow Falling"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.tipped_arrow",
+      "version": "1.13"
+    }
+  },
+  "minecraft.tipped_arrow.effect.slow_falling.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Slow Falling (0:30)",
+        "search_names": [
+          "Extended Tipped Arrow of Slow Falling",
+          "Extended Arrow of Slow Falling",
+          "Lengthened Tipped Arrow of Slow Falling",
+          "Lengthened Arrow of Slow Falling",
+          "Tipped Arrow of Slow Falling Extended",
+          "Arrow of Slow Falling Extended",
+          "Tipped Arrow of Slow Falling Lengthened",
+          "Arrow of Slow Falling Lengthened",
+          "Tipped Arrow of Slow Falling+",
+          "Arrow of Slow Falling+",
+          "Tipped Arrow of Slow Falling +",
+          "Arrow of Slow Falling +",
+          "Tipped Arrow of Extended Slow Falling",
+          "Arrow of Extended Slow Falling",
+          "Tipped Arrow of Lengthened Slow Falling",
+          "Arrow of Lengthened Slow Falling",
+          "Extended Slow Falling Tipped Arrow",
+          "Extended Slow Falling Arrow",
+          "Lengthened Slow Falling Tipped Arrow",
+          "Lengthened Slow Falling Arrow",
+          "Slow Falling Tipped Arrow Extended",
+          "Slow Falling Arrow Extended",
+          "Slow Falling Tipped Arrow Lengthened",
+          "Slow Falling Arrow Lengthened"
+        ],
+        "display_name": "Arrow of Slow Falling (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Arrow of Slow Falling",
+      "actual_id": "minecraft.tipped_arrow",
+      "version": "1.13"
+    }
+  },
+  "minecraft.tipped_arrow.effect.slowness.iv": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness IV (0:02)",
+        "search_names": [
+          "Enhanced Tipped Arrow of Slowness",
+          "Enhanced Arrow of Slowness",
+          "Amplified Tipped Arrow of Slowness",
+          "Amplified Arrow of Slowness",
+          "Tipped Arrow of Slowness IV",
+          "Arrow of Slowness IV",
+          "Tipped Arrow of Slowness 4",
+          "Arrow of Slowness 4",
+          "Tipped Arrow of Slowness Enhanced",
+          "Arrow of Slowness Enhanced",
+          "Tipped Arrow of Slowness Amplified",
+          "Arrow of Slowness Amplified",
+          "Tipped Arrow of Enhanced Slowness",
+          "Arrow of Enhanced Slowness",
+          "Tipped Arrow of Amplified Slowness",
+          "Arrow of Amplified Slowness",
+          "Enhanced Slowness Tipped Arrow",
+          "Enhanced Slowness Arrow",
+          "Amplified Slowness Tipped Arrow",
+          "Amplified Slowness Arrow",
+          "Slowness Tipped Arrow IV",
+          "Slowness Arrow IV",
+          "Slowness Tipped Arrow 4",
+          "Slowness Arrow 4",
+          "Slowness Tipped Arrow Enhanced",
+          "Slowness Arrow Enhanced",
+          "Slowness Tipped Arrow Amplified",
+          "Slowness Arrow Amplified",
+          "Tipped Arrow of Slowness (enhanced)"
+        ],
+        "display_name": "Arrow of Slowness (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Arrow of Slowness",
+      "actual_id": "minecraft.tipped_arrow",
+      "version": "1.13"
+    }
+  },
+  "minecraft.tipped_arrow.effect.turtle_master": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness IV (0:02)\nResistance III (0:02)",
+        "search_names": [
+          "Turtle Master Tipped Arrow",
+          "Turtle Master Arrow",
+          "Turtle Tipped Arrow",
+          "Turtle Arrow",
+          "Tipped Arrow of the Turtle Master"
+        ],
+        "display_name": "Arrow of the Turtle Master"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.tipped_arrow",
+      "version": "1.13"
+    }
+  },
+  "minecraft.tipped_arrow.effect.turtle_master.extended": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness IV (0:05)\nResistance III (0:05)",
+        "search_names": [
+          "Extended Tipped Arrow of the Turtle Master",
+          "Extended Arrow of the Turtle Master",
+          "Lengthened Tipped Arrow of the Turtle Master",
+          "Lengthened Arrow of the Turtle Master",
+          "Tipped Arrow of the Turtle Master Extended",
+          "Arrow of the Turtle Master Extended",
+          "Tipped Arrow of the Turtle Master Lengthened",
+          "Arrow of the Turtle Master Lengthened",
+          "Tipped Arrow of the Turtle Master+",
+          "Arrow of the Turtle Master+",
+          "Tipped Arrow of the Turtle Master +",
+          "Arrow of the Turtle Master +",
+          "Extended Turtle Master Tipped Arrow",
+          "Extended Turtle Master Arrow",
+          "Lengthened Turtle Master Tipped Arrow",
+          "Lengthened Turtle Master Arrow",
+          "Turtle Master Tipped Arrow Extended",
+          "Turtle Master Arrow Extended",
+          "Turtle Master Tipped Arrow Lengthened",
+          "Turtle Master Arrow Lengthened",
+          "Extended Turtle Tipped Arrow",
+          "Extended Turtle Arrow",
+          "Lengthened Turtle Tipped Arrow",
+          "Lengthened Turtle Arrow",
+          "Turtle Tipped Arrow Extended",
+          "Turtle Arrow Extended",
+          "Turtle Tipped Arrow Lengthened",
+          "Turtle Arrow Lengthened"
+        ],
+        "display_name": "Arrow of the Turtle Master (extended)"
+      }
+    },
+    "properties": {
+      "image_key": "Arrow of the Turtle Master",
+      "actual_id": "minecraft.tipped_arrow",
+      "version": "1.13"
+    }
+  },
+  "minecraft.tipped_arrow.effect.turtle_master.ii": {
+    "lang": {
+      "en_US": {
+        "lore": "Slowness VI (0:02)\nResistance IV (0:02)",
+        "search_names": [
+          "Enhanced Tipped Arrow of the Turtle Master",
+          "Enhanced Arrow of the Turtle Master",
+          "Amplified Tipped Arrow of the Turtle Master",
+          "Amplified Arrow of the Turtle Master",
+          "Tipped Arrow of the Turtle Master II",
+          "Arrow of the Turtle Master II",
+          "Tipped Arrow of the Turtle Master 2",
+          "Arrow of the Turtle Master 2",
+          "Tipped Arrow of the Turtle Master Enhanced",
+          "Arrow of the Turtle Master Enhanced",
+          "Tipped Arrow of the Turtle Master Amplified",
+          "Arrow of the Turtle Master Amplified",
+          "Enhanced Turtle Master Tipped Arrow",
+          "Enhanced Turtle Master Arrow",
+          "Amplified Turtle Master Tipped Arrow",
+          "Amplified Turtle Master Arrow",
+          "Turtle Master Tipped Arrow II",
+          "Turtle Master Arrow II",
+          "Turtle Master Tipped Arrow 2",
+          "Turtle Master Arrow 2",
+          "Turtle Master Tipped Arrow Enhanced",
+          "Turtle Master Arrow Enhanced",
+          "Turtle Master Tipped Arrow Amplified",
+          "Turtle Master Arrow Amplified",
+          "Enhanced Turtle Tipped Arrow",
+          "Enhanced Turtle Arrow",
+          "Amplified Turtle Tipped Arrow",
+          "Amplified Turtle Arrow",
+          "Turtle Tipped Arrow II",
+          "Turtle Arrow II",
+          "Turtle Tipped Arrow 2",
+          "Turtle Arrow 2",
+          "Turtle Tipped Arrow Enhanced",
+          "Turtle Arrow Enhanced",
+          "Turtle Tipped Arrow Amplified",
+          "Turtle Arrow Amplified"
+        ],
+        "display_name": "Arrow of the Turtle Master (enhanced)"
+      }
+    },
+    "properties": {
+      "image_key": "Arrow of the Turtle Master",
+      "actual_id": "minecraft.tipped_arrow",
+      "version": "1.13"
+    }
+  },
+  "minecraft.lingering_potion.effect.infested": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Lingering Potion of Silverfish",
+          "Infestation Lingering Potion",
+          "Lingering Infestation Potion",
+          "Infested Lingering Potion",
+          "Lingering Infested Potion",
+          "Silverfish Lingering Potion",
+          "Lingering Silverfish Potion"
+        ],
+        "display_name": "Lingering Potion of Infestation"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.lingering_potion.effect.oozing": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Lingering Potion of Ooze",
+          "Lingering Potion of Slime",
+          "Oozing Lingering Potion",
+          "Lingering Oozing Potion",
+          "Ooze Lingering Potion",
+          "Lingering Ooze Potion",
+          "Slime Lingering Potion",
+          "Lingering Slime Potion"
+        ],
+        "display_name": "Lingering Potion of Oozing"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.lingering_potion.effect.weaving": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Lingering Potion of Cobwebs",
+          "Lingering Potion of Spiders",
+          "Weaving Lingering Potion",
+          "Lingering Weaving Potion",
+          "Cobweb Lingering Potion",
+          "Lingering Cobweb Potion",
+          "Spider Lingering Potion",
+          "Lingering Spider Potion"
+        ],
+        "display_name": "Lingering Potion of Weaving"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.lingering_potion.effect.wind_charged": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Lingering Potion of Wind",
+          "Lingering Potion of Air",
+          "Wind Charging Lingering Potion",
+          "Lingering Wind Charging Potion",
+          "Wind Charged Lingering Potion",
+          "Lingering Wind Charged Potion",
+          "Wind Lingering Potion",
+          "Lingering Wind Potion",
+          "Air Lingering Potion",
+          "Lingering Air Potion",
+          "Fart Lingering Potion",
+          "Lingering Fart Potion"
+        ],
+        "display_name": "Lingering Potion of Wind Charging"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.lingering_potion",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.potion.effect.infested": {
+    "lang": {
+      "en_US": {
+        "lore": "Infestation (3:00)",
+        "search_names": [
+          "Potion of Silverfish",
+          "Infestation Potion",
+          "Infested Potion",
+          "Silverfish Potion"
+        ],
+        "display_name": "Potion of Infestation"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.potion",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.potion.effect.oozing": {
+    "lang": {
+      "en_US": {
+        "lore": "Oozing (3:00)",
+        "search_names": [
+          "Potion of Ooze",
+          "Potion of Slime",
+          "Oozing Potion",
+          "Ooze Potion",
+          "Slime Potion"
+        ],
+        "display_name": "Potion of Oozing"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.potion",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.potion.effect.weaving": {
+    "lang": {
+      "en_US": {
+        "lore": "Weaving (3:00)",
+        "search_names": [
+          "Potion of Cobwebs",
+          "Potion of Spiders",
+          "Weaving Potion",
+          "Cobweb Potion",
+          "Spider Potion"
+        ],
+        "display_name": "Potion of Weaving"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.potion",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.potion.effect.wind_charged": {
+    "lang": {
+      "en_US": {
+        "lore": "Wind Charging (3:00)",
+        "search_names": [
+          "Potion of Wind",
+          "Potion of Air",
+          "Wind Charging Potion",
+          "Wind Charged Potion",
+          "Wind Potion",
+          "Air Potion",
+          "Fart Potion"
+        ],
+        "display_name": "Potion of Wind Charging"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.potion",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.splash_potion.effect.infested": {
+    "lang": {
+      "en_US": {
+        "lore": "Infestation (3:00)",
+        "search_names": [
+          "Splash Potion of Silverfish",
+          "Infestation Splash Potion",
+          "Splash Infestation Potion",
+          "Infested Splash Potion",
+          "Splash Infested Potion",
+          "Silverfish Splash Potion",
+          "Splash Silverfish Potion"
+        ],
+        "display_name": "Splash Potion of Infestation"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.splash_potion",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.splash_potion.effect.oozing": {
+    "lang": {
+      "en_US": {
+        "lore": "Oozing (3:00)",
+        "search_names": [
+          "Splash Potion of Ooze",
+          "Splash Potion of Slime",
+          "Oozing Splash Potion",
+          "Splash Oozing Potion",
+          "Ooze Splash Potion",
+          "Splash Ooze Potion",
+          "Slime Splash Potion",
+          "Splash Slime Potion"
+        ],
+        "display_name": "Splash Potion of Oozing"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.splash_potion",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.splash_potion.effect.weaving": {
+    "lang": {
+      "en_US": {
+        "lore": "Weaving (3:00)",
+        "search_names": [
+          "Splash Potion of Cobwebs",
+          "Splash Potion of Spiders",
+          "Weaving Splash Potion",
+          "Splash Weaving Potion",
+          "Cobweb Splash Potion",
+          "Splash Cobweb Potion",
+          "Spider Splash Potion",
+          "Splash Spider Potion"
+        ],
+        "display_name": "Splash Potion of Weaving"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.splash_potion",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.splash_potion.effect.wind_charged": {
+    "lang": {
+      "en_US": {
+        "lore": "Wind Charging (3:00)",
+        "search_names": [
+          "Splash Potion of Wind",
+          "Splash Potion of Air",
+          "Wind Charging Splash Potion",
+          "Splash Wind Charging Potion",
+          "Wind Charged Splash Potion",
+          "Splash Wind Charged Potion",
+          "Wind Splash Potion",
+          "Splash Wind Potion",
+          "Air Splash Potion",
+          "Splash Air Potion",
+          "Fart Splash Potion",
+          "Splash Fart Potion"
+        ],
+        "display_name": "Splash Potion of Wind Charging"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.splash_potion",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.tipped_arrow.effect.infested": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Tipped Arrow of Silverfish",
+          "Arrow of Silverfish",
+          "Infestation Tipped Arrow",
+          "Infestation Arrow",
+          "Infested Tipped Arrow",
+          "Infested Arrow",
+          "Silverfish Tipped Arrow",
+          "Silverfish Arrow",
+          "Tipped Arrow of Infestation"
+        ],
+        "display_name": "Arrow of Infestation"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.tipped_arrow",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.tipped_arrow.effect.oozing": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Tipped Arrow of Ooze",
+          "Arrow of Ooze",
+          "Tipped Arrow of Slime",
+          "Arrow of Slime",
+          "Oozing Tipped Arrow",
+          "Oozing Arrow",
+          "Ooze Tipped Arrow",
+          "Ooze Arrow",
+          "Slime Tipped Arrow",
+          "Slime Arrow",
+          "Tipped Arrow of Oozing"
+        ],
+        "display_name": "Arrow of Oozing"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.tipped_arrow",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.tipped_arrow.effect.weaving": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Tipped Arrow of Cobwebs",
+          "Arrow of Cobwebs",
+          "Tipped Arrow of Spiders",
+          "Arrow of Spiders",
+          "Weaving Tipped Arrow",
+          "Weaving Arrow",
+          "Cobweb Tipped Arrow",
+          "Cobweb Arrow",
+          "Spider Tipped Arrow",
+          "Spider Arrow",
+          "Tipped Arrow of Weaving"
+        ],
+        "display_name": "Arrow of Weaving"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.tipped_arrow",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "minecraft.tipped_arrow.effect.wind_charged": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Tipped Arrow of Wind",
+          "Arrow of Wind",
+          "Tipped Arrow of Air",
+          "Arrow of Air",
+          "Wind Charging Tipped Arrow",
+          "Wind Charging Arrow",
+          "Wind Charged Tipped Arrow",
+          "Wind Charged Arrow",
+          "Wind Tipped Arrow",
+          "Wind Arrow",
+          "Air Tipped Arrow",
+          "Air Arrow",
+          "Fart Tipped Arrow",
+          "Fart Arrow",
+          "Tipped Arrow of Wind Charging"
+        ],
+        "display_name": "Arrow of Wind Charging"
+      }
+    },
+    "properties": {
+      "actual_id": "minecraft.tipped_arrow",
+      "feature_flag": "1.21",
+      "version": "1.20.5"
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.17.10</version>
+  <version>0.17.11</version>
 
   <repositories>
     <repository>

--- a/recipes.json
+++ b/recipes.json
@@ -1,8 +1,8 @@
 {
   "acacia_planks": {
     "result": {
-      "item": "minecraft:acacia_planks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:acacia_planks"
     },
     "ingredients": [
       {
@@ -16,8 +16,8 @@
   },
   "acacia_slab": {
     "result": {
-      "item": "minecraft:acacia_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:acacia_slab"
     },
     "pattern": [
       "###"
@@ -31,8 +31,8 @@
   },
   "acacia_stairs": {
     "result": {
-      "item": "minecraft:acacia_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:acacia_stairs"
     },
     "pattern": [
       "#  ",
@@ -48,8 +48,8 @@
   },
   "activator_rail": {
     "result": {
-      "item": "minecraft:activator_rail",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:activator_rail"
     },
     "pattern": [
       "XSX",
@@ -70,7 +70,9 @@
     }
   },
   "amplified_harming_potion": {
-    "result": "minecraft.potion.effect.harming.ii",
+    "result": {
+      "id": "minecraft.potion.effect.harming.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -80,7 +82,9 @@
     }
   },
   "amplified_harming_potion_from_corrupt": {
-    "result": "minecraft.potion.effect.harming.ii",
+    "result": {
+      "id": "minecraft.potion.effect.harming.ii"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -95,7 +99,9 @@
     ]
   },
   "amplified_harming_splash_potion": {
-    "result": "minecraft.splash_potion.effect.harming.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.harming.ii"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -105,7 +111,9 @@
     }
   },
   "amplified_healing_potion": {
-    "result": "minecraft.potion.effect.healing.ii",
+    "result": {
+      "id": "minecraft.potion.effect.healing.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -115,7 +123,9 @@
     }
   },
   "amplified_healing_splash_potion": {
-    "result": "minecraft.splash_potion.effect.healing.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.healing.ii"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -125,7 +135,9 @@
     }
   },
   "amplified_poison_potion": {
-    "result": "minecraft.potion.effect.poison.ii",
+    "result": {
+      "id": "minecraft.potion.effect.poison.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -135,7 +147,9 @@
     }
   },
   "amplified_poison_splash_potion": {
-    "result": "minecraft.splash_potion.effect.poison.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.poison.ii"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -145,7 +159,9 @@
     }
   },
   "amplified_regeneration_potion": {
-    "result": "minecraft.potion.effect.regeneration.ii",
+    "result": {
+      "id": "minecraft.potion.effect.regeneration.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -155,7 +171,9 @@
     }
   },
   "amplified_regeneration_splash_potion": {
-    "result": "minecraft.splash_potion.effect.regeneration.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.regeneration.ii"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -165,7 +183,9 @@
     }
   },
   "amplified_strength_potion": {
-    "result": "minecraft.potion.effect.strength.ii",
+    "result": {
+      "id": "minecraft.potion.effect.strength.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -175,7 +195,9 @@
     }
   },
   "amplified_strength_splash_potion": {
-    "result": "minecraft.splash_potion.effect.strength.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.strength.ii"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -185,7 +207,9 @@
     }
   },
   "amplified_swiftness_potion": {
-    "result": "minecraft.potion.effect.swiftness.ii",
+    "result": {
+      "id": "minecraft.potion.effect.swiftness.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -195,7 +219,9 @@
     }
   },
   "amplified_swiftness_splash_potion": {
-    "result": "minecraft.splash_potion.effect.swiftness.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.swiftness.ii"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -206,7 +232,8 @@
   },
   "anvil": {
     "result": {
-      "item": "minecraft:anvil"
+      "count": 1,
+      "id": "minecraft:anvil"
     },
     "pattern": [
       "III",
@@ -225,8 +252,8 @@
   },
   "arrow": {
     "result": {
-      "item": "minecraft:arrow",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:arrow"
     },
     "pattern": [
       "X",
@@ -247,7 +274,9 @@
     }
   },
   "awkward_potion": {
-    "result": "minecraft.potion.effect.awkward",
+    "result": {
+      "id": "minecraft.potion.effect.awkward"
+    },
     "reagent": {
       "item": "minecraft:nether_wart"
     },
@@ -257,7 +286,9 @@
     }
   },
   "baked_potato": {
-    "result": "minecraft:baked_potato",
+    "result": {
+      "id": "minecraft:baked_potato"
+    },
     "ingredient": {
       "item": "minecraft:potato"
     },
@@ -265,7 +296,9 @@
     "experience": 0.35
   },
   "baked_potato_from_campfire_cooking": {
-    "result": "minecraft:baked_potato",
+    "result": {
+      "id": "minecraft:baked_potato"
+    },
     "ingredient": {
       "item": "minecraft:potato"
     },
@@ -273,7 +306,9 @@
     "experience": 0.35
   },
   "baked_potato_from_smoking": {
-    "result": "minecraft:baked_potato",
+    "result": {
+      "id": "minecraft:baked_potato"
+    },
     "ingredient": {
       "item": "minecraft:potato"
     },
@@ -282,7 +317,8 @@
   },
   "beacon": {
     "result": {
-      "item": "minecraft:beacon"
+      "count": 1,
+      "id": "minecraft:beacon"
     },
     "pattern": [
       "GGG",
@@ -304,8 +340,8 @@
   },
   "birch_planks": {
     "result": {
-      "item": "minecraft:birch_planks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:birch_planks"
     },
     "ingredients": [
       {
@@ -319,8 +355,8 @@
   },
   "birch_slab": {
     "result": {
-      "item": "minecraft:birch_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:birch_slab"
     },
     "pattern": [
       "###"
@@ -334,8 +370,8 @@
   },
   "birch_stairs": {
     "result": {
-      "item": "minecraft:birch_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:birch_stairs"
     },
     "pattern": [
       "#  ",
@@ -351,7 +387,8 @@
   },
   "black_banner": {
     "result": {
-      "item": "minecraft:black_banner"
+      "count": 1,
+      "id": "minecraft:black_banner"
     },
     "pattern": [
       "###",
@@ -370,8 +407,8 @@
   },
   "black_carpet": {
     "result": {
-      "item": "minecraft:black_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:black_carpet"
     },
     "pattern": [
       "##"
@@ -385,8 +422,8 @@
   },
   "black_stained_glass_legacy": {
     "result": {
-      "item": "minecraft:black_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:black_stained_glass"
     },
     "pattern": [
       "###",
@@ -408,8 +445,8 @@
   },
   "black_stained_glass_pane": {
     "result": {
-      "item": "minecraft:black_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:black_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -424,8 +461,8 @@
   },
   "black_stained_glass_pane_from_glass_pane_legacy": {
     "result": {
-      "item": "minecraft:black_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:black_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -447,8 +484,8 @@
   },
   "black_terracotta_legacy": {
     "result": {
-      "item": "minecraft:black_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:black_terracotta"
     },
     "pattern": [
       "###",
@@ -470,7 +507,7 @@
   },
   "black_wool_legacy": {
     "result": {
-      "item": "minecraft:black_wool"
+      "id": "minecraft:black_wool"
     },
     "ingredients": [
       {
@@ -487,8 +524,8 @@
   },
   "blaze_powder": {
     "result": {
-      "item": "minecraft:blaze_powder",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:blaze_powder"
     },
     "ingredients": [
       {
@@ -499,7 +536,8 @@
   },
   "blue_banner": {
     "result": {
-      "item": "minecraft:blue_banner"
+      "count": 1,
+      "id": "minecraft:blue_banner"
     },
     "pattern": [
       "###",
@@ -518,8 +556,8 @@
   },
   "blue_carpet": {
     "result": {
-      "item": "minecraft:blue_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:blue_carpet"
     },
     "pattern": [
       "##"
@@ -533,8 +571,8 @@
   },
   "blue_stained_glass_legacy": {
     "result": {
-      "item": "minecraft:blue_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:blue_stained_glass"
     },
     "pattern": [
       "###",
@@ -556,8 +594,8 @@
   },
   "blue_stained_glass_pane": {
     "result": {
-      "item": "minecraft:blue_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:blue_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -572,8 +610,8 @@
   },
   "blue_stained_glass_pane_from_glass_pane_legacy": {
     "result": {
-      "item": "minecraft:blue_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:blue_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -595,8 +633,8 @@
   },
   "blue_terracotta_legacy": {
     "result": {
-      "item": "minecraft:blue_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:blue_terracotta"
     },
     "pattern": [
       "###",
@@ -618,7 +656,7 @@
   },
   "blue_wool_legacy": {
     "result": {
-      "item": "minecraft:blue_wool"
+      "id": "minecraft:blue_wool"
     },
     "ingredients": [
       {
@@ -635,8 +673,8 @@
   },
   "bone_meal": {
     "result": {
-      "item": "minecraft:bone_meal",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:bone_meal"
     },
     "ingredients": [
       {
@@ -647,7 +685,8 @@
   },
   "book": {
     "result": {
-      "item": "minecraft:book"
+      "count": 1,
+      "id": "minecraft:book"
     },
     "ingredients": [
       {
@@ -667,7 +706,8 @@
   },
   "bookshelf": {
     "result": {
-      "item": "minecraft:bookshelf"
+      "count": 1,
+      "id": "minecraft:bookshelf"
     },
     "pattern": [
       "###",
@@ -689,7 +729,8 @@
   },
   "bow": {
     "result": {
-      "item": "minecraft:bow"
+      "count": 1,
+      "id": "minecraft:bow"
     },
     "pattern": [
       " #X",
@@ -708,8 +749,8 @@
   },
   "bowl": {
     "result": {
-      "item": "minecraft:bowl",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:bowl"
     },
     "pattern": [
       "# #",
@@ -727,7 +768,8 @@
   },
   "bread": {
     "result": {
-      "item": "minecraft:bread"
+      "count": 1,
+      "id": "minecraft:bread"
     },
     "pattern": [
       "###"
@@ -741,7 +783,7 @@
   },
   "brewing_stand": {
     "result": {
-      "item": "minecraft:brewing_stand"
+      "id": "minecraft:brewing_stand"
     },
     "pattern": [
       " B ",
@@ -758,7 +800,9 @@
     }
   },
   "brick": {
-    "result": "minecraft:brick",
+    "result": {
+      "id": "minecraft:brick"
+    },
     "ingredient": {
       "item": "minecraft:clay_ball"
     },
@@ -767,8 +811,8 @@
   },
   "brick_slab": {
     "result": {
-      "item": "minecraft:brick_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:brick_slab"
     },
     "pattern": [
       "###"
@@ -782,8 +826,8 @@
   },
   "brick_stairs": {
     "result": {
-      "item": "minecraft:brick_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:brick_stairs"
     },
     "pattern": [
       "#  ",
@@ -799,7 +843,8 @@
   },
   "bricks": {
     "result": {
-      "item": "minecraft:bricks"
+      "count": 1,
+      "id": "minecraft:bricks"
     },
     "pattern": [
       "##",
@@ -814,7 +859,8 @@
   },
   "brown_banner": {
     "result": {
-      "item": "minecraft:brown_banner"
+      "count": 1,
+      "id": "minecraft:brown_banner"
     },
     "pattern": [
       "###",
@@ -833,8 +879,8 @@
   },
   "brown_carpet": {
     "result": {
-      "item": "minecraft:brown_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:brown_carpet"
     },
     "pattern": [
       "##"
@@ -848,8 +894,8 @@
   },
   "brown_stained_glass_legacy": {
     "result": {
-      "item": "minecraft:brown_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:brown_stained_glass"
     },
     "pattern": [
       "###",
@@ -871,8 +917,8 @@
   },
   "brown_stained_glass_pane": {
     "result": {
-      "item": "minecraft:brown_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:brown_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -887,8 +933,8 @@
   },
   "brown_stained_glass_pane_from_glass_pane_legacy": {
     "result": {
-      "item": "minecraft:brown_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:brown_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -910,8 +956,8 @@
   },
   "brown_terracotta_legacy": {
     "result": {
-      "item": "minecraft:brown_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:brown_terracotta"
     },
     "pattern": [
       "###",
@@ -933,7 +979,7 @@
   },
   "brown_wool_legacy": {
     "result": {
-      "item": "minecraft:brown_wool"
+      "id": "minecraft:brown_wool"
     },
     "ingredients": [
       {
@@ -950,7 +996,8 @@
   },
   "bucket": {
     "result": {
-      "item": "minecraft:bucket"
+      "count": 1,
+      "id": "minecraft:bucket"
     },
     "pattern": [
       "# #",
@@ -965,7 +1012,8 @@
   },
   "cake": {
     "result": {
-      "item": "minecraft:cake"
+      "count": 1,
+      "id": "minecraft:cake"
     },
     "pattern": [
       "AAA",
@@ -995,7 +1043,8 @@
   },
   "carrot_on_a_stick": {
     "result": {
-      "item": "minecraft:carrot_on_a_stick"
+      "count": 1,
+      "id": "minecraft:carrot_on_a_stick"
     },
     "pattern": [
       "# ",
@@ -1013,7 +1062,8 @@
   },
   "cauldron": {
     "result": {
-      "item": "minecraft:cauldron"
+      "count": 1,
+      "id": "minecraft:cauldron"
     },
     "pattern": [
       "# #",
@@ -1029,7 +1079,7 @@
   },
   "chainmail_boots": {
     "result": {
-      "item": "minecraft:chainmail_boots"
+      "id": "minecraft:chainmail_boots"
     },
     "pattern": [
       "X X",
@@ -1047,7 +1097,7 @@
   },
   "chainmail_chestplate": {
     "result": {
-      "item": "minecraft:chainmail_chestplate"
+      "id": "minecraft:chainmail_chestplate"
     },
     "pattern": [
       "X X",
@@ -1066,7 +1116,7 @@
   },
   "chainmail_helmet": {
     "result": {
-      "item": "minecraft:chainmail_helmet"
+      "id": "minecraft:chainmail_helmet"
     },
     "pattern": [
       "XXX",
@@ -1084,7 +1134,7 @@
   },
   "chainmail_leggings": {
     "result": {
-      "item": "minecraft:chainmail_leggings"
+      "id": "minecraft:chainmail_leggings"
     },
     "pattern": [
       "XXX",
@@ -1102,7 +1152,9 @@
     }
   },
   "charcoal": {
-    "result": "minecraft:charcoal",
+    "result": {
+      "id": "minecraft:charcoal"
+    },
     "ingredient": {
       "tag": "minecraft:logs_that_burn"
     },
@@ -1114,7 +1166,8 @@
   },
   "chest": {
     "result": {
-      "item": "minecraft:chest"
+      "count": 1,
+      "id": "minecraft:chest"
     },
     "pattern": [
       "###",
@@ -1133,7 +1186,8 @@
   },
   "chest_minecart": {
     "result": {
-      "item": "minecraft:chest_minecart"
+      "count": 1,
+      "id": "minecraft:chest_minecart"
     },
     "ingredients": [
       {
@@ -1152,7 +1206,8 @@
   },
   "chiseled_quartz_block": {
     "result": {
-      "item": "minecraft:chiseled_quartz_block"
+      "count": 1,
+      "id": "minecraft:chiseled_quartz_block"
     },
     "pattern": [
       "#",
@@ -1167,7 +1222,8 @@
   },
   "chiseled_red_sandstone": {
     "result": {
-      "item": "minecraft:chiseled_red_sandstone"
+      "count": 1,
+      "id": "minecraft:chiseled_red_sandstone"
     },
     "pattern": [
       "#",
@@ -1182,7 +1238,8 @@
   },
   "chiseled_sandstone": {
     "result": {
-      "item": "minecraft:chiseled_sandstone"
+      "count": 1,
+      "id": "minecraft:chiseled_sandstone"
     },
     "pattern": [
       "#",
@@ -1197,7 +1254,8 @@
   },
   "clay": {
     "result": {
-      "item": "minecraft:clay"
+      "count": 1,
+      "id": "minecraft:clay"
     },
     "pattern": [
       "##",
@@ -1212,7 +1270,8 @@
   },
   "clock": {
     "result": {
-      "item": "minecraft:clock"
+      "count": 1,
+      "id": "minecraft:clock"
     },
     "pattern": [
       " # ",
@@ -1231,8 +1290,8 @@
   },
   "coal": {
     "result": {
-      "item": "minecraft:coal",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:coal"
     },
     "ingredients": [
       {
@@ -1243,7 +1302,8 @@
   },
   "coal_block": {
     "result": {
-      "item": "minecraft:coal_block"
+      "count": 1,
+      "id": "minecraft:coal_block"
     },
     "pattern": [
       "###",
@@ -1258,7 +1318,9 @@
     }
   },
   "coal_from_smelting_coal_ore": {
-    "result": "minecraft:coal",
+    "result": {
+      "id": "minecraft:coal"
+    },
     "ingredient": {
       "item": "minecraft:coal_ore"
     },
@@ -1267,8 +1329,8 @@
   },
   "cobblestone_stairs": {
     "result": {
-      "item": "minecraft:cobblestone_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:cobblestone_stairs"
     },
     "pattern": [
       "#  ",
@@ -1284,8 +1346,8 @@
   },
   "cobblestone_wall": {
     "result": {
-      "item": "minecraft:cobblestone_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:cobblestone_wall"
     },
     "pattern": [
       "###",
@@ -1300,7 +1362,8 @@
   },
   "comparator": {
     "result": {
-      "item": "minecraft:comparator"
+      "count": 1,
+      "id": "minecraft:comparator"
     },
     "pattern": [
       " # ",
@@ -1322,7 +1385,8 @@
   },
   "compass": {
     "result": {
-      "item": "minecraft:compass"
+      "count": 1,
+      "id": "minecraft:compass"
     },
     "pattern": [
       " # ",
@@ -1340,7 +1404,9 @@
     }
   },
   "cooked_beef": {
-    "result": "minecraft:cooked_beef",
+    "result": {
+      "id": "minecraft:cooked_beef"
+    },
     "ingredient": {
       "item": "minecraft:beef"
     },
@@ -1348,7 +1414,9 @@
     "experience": 0.35
   },
   "cooked_beef_from_campfire_cooking": {
-    "result": "minecraft:cooked_beef",
+    "result": {
+      "id": "minecraft:cooked_beef"
+    },
     "ingredient": {
       "item": "minecraft:beef"
     },
@@ -1356,7 +1424,9 @@
     "experience": 0.35
   },
   "cooked_beef_from_smoking": {
-    "result": "minecraft:cooked_beef",
+    "result": {
+      "id": "minecraft:cooked_beef"
+    },
     "ingredient": {
       "item": "minecraft:beef"
     },
@@ -1364,7 +1434,9 @@
     "experience": 0.35
   },
   "cooked_chicken": {
-    "result": "minecraft:cooked_chicken",
+    "result": {
+      "id": "minecraft:cooked_chicken"
+    },
     "ingredient": {
       "item": "minecraft:chicken"
     },
@@ -1372,7 +1444,9 @@
     "experience": 0.35
   },
   "cooked_chicken_from_campfire_cooking": {
-    "result": "minecraft:cooked_chicken",
+    "result": {
+      "id": "minecraft:cooked_chicken"
+    },
     "ingredient": {
       "item": "minecraft:chicken"
     },
@@ -1380,7 +1454,9 @@
     "experience": 0.35
   },
   "cooked_chicken_from_smoking": {
-    "result": "minecraft:cooked_chicken",
+    "result": {
+      "id": "minecraft:cooked_chicken"
+    },
     "ingredient": {
       "item": "minecraft:chicken"
     },
@@ -1388,7 +1464,9 @@
     "experience": 0.35
   },
   "cooked_cod": {
-    "result": "minecraft:cooked_cod",
+    "result": {
+      "id": "minecraft:cooked_cod"
+    },
     "ingredient": {
       "item": "minecraft:cod"
     },
@@ -1396,7 +1474,9 @@
     "experience": 0.35
   },
   "cooked_cod_from_campfire_cooking": {
-    "result": "minecraft:cooked_cod",
+    "result": {
+      "id": "minecraft:cooked_cod"
+    },
     "ingredient": {
       "item": "minecraft:cod"
     },
@@ -1404,7 +1484,9 @@
     "experience": 0.35
   },
   "cooked_cod_from_smoking": {
-    "result": "minecraft:cooked_cod",
+    "result": {
+      "id": "minecraft:cooked_cod"
+    },
     "ingredient": {
       "item": "minecraft:cod"
     },
@@ -1412,7 +1494,9 @@
     "experience": 0.35
   },
   "cooked_mutton": {
-    "result": "minecraft:cooked_mutton",
+    "result": {
+      "id": "minecraft:cooked_mutton"
+    },
     "ingredient": {
       "item": "minecraft:mutton"
     },
@@ -1420,7 +1504,9 @@
     "experience": 0.35
   },
   "cooked_porkchop": {
-    "result": "minecraft:cooked_porkchop",
+    "result": {
+      "id": "minecraft:cooked_porkchop"
+    },
     "ingredient": {
       "item": "minecraft:porkchop"
     },
@@ -1428,7 +1514,9 @@
     "experience": 0.35
   },
   "cooked_porkchop_from_campfire_cooking": {
-    "result": "minecraft:cooked_porkchop",
+    "result": {
+      "id": "minecraft:cooked_porkchop"
+    },
     "ingredient": {
       "item": "minecraft:porkchop"
     },
@@ -1436,7 +1524,9 @@
     "experience": 0.35
   },
   "cooked_porkchop_from_smoking": {
-    "result": "minecraft:cooked_porkchop",
+    "result": {
+      "id": "minecraft:cooked_porkchop"
+    },
     "ingredient": {
       "item": "minecraft:porkchop"
     },
@@ -1444,7 +1534,9 @@
     "experience": 0.35
   },
   "cooked_rabbit": {
-    "result": "minecraft:cooked_rabbit",
+    "result": {
+      "id": "minecraft:cooked_rabbit"
+    },
     "ingredient": {
       "item": "minecraft:rabbit"
     },
@@ -1452,7 +1544,9 @@
     "experience": 0.35
   },
   "cooked_rabbit_from_campfire_cooking": {
-    "result": "minecraft:cooked_rabbit",
+    "result": {
+      "id": "minecraft:cooked_rabbit"
+    },
     "ingredient": {
       "item": "minecraft:rabbit"
     },
@@ -1460,7 +1554,9 @@
     "experience": 0.35
   },
   "cooked_rabbit_from_smoking": {
-    "result": "minecraft:cooked_rabbit",
+    "result": {
+      "id": "minecraft:cooked_rabbit"
+    },
     "ingredient": {
       "item": "minecraft:rabbit"
     },
@@ -1468,7 +1564,9 @@
     "experience": 0.35
   },
   "cooked_salmon": {
-    "result": "minecraft:cooked_salmon",
+    "result": {
+      "id": "minecraft:cooked_salmon"
+    },
     "ingredient": {
       "item": "minecraft:salmon"
     },
@@ -1476,7 +1574,9 @@
     "experience": 0.35
   },
   "cooked_salmon_from_campfire_cooking": {
-    "result": "minecraft:cooked_salmon",
+    "result": {
+      "id": "minecraft:cooked_salmon"
+    },
     "ingredient": {
       "item": "minecraft:salmon"
     },
@@ -1484,7 +1584,9 @@
     "experience": 0.35
   },
   "cooked_salmon_from_smoking": {
-    "result": "minecraft:cooked_salmon",
+    "result": {
+      "id": "minecraft:cooked_salmon"
+    },
     "ingredient": {
       "item": "minecraft:salmon"
     },
@@ -1493,8 +1595,8 @@
   },
   "cookie": {
     "result": {
-      "item": "minecraft:cookie",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:cookie"
     },
     "pattern": [
       "#X#"
@@ -1511,7 +1613,8 @@
   },
   "crafting_table": {
     "result": {
-      "item": "minecraft:crafting_table"
+      "count": 1,
+      "id": "minecraft:crafting_table"
     },
     "pattern": [
       "##",
@@ -1529,7 +1632,8 @@
   },
   "cyan_banner": {
     "result": {
-      "item": "minecraft:cyan_banner"
+      "count": 1,
+      "id": "minecraft:cyan_banner"
     },
     "pattern": [
       "###",
@@ -1548,8 +1652,8 @@
   },
   "cyan_carpet": {
     "result": {
-      "item": "minecraft:cyan_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:cyan_carpet"
     },
     "pattern": [
       "##"
@@ -1563,8 +1667,8 @@
   },
   "cyan_dye_legacy": {
     "result": {
-      "item": "minecraft:cyan_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:cyan_dye"
     },
     "ingredients": [
       {
@@ -1581,8 +1685,8 @@
   },
   "cyan_stained_glass": {
     "result": {
-      "item": "minecraft:cyan_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:cyan_stained_glass"
     },
     "pattern": [
       "###",
@@ -1601,8 +1705,8 @@
   },
   "cyan_stained_glass_pane": {
     "result": {
-      "item": "minecraft:cyan_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:cyan_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -1617,8 +1721,8 @@
   },
   "cyan_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:cyan_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:cyan_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -1637,8 +1741,8 @@
   },
   "cyan_terracotta": {
     "result": {
-      "item": "minecraft:cyan_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:cyan_terracotta"
     },
     "pattern": [
       "###",
@@ -1657,7 +1761,7 @@
   },
   "cyan_wool": {
     "result": {
-      "item": "minecraft:cyan_wool"
+      "id": "minecraft:cyan_wool"
     },
     "ingredients": [
       {
@@ -1674,8 +1778,8 @@
   },
   "dark_oak_planks": {
     "result": {
-      "item": "minecraft:dark_oak_planks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:dark_oak_planks"
     },
     "ingredients": [
       {
@@ -1689,8 +1793,8 @@
   },
   "dark_oak_slab": {
     "result": {
-      "item": "minecraft:dark_oak_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:dark_oak_slab"
     },
     "pattern": [
       "###"
@@ -1704,8 +1808,8 @@
   },
   "dark_oak_stairs": {
     "result": {
-      "item": "minecraft:dark_oak_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:dark_oak_stairs"
     },
     "pattern": [
       "#  ",
@@ -1721,7 +1825,8 @@
   },
   "daylight_detector": {
     "result": {
-      "item": "minecraft:daylight_detector"
+      "count": 1,
+      "id": "minecraft:daylight_detector"
     },
     "pattern": [
       "GGG",
@@ -1746,8 +1851,8 @@
   },
   "detector_rail": {
     "result": {
-      "item": "minecraft:detector_rail",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:detector_rail"
     },
     "pattern": [
       "X X",
@@ -1769,8 +1874,8 @@
   },
   "diamond": {
     "result": {
-      "item": "minecraft:diamond",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:diamond"
     },
     "ingredients": [
       {
@@ -1781,7 +1886,8 @@
   },
   "diamond_axe": {
     "result": {
-      "item": "minecraft:diamond_axe"
+      "count": 1,
+      "id": "minecraft:diamond_axe"
     },
     "pattern": [
       "XX",
@@ -1800,7 +1906,8 @@
   },
   "diamond_block": {
     "result": {
-      "item": "minecraft:diamond_block"
+      "count": 1,
+      "id": "minecraft:diamond_block"
     },
     "pattern": [
       "###",
@@ -1816,7 +1923,8 @@
   },
   "diamond_boots": {
     "result": {
-      "item": "minecraft:diamond_boots"
+      "count": 1,
+      "id": "minecraft:diamond_boots"
     },
     "pattern": [
       "X X",
@@ -1831,7 +1939,8 @@
   },
   "diamond_chestplate": {
     "result": {
-      "item": "minecraft:diamond_chestplate"
+      "count": 1,
+      "id": "minecraft:diamond_chestplate"
     },
     "pattern": [
       "X X",
@@ -1846,7 +1955,9 @@
     }
   },
   "diamond_from_blasting_diamond_ore": {
-    "result": "minecraft:diamond",
+    "result": {
+      "id": "minecraft:diamond"
+    },
     "ingredient": {
       "item": "minecraft:diamond_ore"
     },
@@ -1854,7 +1965,9 @@
     "experience": 1
   },
   "diamond_from_smelting_diamond_ore": {
-    "result": "minecraft:diamond",
+    "result": {
+      "id": "minecraft:diamond"
+    },
     "ingredient": {
       "item": "minecraft:diamond_ore"
     },
@@ -1863,7 +1976,8 @@
   },
   "diamond_helmet": {
     "result": {
-      "item": "minecraft:diamond_helmet"
+      "count": 1,
+      "id": "minecraft:diamond_helmet"
     },
     "pattern": [
       "XXX",
@@ -1878,7 +1992,8 @@
   },
   "diamond_hoe": {
     "result": {
-      "item": "minecraft:diamond_hoe"
+      "count": 1,
+      "id": "minecraft:diamond_hoe"
     },
     "pattern": [
       "XX",
@@ -1897,7 +2012,8 @@
   },
   "diamond_leggings": {
     "result": {
-      "item": "minecraft:diamond_leggings"
+      "count": 1,
+      "id": "minecraft:diamond_leggings"
     },
     "pattern": [
       "XXX",
@@ -1913,7 +2029,8 @@
   },
   "diamond_pickaxe": {
     "result": {
-      "item": "minecraft:diamond_pickaxe"
+      "count": 1,
+      "id": "minecraft:diamond_pickaxe"
     },
     "pattern": [
       "XXX",
@@ -1932,7 +2049,8 @@
   },
   "diamond_shovel": {
     "result": {
-      "item": "minecraft:diamond_shovel"
+      "count": 1,
+      "id": "minecraft:diamond_shovel"
     },
     "pattern": [
       "X",
@@ -1951,7 +2069,8 @@
   },
   "diamond_sword": {
     "result": {
-      "item": "minecraft:diamond_sword"
+      "count": 1,
+      "id": "minecraft:diamond_sword"
     },
     "pattern": [
       "X",
@@ -1970,7 +2089,8 @@
   },
   "dispenser": {
     "result": {
-      "item": "minecraft:dispenser"
+      "count": 1,
+      "id": "minecraft:dispenser"
     },
     "pattern": [
       "###",
@@ -1992,7 +2112,8 @@
   },
   "dropper": {
     "result": {
-      "item": "minecraft:dropper"
+      "count": 1,
+      "id": "minecraft:dropper"
     },
     "pattern": [
       "###",
@@ -2011,8 +2132,8 @@
   },
   "emerald": {
     "result": {
-      "item": "minecraft:emerald",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:emerald"
     },
     "ingredients": [
       {
@@ -2023,7 +2144,8 @@
   },
   "emerald_block": {
     "result": {
-      "item": "minecraft:emerald_block"
+      "count": 1,
+      "id": "minecraft:emerald_block"
     },
     "pattern": [
       "###",
@@ -2038,7 +2160,9 @@
     }
   },
   "emerald_from_blasting_emerald_ore": {
-    "result": "minecraft:emerald",
+    "result": {
+      "id": "minecraft:emerald"
+    },
     "ingredient": {
       "item": "minecraft:emerald_ore"
     },
@@ -2046,7 +2170,9 @@
     "experience": 1
   },
   "emerald_from_smelting_emerald_ore": {
-    "result": "minecraft:emerald",
+    "result": {
+      "id": "minecraft:emerald"
+    },
     "ingredient": {
       "item": "minecraft:emerald_ore"
     },
@@ -2055,7 +2181,7 @@
   },
   "enchanted_golden_apple": {
     "result": {
-      "item": "minecraft:enchanted_golden_apple"
+      "id": "minecraft:enchanted_golden_apple"
     },
     "pattern": [
       "###",
@@ -2077,7 +2203,8 @@
   },
   "enchanting_table": {
     "result": {
-      "item": "minecraft:enchanting_table"
+      "count": 1,
+      "id": "minecraft:enchanting_table"
     },
     "pattern": [
       " B ",
@@ -2099,7 +2226,8 @@
   },
   "ender_chest": {
     "result": {
-      "item": "minecraft:ender_chest"
+      "count": 1,
+      "id": "minecraft:ender_chest"
     },
     "pattern": [
       "###",
@@ -2118,7 +2246,8 @@
   },
   "ender_eye": {
     "result": {
-      "item": "minecraft:ender_eye"
+      "count": 1,
+      "id": "minecraft:ender_eye"
     },
     "ingredients": [
       {
@@ -2131,7 +2260,9 @@
     "type": "minecraft:crafting_shapeless"
   },
   "extended_fire_resistance_potion": {
-    "result": "minecraft.potion.effect.fire_resistance.extended",
+    "result": {
+      "id": "minecraft.potion.effect.fire_resistance.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -2141,7 +2272,9 @@
     }
   },
   "extended_fire_resistance_splash_potion": {
-    "result": "minecraft.splash_potion.effect.fire_resistance.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.fire_resistance.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -2151,7 +2284,9 @@
     }
   },
   "extended_invisibility_potion": {
-    "result": "minecraft.potion.effect.invisibility.extended",
+    "result": {
+      "id": "minecraft.potion.effect.invisibility.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -2161,7 +2296,9 @@
     }
   },
   "extended_invisibility_potion_from_corrupt": {
-    "result": "minecraft.potion.effect.invisibility.extended",
+    "result": {
+      "id": "minecraft.potion.effect.invisibility.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -2171,7 +2308,9 @@
     }
   },
   "extended_invisibility_splash_potion": {
-    "result": "minecraft.splash_potion.effect.invisibility.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.invisibility.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -2181,7 +2320,9 @@
     }
   },
   "extended_night_vision_potion": {
-    "result": "minecraft.potion.effect.night_vision.extended",
+    "result": {
+      "id": "minecraft.potion.effect.night_vision.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -2191,7 +2332,9 @@
     }
   },
   "extended_night_vision_splash_potion": {
-    "result": "minecraft.splash_potion.effect.night_vision.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.night_vision.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -2201,7 +2344,9 @@
     }
   },
   "extended_poison_potion": {
-    "result": "minecraft.potion.effect.poison.extended",
+    "result": {
+      "id": "minecraft.potion.effect.poison.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -2211,7 +2356,9 @@
     }
   },
   "extended_poison_splash_potion": {
-    "result": "minecraft.splash_potion.effect.poison.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.poison.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -2221,7 +2368,9 @@
     }
   },
   "extended_regeneration_potion": {
-    "result": "minecraft.potion.effect.regeneration.extended",
+    "result": {
+      "id": "minecraft.potion.effect.regeneration.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -2231,7 +2380,9 @@
     }
   },
   "extended_regeneration_splash_potion": {
-    "result": "minecraft.splash_potion.effect.regeneration.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.regeneration.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -2241,7 +2392,9 @@
     }
   },
   "extended_slowness_potion": {
-    "result": "minecraft.potion.effect.slowness.extended",
+    "result": {
+      "id": "minecraft.potion.effect.slowness.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -2251,7 +2404,9 @@
     }
   },
   "extended_slowness_potion_from_corrupt": {
-    "result": "minecraft.potion.effect.slowness.extended",
+    "result": {
+      "id": "minecraft.potion.effect.slowness.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -2266,7 +2421,9 @@
     ]
   },
   "extended_slowness_potion_from_corrupt_legacy": {
-    "result": "minecraft.potion.effect.slowness.extended",
+    "result": {
+      "id": "minecraft.potion.effect.slowness.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -2279,7 +2436,9 @@
     }
   },
   "extended_slowness_splash_potion": {
-    "result": "minecraft.splash_potion.effect.slowness.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slowness.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -2289,7 +2448,9 @@
     }
   },
   "extended_strength_potion": {
-    "result": "minecraft.potion.effect.strength.extended",
+    "result": {
+      "id": "minecraft.potion.effect.strength.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -2299,7 +2460,9 @@
     }
   },
   "extended_strength_splash_potion": {
-    "result": "minecraft.splash_potion.effect.strength.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.strength.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -2309,7 +2472,9 @@
     }
   },
   "extended_swiftness_potion": {
-    "result": "minecraft.potion.effect.swiftness.extended",
+    "result": {
+      "id": "minecraft.potion.effect.swiftness.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -2319,7 +2484,9 @@
     }
   },
   "extended_swiftness_splash_potion": {
-    "result": "minecraft.splash_potion.effect.swiftness.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.swiftness.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -2329,7 +2496,9 @@
     }
   },
   "extended_water_breathing_potion": {
-    "result": "minecraft.potion.effect.water_breathing.extended",
+    "result": {
+      "id": "minecraft.potion.effect.water_breathing.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -2339,7 +2508,9 @@
     }
   },
   "extended_water_breathing_splash_potion": {
-    "result": "minecraft.splash_potion.effect.water_breathing.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.water_breathing.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -2349,7 +2520,9 @@
     }
   },
   "extended_weakness_potion": {
-    "result": "minecraft.potion.effect.weakness.extended",
+    "result": {
+      "id": "minecraft.potion.effect.weakness.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -2359,7 +2532,9 @@
     }
   },
   "extended_weakness_potion_from_corrupt": {
-    "result": "minecraft.potion.effect.weakness.extended",
+    "result": {
+      "id": "minecraft.potion.effect.weakness.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -2377,7 +2552,9 @@
     ]
   },
   "extended_weakness_potion_legacy": {
-    "result": "minecraft.potion.effect.weakness.extended",
+    "result": {
+      "id": "minecraft.potion.effect.weakness.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -2390,7 +2567,9 @@
     }
   },
   "extended_weakness_splash_potion": {
-    "result": "minecraft.splash_potion.effect.weakness.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.weakness.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -2401,7 +2580,8 @@
   },
   "fermented_spider_eye": {
     "result": {
-      "item": "minecraft:fermented_spider_eye"
+      "count": 1,
+      "id": "minecraft:fermented_spider_eye"
     },
     "ingredients": [
       {
@@ -2418,8 +2598,8 @@
   },
   "fire_charge": {
     "result": {
-      "item": "minecraft:fire_charge",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:fire_charge"
     },
     "ingredients": [
       {
@@ -2443,7 +2623,9 @@
     }
   },
   "fire_resistance_potion": {
-    "result": "minecraft.potion.effect.fire_resistance",
+    "result": {
+      "id": "minecraft.potion.effect.fire_resistance"
+    },
     "reagent": {
       "item": "minecraft:magma_cream"
     },
@@ -2453,7 +2635,9 @@
     }
   },
   "fire_resistance_splash_potion": {
-    "result": "minecraft.splash_potion.effect.fire_resistance",
+    "result": {
+      "id": "minecraft.splash_potion.effect.fire_resistance"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -2464,7 +2648,7 @@
   },
   "firework_rocket": {
     "result": {
-      "item": "minecraft:firework_rocket"
+      "id": "minecraft:firework_rocket"
     },
     "ingredients": [
       {
@@ -2489,7 +2673,7 @@
   },
   "firework_star_fade_legacy": {
     "result": {
-      "item": "minecraft:firework_star"
+      "id": "minecraft:firework_star"
     },
     "ingredients": [
       {
@@ -2559,7 +2743,7 @@
   },
   "firework_star_legacy": {
     "result": {
-      "item": "minecraft:firework_star"
+      "id": "minecraft:firework_star"
     },
     "ingredients": [
       {
@@ -2664,7 +2848,8 @@
   },
   "fishing_rod": {
     "result": {
-      "item": "minecraft:fishing_rod"
+      "count": 1,
+      "id": "minecraft:fishing_rod"
     },
     "pattern": [
       "  #",
@@ -2683,7 +2868,8 @@
   },
   "flint_and_steel": {
     "result": {
-      "item": "minecraft:flint_and_steel"
+      "count": 1,
+      "id": "minecraft:flint_and_steel"
     },
     "ingredients": [
       {
@@ -2697,7 +2883,8 @@
   },
   "flower_pot": {
     "result": {
-      "item": "minecraft:flower_pot"
+      "count": 1,
+      "id": "minecraft:flower_pot"
     },
     "pattern": [
       "# #",
@@ -2712,7 +2899,8 @@
   },
   "furnace": {
     "result": {
-      "item": "minecraft:furnace"
+      "count": 1,
+      "id": "minecraft:furnace"
     },
     "pattern": [
       "###",
@@ -2731,7 +2919,8 @@
   },
   "furnace_minecart": {
     "result": {
-      "item": "minecraft:furnace_minecart"
+      "count": 1,
+      "id": "minecraft:furnace_minecart"
     },
     "ingredients": [
       {
@@ -2749,7 +2938,9 @@
     }
   },
   "glass": {
-    "result": "minecraft:glass",
+    "result": {
+      "id": "minecraft:glass"
+    },
     "ingredient": {
       "tag": "minecraft:smelts_to_glass"
     },
@@ -2761,8 +2952,8 @@
   },
   "glass_bottle": {
     "result": {
-      "item": "minecraft:glass_bottle",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:glass_bottle"
     },
     "pattern": [
       "# #",
@@ -2777,8 +2968,8 @@
   },
   "glass_pane": {
     "result": {
-      "item": "minecraft:glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:glass_pane"
     },
     "pattern": [
       "###",
@@ -2793,7 +2984,8 @@
   },
   "glistering_melon_slice": {
     "result": {
-      "item": "minecraft:glistering_melon_slice"
+      "count": 1,
+      "id": "minecraft:glistering_melon_slice"
     },
     "pattern": [
       "###",
@@ -2812,7 +3004,8 @@
   },
   "glowstone": {
     "result": {
-      "item": "minecraft:glowstone"
+      "count": 1,
+      "id": "minecraft:glowstone"
     },
     "pattern": [
       "##",
@@ -2827,7 +3020,8 @@
   },
   "gold_block": {
     "result": {
-      "item": "minecraft:gold_block"
+      "count": 1,
+      "id": "minecraft:gold_block"
     },
     "pattern": [
       "###",
@@ -2842,7 +3036,9 @@
     }
   },
   "gold_ingot_from_blasting_gold_ore": {
-    "result": "minecraft:gold_ingot",
+    "result": {
+      "id": "minecraft:gold_ingot"
+    },
     "ingredient": {
       "item": "minecraft:gold_ore"
     },
@@ -2851,8 +3047,8 @@
   },
   "gold_ingot_from_gold_block": {
     "result": {
-      "item": "minecraft:gold_ingot",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:gold_ingot"
     },
     "ingredients": [
       {
@@ -2863,7 +3059,8 @@
   },
   "gold_ingot_from_nuggets": {
     "result": {
-      "item": "minecraft:gold_ingot"
+      "count": 1,
+      "id": "minecraft:gold_ingot"
     },
     "pattern": [
       "###",
@@ -2878,7 +3075,9 @@
     }
   },
   "gold_ingot_from_smelting_gold_ore": {
-    "result": "minecraft:gold_ingot",
+    "result": {
+      "id": "minecraft:gold_ingot"
+    },
     "ingredient": {
       "item": "minecraft:gold_ore"
     },
@@ -2887,8 +3086,8 @@
   },
   "gold_nugget": {
     "result": {
-      "item": "minecraft:gold_nugget",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:gold_nugget"
     },
     "ingredients": [
       {
@@ -2898,7 +3097,9 @@
     "type": "minecraft:crafting_shapeless"
   },
   "gold_nugget_from_blasting": {
-    "result": "minecraft:gold_nugget",
+    "result": {
+      "id": "minecraft:gold_nugget"
+    },
     "ingredient": [
       {
         "item": "minecraft:golden_pickaxe"
@@ -2936,7 +3137,8 @@
   },
   "golden_apple": {
     "result": {
-      "item": "minecraft:golden_apple"
+      "count": 1,
+      "id": "minecraft:golden_apple"
     },
     "pattern": [
       "###",
@@ -2955,7 +3157,8 @@
   },
   "golden_axe": {
     "result": {
-      "item": "minecraft:golden_axe"
+      "count": 1,
+      "id": "minecraft:golden_axe"
     },
     "pattern": [
       "XX",
@@ -2974,7 +3177,8 @@
   },
   "golden_boots": {
     "result": {
-      "item": "minecraft:golden_boots"
+      "count": 1,
+      "id": "minecraft:golden_boots"
     },
     "pattern": [
       "X X",
@@ -2989,7 +3193,8 @@
   },
   "golden_carrot": {
     "result": {
-      "item": "minecraft:golden_carrot"
+      "count": 1,
+      "id": "minecraft:golden_carrot"
     },
     "pattern": [
       "###",
@@ -3008,7 +3213,8 @@
   },
   "golden_chestplate": {
     "result": {
-      "item": "minecraft:golden_chestplate"
+      "count": 1,
+      "id": "minecraft:golden_chestplate"
     },
     "pattern": [
       "X X",
@@ -3024,7 +3230,8 @@
   },
   "golden_helmet": {
     "result": {
-      "item": "minecraft:golden_helmet"
+      "count": 1,
+      "id": "minecraft:golden_helmet"
     },
     "pattern": [
       "XXX",
@@ -3039,7 +3246,8 @@
   },
   "golden_hoe": {
     "result": {
-      "item": "minecraft:golden_hoe"
+      "count": 1,
+      "id": "minecraft:golden_hoe"
     },
     "pattern": [
       "XX",
@@ -3058,7 +3266,8 @@
   },
   "golden_leggings": {
     "result": {
-      "item": "minecraft:golden_leggings"
+      "count": 1,
+      "id": "minecraft:golden_leggings"
     },
     "pattern": [
       "XXX",
@@ -3074,7 +3283,8 @@
   },
   "golden_pickaxe": {
     "result": {
-      "item": "minecraft:golden_pickaxe"
+      "count": 1,
+      "id": "minecraft:golden_pickaxe"
     },
     "pattern": [
       "XXX",
@@ -3093,7 +3303,8 @@
   },
   "golden_shovel": {
     "result": {
-      "item": "minecraft:golden_shovel"
+      "count": 1,
+      "id": "minecraft:golden_shovel"
     },
     "pattern": [
       "X",
@@ -3112,7 +3323,8 @@
   },
   "golden_sword": {
     "result": {
-      "item": "minecraft:golden_sword"
+      "count": 1,
+      "id": "minecraft:golden_sword"
     },
     "pattern": [
       "X",
@@ -3131,7 +3343,8 @@
   },
   "gray_banner": {
     "result": {
-      "item": "minecraft:gray_banner"
+      "count": 1,
+      "id": "minecraft:gray_banner"
     },
     "pattern": [
       "###",
@@ -3150,8 +3363,8 @@
   },
   "gray_carpet": {
     "result": {
-      "item": "minecraft:gray_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:gray_carpet"
     },
     "pattern": [
       "##"
@@ -3165,8 +3378,8 @@
   },
   "gray_dye_legacy": {
     "result": {
-      "item": "minecraft:gray_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:gray_dye"
     },
     "ingredients": [
       {
@@ -3183,8 +3396,8 @@
   },
   "gray_stained_glass": {
     "result": {
-      "item": "minecraft:gray_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:gray_stained_glass"
     },
     "pattern": [
       "###",
@@ -3203,8 +3416,8 @@
   },
   "gray_stained_glass_pane": {
     "result": {
-      "item": "minecraft:gray_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:gray_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -3219,8 +3432,8 @@
   },
   "gray_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:gray_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:gray_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -3239,8 +3452,8 @@
   },
   "gray_terracotta": {
     "result": {
-      "item": "minecraft:gray_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:gray_terracotta"
     },
     "pattern": [
       "###",
@@ -3259,7 +3472,7 @@
   },
   "gray_wool": {
     "result": {
-      "item": "minecraft:gray_wool"
+      "id": "minecraft:gray_wool"
     },
     "ingredients": [
       {
@@ -3276,7 +3489,8 @@
   },
   "green_banner": {
     "result": {
-      "item": "minecraft:green_banner"
+      "count": 1,
+      "id": "minecraft:green_banner"
     },
     "pattern": [
       "###",
@@ -3295,8 +3509,8 @@
   },
   "green_carpet": {
     "result": {
-      "item": "minecraft:green_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:green_carpet"
     },
     "pattern": [
       "##"
@@ -3309,7 +3523,9 @@
     }
   },
   "green_dye": {
-    "result": "minecraft:green_dye",
+    "result": {
+      "id": "minecraft:green_dye"
+    },
     "ingredient": {
       "item": "minecraft:cactus"
     },
@@ -3318,8 +3534,8 @@
   },
   "green_stained_glass": {
     "result": {
-      "item": "minecraft:green_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:green_stained_glass"
     },
     "pattern": [
       "###",
@@ -3338,8 +3554,8 @@
   },
   "green_stained_glass_pane": {
     "result": {
-      "item": "minecraft:green_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:green_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -3354,8 +3570,8 @@
   },
   "green_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:green_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:green_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -3374,8 +3590,8 @@
   },
   "green_terracotta": {
     "result": {
-      "item": "minecraft:green_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:green_terracotta"
     },
     "pattern": [
       "###",
@@ -3394,7 +3610,7 @@
   },
   "green_wool": {
     "result": {
-      "item": "minecraft:green_wool"
+      "id": "minecraft:green_wool"
     },
     "ingredients": [
       {
@@ -3410,7 +3626,9 @@
     }
   },
   "harming_potion": {
-    "result": "minecraft.potion.effect.harming",
+    "result": {
+      "id": "minecraft.potion.effect.harming"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -3425,7 +3643,9 @@
     ]
   },
   "harming_potion_from_corrupt_legacy": {
-    "result": "minecraft.potion.effect.harming",
+    "result": {
+      "id": "minecraft.potion.effect.harming"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -3438,7 +3658,9 @@
     }
   },
   "harming_splash_potion": {
-    "result": "minecraft.splash_potion.effect.harming",
+    "result": {
+      "id": "minecraft.splash_potion.effect.harming"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -3449,7 +3671,8 @@
   },
   "hay_block": {
     "result": {
-      "item": "minecraft:hay_block"
+      "count": 1,
+      "id": "minecraft:hay_block"
     },
     "ingredients": [
       {
@@ -3483,7 +3706,9 @@
     "type": "minecraft:crafting_shapeless"
   },
   "healing_potion": {
-    "result": "minecraft.potion.effect.healing",
+    "result": {
+      "id": "minecraft.potion.effect.healing"
+    },
     "reagent": {
       "item": "minecraft:glistering_melon_slice"
     },
@@ -3493,7 +3718,9 @@
     }
   },
   "healing_splash_potion": {
-    "result": "minecraft.splash_potion.effect.healing",
+    "result": {
+      "id": "minecraft.splash_potion.effect.healing"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -3504,7 +3731,8 @@
   },
   "heavy_weighted_pressure_plate": {
     "result": {
-      "item": "minecraft:heavy_weighted_pressure_plate"
+      "count": 1,
+      "id": "minecraft:heavy_weighted_pressure_plate"
     },
     "pattern": [
       "##"
@@ -3518,7 +3746,8 @@
   },
   "hopper": {
     "result": {
-      "item": "minecraft:hopper"
+      "count": 1,
+      "id": "minecraft:hopper"
     },
     "pattern": [
       "I I",
@@ -3537,7 +3766,8 @@
   },
   "hopper_minecart": {
     "result": {
-      "item": "minecraft:hopper_minecart"
+      "count": 1,
+      "id": "minecraft:hopper_minecart"
     },
     "ingredients": [
       {
@@ -3555,7 +3785,9 @@
     }
   },
   "invisibility_potion": {
-    "result": "minecraft.potion.effect.invisibility",
+    "result": {
+      "id": "minecraft.potion.effect.invisibility"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -3565,7 +3797,9 @@
     }
   },
   "invisibility_splash_potion": {
-    "result": "minecraft.splash_potion.effect.invisibility",
+    "result": {
+      "id": "minecraft.splash_potion.effect.invisibility"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -3576,7 +3810,8 @@
   },
   "iron_axe": {
     "result": {
-      "item": "minecraft:iron_axe"
+      "count": 1,
+      "id": "minecraft:iron_axe"
     },
     "pattern": [
       "XX",
@@ -3595,8 +3830,8 @@
   },
   "iron_bars": {
     "result": {
-      "item": "minecraft:iron_bars",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:iron_bars"
     },
     "pattern": [
       "###",
@@ -3611,7 +3846,8 @@
   },
   "iron_block": {
     "result": {
-      "item": "minecraft:iron_block"
+      "count": 1,
+      "id": "minecraft:iron_block"
     },
     "pattern": [
       "###",
@@ -3627,7 +3863,8 @@
   },
   "iron_boots": {
     "result": {
-      "item": "minecraft:iron_boots"
+      "count": 1,
+      "id": "minecraft:iron_boots"
     },
     "pattern": [
       "X X",
@@ -3642,7 +3879,8 @@
   },
   "iron_chestplate": {
     "result": {
-      "item": "minecraft:iron_chestplate"
+      "count": 1,
+      "id": "minecraft:iron_chestplate"
     },
     "pattern": [
       "X X",
@@ -3658,8 +3896,8 @@
   },
   "iron_door": {
     "result": {
-      "item": "minecraft:iron_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:iron_door"
     },
     "pattern": [
       "##",
@@ -3675,7 +3913,8 @@
   },
   "iron_helmet": {
     "result": {
-      "item": "minecraft:iron_helmet"
+      "count": 1,
+      "id": "minecraft:iron_helmet"
     },
     "pattern": [
       "XXX",
@@ -3690,7 +3929,8 @@
   },
   "iron_hoe": {
     "result": {
-      "item": "minecraft:iron_hoe"
+      "count": 1,
+      "id": "minecraft:iron_hoe"
     },
     "pattern": [
       "XX",
@@ -3708,7 +3948,9 @@
     }
   },
   "iron_ingot_from_blasting_iron_ore": {
-    "result": "minecraft:iron_ingot",
+    "result": {
+      "id": "minecraft:iron_ingot"
+    },
     "ingredient": {
       "item": "minecraft:iron_ore"
     },
@@ -3717,8 +3959,8 @@
   },
   "iron_ingot_from_iron_block": {
     "result": {
-      "item": "minecraft:iron_ingot",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:iron_ingot"
     },
     "ingredients": [
       {
@@ -3728,7 +3970,9 @@
     "type": "minecraft:crafting_shapeless"
   },
   "iron_ingot_from_smelting_iron_ore": {
-    "result": "minecraft:iron_ingot",
+    "result": {
+      "id": "minecraft:iron_ingot"
+    },
     "ingredient": {
       "item": "minecraft:iron_ore"
     },
@@ -3737,7 +3981,8 @@
   },
   "iron_leggings": {
     "result": {
-      "item": "minecraft:iron_leggings"
+      "count": 1,
+      "id": "minecraft:iron_leggings"
     },
     "pattern": [
       "XXX",
@@ -3753,7 +3998,8 @@
   },
   "iron_pickaxe": {
     "result": {
-      "item": "minecraft:iron_pickaxe"
+      "count": 1,
+      "id": "minecraft:iron_pickaxe"
     },
     "pattern": [
       "XXX",
@@ -3772,7 +4018,8 @@
   },
   "iron_shovel": {
     "result": {
-      "item": "minecraft:iron_shovel"
+      "count": 1,
+      "id": "minecraft:iron_shovel"
     },
     "pattern": [
       "X",
@@ -3791,7 +4038,8 @@
   },
   "iron_sword": {
     "result": {
-      "item": "minecraft:iron_sword"
+      "count": 1,
+      "id": "minecraft:iron_sword"
     },
     "pattern": [
       "X",
@@ -3810,7 +4058,8 @@
   },
   "item_frame": {
     "result": {
-      "item": "minecraft:item_frame"
+      "count": 1,
+      "id": "minecraft:item_frame"
     },
     "pattern": [
       "###",
@@ -3829,7 +4078,8 @@
   },
   "jack_o_lantern": {
     "result": {
-      "item": "minecraft:jack_o_lantern"
+      "count": 1,
+      "id": "minecraft:jack_o_lantern"
     },
     "pattern": [
       "A",
@@ -3847,7 +4097,8 @@
   },
   "jukebox": {
     "result": {
-      "item": "minecraft:jukebox"
+      "count": 1,
+      "id": "minecraft:jukebox"
     },
     "pattern": [
       "###",
@@ -3869,8 +4120,8 @@
   },
   "jungle_planks": {
     "result": {
-      "item": "minecraft:jungle_planks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:jungle_planks"
     },
     "ingredients": [
       {
@@ -3884,8 +4135,8 @@
   },
   "jungle_slab": {
     "result": {
-      "item": "minecraft:jungle_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:jungle_slab"
     },
     "pattern": [
       "###"
@@ -3899,8 +4150,8 @@
   },
   "jungle_stairs": {
     "result": {
-      "item": "minecraft:jungle_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:jungle_stairs"
     },
     "pattern": [
       "#  ",
@@ -3916,8 +4167,8 @@
   },
   "ladder": {
     "result": {
-      "item": "minecraft:ladder",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:ladder"
     },
     "pattern": [
       "# #",
@@ -3933,7 +4184,8 @@
   },
   "lapis_block": {
     "result": {
-      "item": "minecraft:lapis_block"
+      "count": 1,
+      "id": "minecraft:lapis_block"
     },
     "pattern": [
       "###",
@@ -3949,8 +4201,8 @@
   },
   "lapis_lazuli": {
     "result": {
-      "item": "minecraft:lapis_lazuli",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:lapis_lazuli"
     },
     "ingredients": [
       {
@@ -3960,7 +4212,9 @@
     "type": "minecraft:crafting_shapeless"
   },
   "lapis_lazuli_from_blasting_lapis_ore": {
-    "result": "minecraft:lapis_lazuli",
+    "result": {
+      "id": "minecraft:lapis_lazuli"
+    },
     "ingredient": {
       "item": "minecraft:lapis_ore"
     },
@@ -3968,7 +4222,9 @@
     "experience": 0.2
   },
   "lapis_lazuli_from_smelting_lapis_ore": {
-    "result": "minecraft:lapis_lazuli",
+    "result": {
+      "id": "minecraft:lapis_lazuli"
+    },
     "ingredient": {
       "item": "minecraft:lapis_ore"
     },
@@ -3977,8 +4233,8 @@
   },
   "lead": {
     "result": {
-      "item": "minecraft:lead",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:lead"
     },
     "pattern": [
       "~~ ",
@@ -3997,7 +4253,8 @@
   },
   "leather_boots": {
     "result": {
-      "item": "minecraft:leather_boots"
+      "count": 1,
+      "id": "minecraft:leather_boots"
     },
     "pattern": [
       "X X",
@@ -4012,7 +4269,8 @@
   },
   "leather_chestplate": {
     "result": {
-      "item": "minecraft:leather_chestplate"
+      "count": 1,
+      "id": "minecraft:leather_chestplate"
     },
     "pattern": [
       "X X",
@@ -4028,7 +4286,8 @@
   },
   "leather_helmet": {
     "result": {
-      "item": "minecraft:leather_helmet"
+      "count": 1,
+      "id": "minecraft:leather_helmet"
     },
     "pattern": [
       "XXX",
@@ -4043,7 +4302,8 @@
   },
   "leather_leggings": {
     "result": {
-      "item": "minecraft:leather_leggings"
+      "count": 1,
+      "id": "minecraft:leather_leggings"
     },
     "pattern": [
       "XXX",
@@ -4059,7 +4319,8 @@
   },
   "lever": {
     "result": {
-      "item": "minecraft:lever"
+      "count": 1,
+      "id": "minecraft:lever"
     },
     "pattern": [
       "X",
@@ -4077,7 +4338,8 @@
   },
   "light_blue_banner": {
     "result": {
-      "item": "minecraft:light_blue_banner"
+      "count": 1,
+      "id": "minecraft:light_blue_banner"
     },
     "pattern": [
       "###",
@@ -4096,8 +4358,8 @@
   },
   "light_blue_carpet": {
     "result": {
-      "item": "minecraft:light_blue_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:light_blue_carpet"
     },
     "pattern": [
       "##"
@@ -4111,7 +4373,8 @@
   },
   "light_blue_dye_from_blue_orchid": {
     "result": {
-      "item": "minecraft:light_blue_dye"
+      "count": 1,
+      "id": "minecraft:light_blue_dye"
     },
     "ingredients": [
       {
@@ -4122,8 +4385,8 @@
   },
   "light_blue_dye_from_blue_white_dye_legacy": {
     "result": {
-      "item": "minecraft:light_blue_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:light_blue_dye"
     },
     "ingredients": [
       {
@@ -4140,8 +4403,8 @@
   },
   "light_blue_stained_glass": {
     "result": {
-      "item": "minecraft:light_blue_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:light_blue_stained_glass"
     },
     "pattern": [
       "###",
@@ -4160,8 +4423,8 @@
   },
   "light_blue_stained_glass_pane": {
     "result": {
-      "item": "minecraft:light_blue_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:light_blue_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -4176,8 +4439,8 @@
   },
   "light_blue_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:light_blue_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:light_blue_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -4196,8 +4459,8 @@
   },
   "light_blue_terracotta": {
     "result": {
-      "item": "minecraft:light_blue_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:light_blue_terracotta"
     },
     "pattern": [
       "###",
@@ -4216,7 +4479,7 @@
   },
   "light_blue_wool": {
     "result": {
-      "item": "minecraft:light_blue_wool"
+      "id": "minecraft:light_blue_wool"
     },
     "ingredients": [
       {
@@ -4233,7 +4496,8 @@
   },
   "light_gray_banner": {
     "result": {
-      "item": "minecraft:light_gray_banner"
+      "count": 1,
+      "id": "minecraft:light_gray_banner"
     },
     "pattern": [
       "###",
@@ -4252,8 +4516,8 @@
   },
   "light_gray_carpet": {
     "result": {
-      "item": "minecraft:light_gray_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:light_gray_carpet"
     },
     "pattern": [
       "##"
@@ -4267,7 +4531,8 @@
   },
   "light_gray_dye_from_azure_bluet": {
     "result": {
-      "item": "minecraft:light_gray_dye"
+      "count": 1,
+      "id": "minecraft:light_gray_dye"
     },
     "ingredients": [
       {
@@ -4278,8 +4543,8 @@
   },
   "light_gray_dye_from_black_white_dye_legacy": {
     "result": {
-      "item": "minecraft:light_gray_dye",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:light_gray_dye"
     },
     "ingredients": [
       {
@@ -4299,8 +4564,8 @@
   },
   "light_gray_dye_from_gray_white_dye_legacy": {
     "result": {
-      "item": "minecraft:light_gray_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:light_gray_dye"
     },
     "ingredients": [
       {
@@ -4317,7 +4582,8 @@
   },
   "light_gray_dye_from_oxeye_daisy": {
     "result": {
-      "item": "minecraft:light_gray_dye"
+      "count": 1,
+      "id": "minecraft:light_gray_dye"
     },
     "ingredients": [
       {
@@ -4328,7 +4594,8 @@
   },
   "light_gray_dye_from_white_tulip": {
     "result": {
-      "item": "minecraft:light_gray_dye"
+      "count": 1,
+      "id": "minecraft:light_gray_dye"
     },
     "ingredients": [
       {
@@ -4339,8 +4606,8 @@
   },
   "light_gray_stained_glass": {
     "result": {
-      "item": "minecraft:light_gray_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:light_gray_stained_glass"
     },
     "pattern": [
       "###",
@@ -4359,8 +4626,8 @@
   },
   "light_gray_stained_glass_pane": {
     "result": {
-      "item": "minecraft:light_gray_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:light_gray_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -4375,8 +4642,8 @@
   },
   "light_gray_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:light_gray_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:light_gray_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -4395,8 +4662,8 @@
   },
   "light_gray_terracotta": {
     "result": {
-      "item": "minecraft:light_gray_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:light_gray_terracotta"
     },
     "pattern": [
       "###",
@@ -4415,7 +4682,7 @@
   },
   "light_gray_wool": {
     "result": {
-      "item": "minecraft:light_gray_wool"
+      "id": "minecraft:light_gray_wool"
     },
     "ingredients": [
       {
@@ -4432,7 +4699,8 @@
   },
   "light_weighted_pressure_plate": {
     "result": {
-      "item": "minecraft:light_weighted_pressure_plate"
+      "count": 1,
+      "id": "minecraft:light_weighted_pressure_plate"
     },
     "pattern": [
       "##"
@@ -4446,7 +4714,8 @@
   },
   "lime_banner": {
     "result": {
-      "item": "minecraft:lime_banner"
+      "count": 1,
+      "id": "minecraft:lime_banner"
     },
     "pattern": [
       "###",
@@ -4465,8 +4734,8 @@
   },
   "lime_carpet": {
     "result": {
-      "item": "minecraft:lime_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:lime_carpet"
     },
     "pattern": [
       "##"
@@ -4480,8 +4749,8 @@
   },
   "lime_dye_legacy": {
     "result": {
-      "item": "minecraft:lime_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:lime_dye"
     },
     "ingredients": [
       {
@@ -4498,8 +4767,8 @@
   },
   "lime_stained_glass": {
     "result": {
-      "item": "minecraft:lime_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:lime_stained_glass"
     },
     "pattern": [
       "###",
@@ -4518,8 +4787,8 @@
   },
   "lime_stained_glass_pane": {
     "result": {
-      "item": "minecraft:lime_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:lime_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -4534,8 +4803,8 @@
   },
   "lime_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:lime_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:lime_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -4554,8 +4823,8 @@
   },
   "lime_terracotta": {
     "result": {
-      "item": "minecraft:lime_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:lime_terracotta"
     },
     "pattern": [
       "###",
@@ -4574,7 +4843,7 @@
   },
   "lime_wool": {
     "result": {
-      "item": "minecraft:lime_wool"
+      "id": "minecraft:lime_wool"
     },
     "ingredients": [
       {
@@ -4590,7 +4859,9 @@
     }
   },
   "lingering_thick_potion": {
-    "result": "minecraft.lingering_potion.effect.thick",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.thick"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -4601,7 +4872,8 @@
   },
   "magenta_banner": {
     "result": {
-      "item": "minecraft:magenta_banner"
+      "count": 1,
+      "id": "minecraft:magenta_banner"
     },
     "pattern": [
       "###",
@@ -4620,8 +4892,8 @@
   },
   "magenta_carpet": {
     "result": {
-      "item": "minecraft:magenta_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:magenta_carpet"
     },
     "pattern": [
       "##"
@@ -4635,7 +4907,8 @@
   },
   "magenta_dye_from_allium": {
     "result": {
-      "item": "minecraft:magenta_dye"
+      "count": 1,
+      "id": "minecraft:magenta_dye"
     },
     "ingredients": [
       {
@@ -4646,8 +4919,8 @@
   },
   "magenta_dye_from_blue_red_pink_legacy": {
     "result": {
-      "item": "minecraft:magenta_dye",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:magenta_dye"
     },
     "ingredients": [
       {
@@ -4667,8 +4940,8 @@
   },
   "magenta_dye_from_blue_red_white_dye_legacy": {
     "result": {
-      "item": "minecraft:magenta_dye",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:magenta_dye"
     },
     "ingredients": [
       {
@@ -4691,8 +4964,8 @@
   },
   "magenta_dye_from_lilac": {
     "result": {
-      "item": "minecraft:magenta_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:magenta_dye"
     },
     "ingredients": [
       {
@@ -4703,8 +4976,8 @@
   },
   "magenta_dye_from_purple_and_pink": {
     "result": {
-      "item": "minecraft:magenta_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:magenta_dye"
     },
     "ingredients": [
       {
@@ -4718,8 +4991,8 @@
   },
   "magenta_stained_glass": {
     "result": {
-      "item": "minecraft:magenta_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:magenta_stained_glass"
     },
     "pattern": [
       "###",
@@ -4738,8 +5011,8 @@
   },
   "magenta_stained_glass_pane": {
     "result": {
-      "item": "minecraft:magenta_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:magenta_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -4754,8 +5027,8 @@
   },
   "magenta_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:magenta_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:magenta_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -4774,8 +5047,8 @@
   },
   "magenta_terracotta": {
     "result": {
-      "item": "minecraft:magenta_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:magenta_terracotta"
     },
     "pattern": [
       "###",
@@ -4794,7 +5067,7 @@
   },
   "magenta_wool": {
     "result": {
-      "item": "minecraft:magenta_wool"
+      "id": "minecraft:magenta_wool"
     },
     "ingredients": [
       {
@@ -4811,7 +5084,8 @@
   },
   "magma_cream": {
     "result": {
-      "item": "minecraft:magma_cream"
+      "count": 1,
+      "id": "minecraft:magma_cream"
     },
     "ingredients": [
       {
@@ -4825,7 +5099,8 @@
   },
   "map": {
     "result": {
-      "item": "minecraft:map"
+      "count": 1,
+      "id": "minecraft:map"
     },
     "pattern": [
       "###",
@@ -4844,7 +5119,8 @@
   },
   "melon": {
     "result": {
-      "item": "minecraft:melon"
+      "count": 1,
+      "id": "minecraft:melon"
     },
     "ingredients": [
       {
@@ -4879,7 +5155,8 @@
   },
   "melon_seeds": {
     "result": {
-      "item": "minecraft:melon_seeds"
+      "count": 1,
+      "id": "minecraft:melon_seeds"
     },
     "ingredients": [
       {
@@ -4890,7 +5167,8 @@
   },
   "minecart": {
     "result": {
-      "item": "minecraft:minecart"
+      "count": 1,
+      "id": "minecraft:minecart"
     },
     "pattern": [
       "# #",
@@ -4904,7 +5182,9 @@
     }
   },
   "mundane_potion": {
-    "result": "minecraft.potion.effect.mundane",
+    "result": {
+      "id": "minecraft.potion.effect.mundane"
+    },
     "reagent": [
       {
         "item": "minecraft:spider_eye"
@@ -4941,7 +5221,8 @@
   },
   "mushroom_stew": {
     "result": {
-      "item": "minecraft:mushroom_stew"
+      "count": 1,
+      "id": "minecraft:mushroom_stew"
     },
     "ingredients": [
       {
@@ -4957,7 +5238,9 @@
     "type": "minecraft:crafting_shapeless"
   },
   "nether_brick": {
-    "result": "minecraft:nether_brick",
+    "result": {
+      "id": "minecraft:nether_brick"
+    },
     "ingredient": {
       "item": "minecraft:netherrack"
     },
@@ -4966,8 +5249,8 @@
   },
   "nether_brick_fence_legacy": {
     "result": {
-      "item": "minecraft:nether_brick_fence",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:nether_brick_fence"
     },
     "pattern": [
       "###",
@@ -4985,8 +5268,8 @@
   },
   "nether_brick_slab": {
     "result": {
-      "item": "minecraft:nether_brick_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:nether_brick_slab"
     },
     "pattern": [
       "###"
@@ -5000,8 +5283,8 @@
   },
   "nether_brick_stairs": {
     "result": {
-      "item": "minecraft:nether_brick_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:nether_brick_stairs"
     },
     "pattern": [
       "#  ",
@@ -5017,7 +5300,8 @@
   },
   "nether_bricks": {
     "result": {
-      "item": "minecraft:nether_bricks"
+      "count": 1,
+      "id": "minecraft:nether_bricks"
     },
     "pattern": [
       "##",
@@ -5031,7 +5315,9 @@
     }
   },
   "night_vision_potion": {
-    "result": "minecraft.potion.effect.night_vision",
+    "result": {
+      "id": "minecraft.potion.effect.night_vision"
+    },
     "reagent": {
       "item": "minecraft:golden_carrot"
     },
@@ -5041,7 +5327,9 @@
     }
   },
   "night_vision_splash_potion": {
-    "result": "minecraft.splash_potion.effect.night_vision",
+    "result": {
+      "id": "minecraft.splash_potion.effect.night_vision"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -5052,7 +5340,8 @@
   },
   "note_block": {
     "result": {
-      "item": "minecraft:note_block"
+      "count": 1,
+      "id": "minecraft:note_block"
     },
     "pattern": [
       "###",
@@ -5074,7 +5363,8 @@
   },
   "oak_boat": {
     "result": {
-      "item": "minecraft:oak_boat"
+      "count": 1,
+      "id": "minecraft:oak_boat"
     },
     "pattern": [
       "# #",
@@ -5089,7 +5379,8 @@
   },
   "oak_button": {
     "result": {
-      "item": "minecraft:oak_button"
+      "count": 1,
+      "id": "minecraft:oak_button"
     },
     "ingredients": [
       {
@@ -5100,8 +5391,8 @@
   },
   "oak_door": {
     "result": {
-      "item": "minecraft:oak_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:oak_door"
     },
     "pattern": [
       "##",
@@ -5122,8 +5413,8 @@
   },
   "oak_fence": {
     "result": {
-      "item": "minecraft:oak_fence",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:oak_fence"
     },
     "pattern": [
       "W#W",
@@ -5141,7 +5432,8 @@
   },
   "oak_fence_gate": {
     "result": {
-      "item": "minecraft:oak_fence_gate"
+      "count": 1,
+      "id": "minecraft:oak_fence_gate"
     },
     "pattern": [
       "#W#",
@@ -5159,8 +5451,8 @@
   },
   "oak_fence_legacy": {
     "result": {
-      "item": "minecraft:oak_fence",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:oak_fence"
     },
     "pattern": [
       "###",
@@ -5178,8 +5470,8 @@
   },
   "oak_planks": {
     "result": {
-      "item": "minecraft:oak_planks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:oak_planks"
     },
     "ingredients": [
       {
@@ -5193,7 +5485,8 @@
   },
   "oak_pressure_plate": {
     "result": {
-      "item": "minecraft:oak_pressure_plate"
+      "count": 1,
+      "id": "minecraft:oak_pressure_plate"
     },
     "pattern": [
       "##"
@@ -5207,8 +5500,8 @@
   },
   "oak_sign": {
     "result": {
-      "item": "minecraft:oak_sign",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:oak_sign"
     },
     "pattern": [
       "###",
@@ -5227,8 +5520,8 @@
   },
   "oak_slab": {
     "result": {
-      "item": "minecraft:oak_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:oak_slab"
     },
     "pattern": [
       "###"
@@ -5242,8 +5535,8 @@
   },
   "oak_stairs": {
     "result": {
-      "item": "minecraft:oak_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:oak_stairs"
     },
     "pattern": [
       "#  ",
@@ -5259,8 +5552,8 @@
   },
   "oak_trapdoor": {
     "result": {
-      "item": "minecraft:oak_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:oak_trapdoor"
     },
     "pattern": [
       "###",
@@ -5275,7 +5568,8 @@
   },
   "orange_banner": {
     "result": {
-      "item": "minecraft:orange_banner"
+      "count": 1,
+      "id": "minecraft:orange_banner"
     },
     "pattern": [
       "###",
@@ -5294,8 +5588,8 @@
   },
   "orange_carpet": {
     "result": {
-      "item": "minecraft:orange_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:orange_carpet"
     },
     "pattern": [
       "##"
@@ -5309,7 +5603,8 @@
   },
   "orange_dye_from_orange_tulip": {
     "result": {
-      "item": "minecraft:orange_dye"
+      "count": 1,
+      "id": "minecraft:orange_dye"
     },
     "ingredients": [
       {
@@ -5320,8 +5615,8 @@
   },
   "orange_dye_from_red_yellow": {
     "result": {
-      "item": "minecraft:orange_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:orange_dye"
     },
     "ingredients": [
       {
@@ -5335,8 +5630,8 @@
   },
   "orange_stained_glass": {
     "result": {
-      "item": "minecraft:orange_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:orange_stained_glass"
     },
     "pattern": [
       "###",
@@ -5355,8 +5650,8 @@
   },
   "orange_stained_glass_pane": {
     "result": {
-      "item": "minecraft:orange_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:orange_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -5371,8 +5666,8 @@
   },
   "orange_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:orange_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:orange_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -5391,8 +5686,8 @@
   },
   "orange_terracotta": {
     "result": {
-      "item": "minecraft:orange_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:orange_terracotta"
     },
     "pattern": [
       "###",
@@ -5411,7 +5706,7 @@
   },
   "orange_wool": {
     "result": {
-      "item": "minecraft:orange_wool"
+      "id": "minecraft:orange_wool"
     },
     "ingredients": [
       {
@@ -5428,7 +5723,8 @@
   },
   "painting": {
     "result": {
-      "item": "minecraft:painting"
+      "count": 1,
+      "id": "minecraft:painting"
     },
     "pattern": [
       "###",
@@ -5450,8 +5746,8 @@
   },
   "paper": {
     "result": {
-      "item": "minecraft:paper",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:paper"
     },
     "pattern": [
       "###"
@@ -5465,7 +5761,8 @@
   },
   "pink_banner": {
     "result": {
-      "item": "minecraft:pink_banner"
+      "count": 1,
+      "id": "minecraft:pink_banner"
     },
     "pattern": [
       "###",
@@ -5484,8 +5781,8 @@
   },
   "pink_carpet": {
     "result": {
-      "item": "minecraft:pink_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:pink_carpet"
     },
     "pattern": [
       "##"
@@ -5499,8 +5796,8 @@
   },
   "pink_dye_from_peony": {
     "result": {
-      "item": "minecraft:pink_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:pink_dye"
     },
     "ingredients": [
       {
@@ -5511,7 +5808,8 @@
   },
   "pink_dye_from_pink_tulip": {
     "result": {
-      "item": "minecraft:pink_dye"
+      "count": 1,
+      "id": "minecraft:pink_dye"
     },
     "ingredients": [
       {
@@ -5522,8 +5820,8 @@
   },
   "pink_dye_from_red_white_dye_legacy": {
     "result": {
-      "item": "minecraft:pink_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:pink_dye"
     },
     "ingredients": [
       {
@@ -5540,8 +5838,8 @@
   },
   "pink_stained_glass": {
     "result": {
-      "item": "minecraft:pink_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:pink_stained_glass"
     },
     "pattern": [
       "###",
@@ -5560,8 +5858,8 @@
   },
   "pink_stained_glass_pane": {
     "result": {
-      "item": "minecraft:pink_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:pink_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -5576,8 +5874,8 @@
   },
   "pink_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:pink_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:pink_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -5596,8 +5894,8 @@
   },
   "pink_terracotta": {
     "result": {
-      "item": "minecraft:pink_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:pink_terracotta"
     },
     "pattern": [
       "###",
@@ -5616,7 +5914,7 @@
   },
   "pink_wool": {
     "result": {
-      "item": "minecraft:pink_wool"
+      "id": "minecraft:pink_wool"
     },
     "ingredients": [
       {
@@ -5633,7 +5931,8 @@
   },
   "piston": {
     "result": {
-      "item": "minecraft:piston"
+      "count": 1,
+      "id": "minecraft:piston"
     },
     "pattern": [
       "TTT",
@@ -5660,7 +5959,9 @@
     }
   },
   "poison_potion": {
-    "result": "minecraft.potion.effect.poison",
+    "result": {
+      "id": "minecraft.potion.effect.poison"
+    },
     "reagent": {
       "item": "minecraft:spider_eye"
     },
@@ -5670,7 +5971,9 @@
     }
   },
   "poison_splash_potion": {
-    "result": "minecraft.splash_potion.effect.poison",
+    "result": {
+      "id": "minecraft.splash_potion.effect.poison"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -5681,8 +5984,8 @@
   },
   "powered_rail": {
     "result": {
-      "item": "minecraft:powered_rail",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:powered_rail"
     },
     "pattern": [
       "X X",
@@ -5704,7 +6007,8 @@
   },
   "purple_banner": {
     "result": {
-      "item": "minecraft:purple_banner"
+      "count": 1,
+      "id": "minecraft:purple_banner"
     },
     "pattern": [
       "###",
@@ -5723,8 +6027,8 @@
   },
   "purple_carpet": {
     "result": {
-      "item": "minecraft:purple_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:purple_carpet"
     },
     "pattern": [
       "##"
@@ -5738,8 +6042,8 @@
   },
   "purple_dye_legacy": {
     "result": {
-      "item": "minecraft:purple_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:purple_dye"
     },
     "ingredients": [
       {
@@ -5756,8 +6060,8 @@
   },
   "purple_stained_glass": {
     "result": {
-      "item": "minecraft:purple_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:purple_stained_glass"
     },
     "pattern": [
       "###",
@@ -5776,8 +6080,8 @@
   },
   "purple_stained_glass_pane": {
     "result": {
-      "item": "minecraft:purple_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:purple_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -5792,8 +6096,8 @@
   },
   "purple_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:purple_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:purple_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -5812,8 +6116,8 @@
   },
   "purple_terracotta": {
     "result": {
-      "item": "minecraft:purple_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:purple_terracotta"
     },
     "pattern": [
       "###",
@@ -5832,7 +6136,7 @@
   },
   "purple_wool": {
     "result": {
-      "item": "minecraft:purple_wool"
+      "id": "minecraft:purple_wool"
     },
     "ingredients": [
       {
@@ -5848,7 +6152,9 @@
     }
   },
   "quartz": {
-    "result": "minecraft:quartz",
+    "result": {
+      "id": "minecraft:quartz"
+    },
     "ingredient": {
       "item": "minecraft:nether_quartz_ore"
     },
@@ -5857,7 +6163,8 @@
   },
   "quartz_block": {
     "result": {
-      "item": "minecraft:quartz_block"
+      "count": 1,
+      "id": "minecraft:quartz_block"
     },
     "pattern": [
       "##",
@@ -5871,7 +6178,9 @@
     }
   },
   "quartz_from_blasting": {
-    "result": "minecraft:quartz",
+    "result": {
+      "id": "minecraft:quartz"
+    },
     "ingredient": {
       "item": "minecraft:nether_quartz_ore"
     },
@@ -5879,7 +6188,9 @@
     "experience": 0.2
   },
   "quartz_from_smelting": {
-    "result": "minecraft:quartz",
+    "result": {
+      "id": "minecraft:quartz"
+    },
     "ingredient": {
       "item": "minecraft:nether_quartz_ore"
     },
@@ -5888,8 +6199,8 @@
   },
   "quartz_pillar": {
     "result": {
-      "item": "minecraft:quartz_pillar",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:quartz_pillar"
     },
     "pattern": [
       "#",
@@ -5904,8 +6215,8 @@
   },
   "quartz_slab": {
     "result": {
-      "item": "minecraft:quartz_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:quartz_slab"
     },
     "pattern": [
       "###"
@@ -5930,8 +6241,8 @@
   },
   "quartz_stairs": {
     "result": {
-      "item": "minecraft:quartz_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:quartz_stairs"
     },
     "pattern": [
       "#  ",
@@ -5958,8 +6269,8 @@
   },
   "rail": {
     "result": {
-      "item": "minecraft:rail",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:rail"
     },
     "pattern": [
       "X X",
@@ -5978,7 +6289,8 @@
   },
   "red_banner": {
     "result": {
-      "item": "minecraft:red_banner"
+      "count": 1,
+      "id": "minecraft:red_banner"
     },
     "pattern": [
       "###",
@@ -5997,8 +6309,8 @@
   },
   "red_carpet": {
     "result": {
-      "item": "minecraft:red_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:red_carpet"
     },
     "pattern": [
       "##"
@@ -6012,7 +6324,8 @@
   },
   "red_dye_from_poppy": {
     "result": {
-      "item": "minecraft:red_dye"
+      "count": 1,
+      "id": "minecraft:red_dye"
     },
     "ingredients": [
       {
@@ -6023,8 +6336,8 @@
   },
   "red_dye_from_rose_bush": {
     "result": {
-      "item": "minecraft:red_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:red_dye"
     },
     "ingredients": [
       {
@@ -6035,7 +6348,8 @@
   },
   "red_dye_from_tulip": {
     "result": {
-      "item": "minecraft:red_dye"
+      "count": 1,
+      "id": "minecraft:red_dye"
     },
     "ingredients": [
       {
@@ -6046,8 +6360,8 @@
   },
   "red_sandstone_slab": {
     "result": {
-      "item": "minecraft:red_sandstone_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:red_sandstone_slab"
     },
     "pattern": [
       "###"
@@ -6069,8 +6383,8 @@
   },
   "red_sandstone_stairs": {
     "result": {
-      "item": "minecraft:red_sandstone_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:red_sandstone_stairs"
     },
     "pattern": [
       "#  ",
@@ -6097,8 +6411,8 @@
   },
   "red_stained_glass": {
     "result": {
-      "item": "minecraft:red_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:red_stained_glass"
     },
     "pattern": [
       "###",
@@ -6117,8 +6431,8 @@
   },
   "red_stained_glass_pane": {
     "result": {
-      "item": "minecraft:red_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:red_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -6133,8 +6447,8 @@
   },
   "red_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:red_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:red_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -6153,8 +6467,8 @@
   },
   "red_terracotta": {
     "result": {
-      "item": "minecraft:red_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:red_terracotta"
     },
     "pattern": [
       "###",
@@ -6173,7 +6487,7 @@
   },
   "red_wool": {
     "result": {
-      "item": "minecraft:red_wool"
+      "id": "minecraft:red_wool"
     },
     "ingredients": [
       {
@@ -6190,8 +6504,8 @@
   },
   "redstone": {
     "result": {
-      "item": "minecraft:redstone",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:redstone"
     },
     "ingredients": [
       {
@@ -6202,7 +6516,8 @@
   },
   "redstone_block": {
     "result": {
-      "item": "minecraft:redstone_block"
+      "count": 1,
+      "id": "minecraft:redstone_block"
     },
     "pattern": [
       "###",
@@ -6217,7 +6532,9 @@
     }
   },
   "redstone_from_blasting_redstone_ore": {
-    "result": "minecraft:redstone",
+    "result": {
+      "id": "minecraft:redstone"
+    },
     "ingredient": {
       "item": "minecraft:redstone_ore"
     },
@@ -6225,7 +6542,9 @@
     "experience": 0.7
   },
   "redstone_from_smelting_redstone_ore": {
-    "result": "minecraft:redstone",
+    "result": {
+      "id": "minecraft:redstone"
+    },
     "ingredient": {
       "item": "minecraft:redstone_ore"
     },
@@ -6234,7 +6553,8 @@
   },
   "redstone_lamp": {
     "result": {
-      "item": "minecraft:redstone_lamp"
+      "count": 1,
+      "id": "minecraft:redstone_lamp"
     },
     "pattern": [
       " R ",
@@ -6253,7 +6573,8 @@
   },
   "redstone_torch": {
     "result": {
-      "item": "minecraft:redstone_torch"
+      "count": 1,
+      "id": "minecraft:redstone_torch"
     },
     "pattern": [
       "X",
@@ -6270,7 +6591,9 @@
     }
   },
   "regeneration_potion": {
-    "result": "minecraft.potion.effect.regeneration",
+    "result": {
+      "id": "minecraft.potion.effect.regeneration"
+    },
     "reagent": {
       "item": "minecraft:ghast_tear"
     },
@@ -6280,7 +6603,9 @@
     }
   },
   "regeneration_splash_potion": {
-    "result": "minecraft.splash_potion.effect.regeneration",
+    "result": {
+      "id": "minecraft.splash_potion.effect.regeneration"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -6291,7 +6616,8 @@
   },
   "repeater": {
     "result": {
-      "item": "minecraft:repeater"
+      "count": 1,
+      "id": "minecraft:repeater"
     },
     "pattern": [
       "#X#",
@@ -6312,7 +6638,8 @@
   },
   "sandstone": {
     "result": {
-      "item": "minecraft:sandstone"
+      "count": 1,
+      "id": "minecraft:sandstone"
     },
     "pattern": [
       "##",
@@ -6327,8 +6654,8 @@
   },
   "sandstone_slab": {
     "result": {
-      "item": "minecraft:sandstone_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:sandstone_slab"
     },
     "pattern": [
       "###"
@@ -6350,8 +6677,8 @@
   },
   "sandstone_stairs": {
     "result": {
-      "item": "minecraft:sandstone_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:sandstone_stairs"
     },
     "pattern": [
       "#  ",
@@ -6378,7 +6705,8 @@
   },
   "shears": {
     "result": {
-      "item": "minecraft:shears"
+      "count": 1,
+      "id": "minecraft:shears"
     },
     "pattern": [
       " #",
@@ -6392,7 +6720,9 @@
     }
   },
   "slowness_potion": {
-    "result": "minecraft.potion.effect.slowness",
+    "result": {
+      "id": "minecraft.potion.effect.slowness"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6407,7 +6737,9 @@
     ]
   },
   "slowness_potion_from_corrupt_legacy": {
-    "result": "minecraft.potion.effect.slowness",
+    "result": {
+      "id": "minecraft.potion.effect.slowness"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6420,7 +6752,9 @@
     }
   },
   "slowness_splash_potion": {
-    "result": "minecraft.splash_potion.effect.slowness",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slowness"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -6430,7 +6764,9 @@
     }
   },
   "smooth_sandstone": {
-    "result": "minecraft:smooth_sandstone",
+    "result": {
+      "id": "minecraft:smooth_sandstone"
+    },
     "ingredient": {
       "item": "minecraft:sandstone"
     },
@@ -6439,8 +6775,8 @@
   },
   "smooth_stone_slab": {
     "result": {
-      "item": "minecraft:smooth_stone_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:smooth_stone_slab"
     },
     "pattern": [
       "###"
@@ -6454,8 +6790,8 @@
   },
   "snow": {
     "result": {
-      "item": "minecraft:snow",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:snow"
     },
     "pattern": [
       "###"
@@ -6469,7 +6805,8 @@
   },
   "snow_block": {
     "result": {
-      "item": "minecraft:snow_block"
+      "count": 1,
+      "id": "minecraft:snow_block"
     },
     "pattern": [
       "##",
@@ -6483,7 +6820,9 @@
     }
   },
   "splash_amplified_harming_potion": {
-    "result": "minecraft.splash_potion.effect.harming.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.harming.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -6493,7 +6832,9 @@
     }
   },
   "splash_amplified_harming_potion_from_corrupt": {
-    "result": "minecraft.splash_potion.effect.harming.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.harming.ii"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6508,7 +6849,9 @@
     ]
   },
   "splash_amplified_healing_potion": {
-    "result": "minecraft.splash_potion.effect.healing.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.healing.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -6518,7 +6861,9 @@
     }
   },
   "splash_amplified_poison_potion": {
-    "result": "minecraft.splash_potion.effect.poison.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.poison.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -6528,7 +6873,9 @@
     }
   },
   "splash_amplified_regeneration_potion": {
-    "result": "minecraft.splash_potion.effect.regeneration.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.regeneration.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -6538,7 +6885,9 @@
     }
   },
   "splash_amplified_strength_potion": {
-    "result": "minecraft.splash_potion.effect.strength.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.strength.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -6548,7 +6897,9 @@
     }
   },
   "splash_amplified_swiftness_potion": {
-    "result": "minecraft.splash_potion.effect.swiftness.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.swiftness.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -6558,7 +6909,9 @@
     }
   },
   "splash_extended_fire_resistance_potion": {
-    "result": "minecraft.splash_potion.effect.fire_resistance.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.fire_resistance.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -6568,7 +6921,9 @@
     }
   },
   "splash_extended_invisibility_potion": {
-    "result": "minecraft.splash_potion.effect.invisibility.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.invisibility.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -6578,7 +6933,9 @@
     }
   },
   "splash_extended_invisibility_potion_from_corrupt": {
-    "result": "minecraft.splash_potion.effect.invisibility.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.invisibility.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6588,7 +6945,9 @@
     }
   },
   "splash_extended_night_vision_potion": {
-    "result": "minecraft.splash_potion.effect.night_vision.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.night_vision.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -6598,7 +6957,9 @@
     }
   },
   "splash_extended_poison_potion": {
-    "result": "minecraft.splash_potion.effect.poison.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.poison.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -6608,7 +6969,9 @@
     }
   },
   "splash_extended_regeneration_potion": {
-    "result": "minecraft.splash_potion.effect.regeneration.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.regeneration.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -6618,7 +6981,9 @@
     }
   },
   "splash_extended_slowness_potion": {
-    "result": "minecraft.splash_potion.effect.slowness.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slowness.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -6628,7 +6993,9 @@
     }
   },
   "splash_extended_slowness_potion_from_corrupt": {
-    "result": "minecraft.splash_potion.effect.slowness.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slowness.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6643,7 +7010,9 @@
     ]
   },
   "splash_extended_slowness_potion_from_corrupt_legacy": {
-    "result": "minecraft.splash_potion.effect.slowness.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slowness.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6656,7 +7025,9 @@
     }
   },
   "splash_extended_strength_potion": {
-    "result": "minecraft.splash_potion.effect.strength.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.strength.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -6666,7 +7037,9 @@
     }
   },
   "splash_extended_swiftness_potion": {
-    "result": "minecraft.splash_potion.effect.swiftness.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.swiftness.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -6676,7 +7049,9 @@
     }
   },
   "splash_extended_water_breathing_potion": {
-    "result": "minecraft.splash_potion.effect.water_breathing.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.water_breathing.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -6686,7 +7061,9 @@
     }
   },
   "splash_extended_weakness_potion": {
-    "result": "minecraft.splash_potion.effect.weakness.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.weakness.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -6696,7 +7073,9 @@
     }
   },
   "splash_extended_weakness_potion_from_corrupt": {
-    "result": "minecraft.splash_potion.effect.weakness.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.weakness.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6714,7 +7093,9 @@
     ]
   },
   "splash_extended_weakness_potion_legacy": {
-    "result": "minecraft.splash_potion.effect.weakness.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.weakness.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6727,7 +7108,9 @@
     }
   },
   "splash_fire_resistance_potion": {
-    "result": "minecraft.splash_potion.effect.fire_resistance",
+    "result": {
+      "id": "minecraft.splash_potion.effect.fire_resistance"
+    },
     "reagent": {
       "item": "minecraft:magma_cream"
     },
@@ -6737,7 +7120,9 @@
     }
   },
   "splash_harming_potion": {
-    "result": "minecraft.splash_potion.effect.harming",
+    "result": {
+      "id": "minecraft.splash_potion.effect.harming"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6752,7 +7137,9 @@
     ]
   },
   "splash_harming_potion_from_corrupt_legacy": {
-    "result": "minecraft.splash_potion.effect.harming",
+    "result": {
+      "id": "minecraft.splash_potion.effect.harming"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6765,7 +7152,9 @@
     }
   },
   "splash_healing_potion": {
-    "result": "minecraft.splash_potion.effect.healing",
+    "result": {
+      "id": "minecraft.splash_potion.effect.healing"
+    },
     "reagent": {
       "item": "minecraft:glistering_melon_slice"
     },
@@ -6775,7 +7164,9 @@
     }
   },
   "splash_invisibility_potion": {
-    "result": "minecraft.splash_potion.effect.invisibility",
+    "result": {
+      "id": "minecraft.splash_potion.effect.invisibility"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6785,7 +7176,9 @@
     }
   },
   "splash_night_vision_potion": {
-    "result": "minecraft.splash_potion.effect.night_vision",
+    "result": {
+      "id": "minecraft.splash_potion.effect.night_vision"
+    },
     "reagent": {
       "item": "minecraft:golden_carrot"
     },
@@ -6795,7 +7188,9 @@
     }
   },
   "splash_poison_potion": {
-    "result": "minecraft.splash_potion.effect.poison",
+    "result": {
+      "id": "minecraft.splash_potion.effect.poison"
+    },
     "reagent": {
       "item": "minecraft:spider_eye"
     },
@@ -6805,7 +7200,9 @@
     }
   },
   "splash_regeneration_potion": {
-    "result": "minecraft.splash_potion.effect.regeneration",
+    "result": {
+      "id": "minecraft.splash_potion.effect.regeneration"
+    },
     "reagent": {
       "item": "minecraft:ghast_tear"
     },
@@ -6815,7 +7212,9 @@
     }
   },
   "splash_slowness_potion": {
-    "result": "minecraft.splash_potion.effect.slowness",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slowness"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6830,7 +7229,9 @@
     ]
   },
   "splash_slowness_potion_from_corrupt_legacy": {
-    "result": "minecraft.splash_potion.effect.slowness",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slowness"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6843,7 +7244,9 @@
     }
   },
   "splash_strength_potion": {
-    "result": "minecraft.splash_potion.effect.strength",
+    "result": {
+      "id": "minecraft.splash_potion.effect.strength"
+    },
     "reagent": {
       "item": "minecraft:blaze_powder"
     },
@@ -6853,7 +7256,9 @@
     }
   },
   "splash_swiftness_potion": {
-    "result": "minecraft.splash_potion.effect.swiftness",
+    "result": {
+      "id": "minecraft.splash_potion.effect.swiftness"
+    },
     "reagent": {
       "item": "minecraft:sugar"
     },
@@ -6863,7 +7268,9 @@
     }
   },
   "splash_water_breathing_potion": {
-    "result": "minecraft.splash_potion.effect.water_breathing",
+    "result": {
+      "id": "minecraft.splash_potion.effect.water_breathing"
+    },
     "reagent": {
       "item": "minecraft:pufferfish"
     },
@@ -6873,7 +7280,9 @@
     }
   },
   "splash_weakness_potion": {
-    "result": "minecraft.splash_potion.effect.harming",
+    "result": {
+      "id": "minecraft.splash_potion.effect.harming"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6891,7 +7300,9 @@
     ]
   },
   "splash_weakness_potion_legacy": {
-    "result": "minecraft.splash_potion.effect.weakness",
+    "result": {
+      "id": "minecraft.splash_potion.effect.weakness"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -6913,8 +7324,8 @@
   },
   "spruce_planks": {
     "result": {
-      "item": "minecraft:spruce_planks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:spruce_planks"
     },
     "ingredients": [
       {
@@ -6928,8 +7339,8 @@
   },
   "spruce_slab": {
     "result": {
-      "item": "minecraft:spruce_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:spruce_slab"
     },
     "pattern": [
       "###"
@@ -6943,8 +7354,8 @@
   },
   "spruce_stairs": {
     "result": {
-      "item": "minecraft:spruce_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:spruce_stairs"
     },
     "pattern": [
       "#  ",
@@ -6960,8 +7371,8 @@
   },
   "stick": {
     "result": {
-      "item": "minecraft:stick",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:stick"
     },
     "pattern": [
       "#",
@@ -6979,7 +7390,8 @@
   },
   "sticky_piston": {
     "result": {
-      "item": "minecraft:sticky_piston"
+      "count": 1,
+      "id": "minecraft:sticky_piston"
     },
     "pattern": [
       "S",
@@ -6996,7 +7408,9 @@
     }
   },
   "stone": {
-    "result": "minecraft:stone",
+    "result": {
+      "id": "minecraft:stone"
+    },
     "ingredient": {
       "item": "minecraft:cobblestone"
     },
@@ -7005,7 +7419,8 @@
   },
   "stone_axe": {
     "result": {
-      "item": "minecraft:stone_axe"
+      "count": 1,
+      "id": "minecraft:stone_axe"
     },
     "pattern": [
       "XX",
@@ -7027,8 +7442,8 @@
   },
   "stone_brick_slab": {
     "result": {
-      "item": "minecraft:stone_brick_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:stone_brick_slab"
     },
     "pattern": [
       "###"
@@ -7042,8 +7457,8 @@
   },
   "stone_brick_stairs": {
     "result": {
-      "item": "minecraft:stone_brick_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:stone_brick_stairs"
     },
     "pattern": [
       "#  ",
@@ -7059,8 +7474,8 @@
   },
   "stone_bricks": {
     "result": {
-      "item": "minecraft:stone_bricks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:stone_bricks"
     },
     "pattern": [
       "##",
@@ -7075,7 +7490,8 @@
   },
   "stone_button": {
     "result": {
-      "item": "minecraft:stone_button"
+      "count": 1,
+      "id": "minecraft:stone_button"
     },
     "ingredients": [
       {
@@ -7086,7 +7502,8 @@
   },
   "stone_hoe": {
     "result": {
-      "item": "minecraft:stone_hoe"
+      "count": 1,
+      "id": "minecraft:stone_hoe"
     },
     "pattern": [
       "XX",
@@ -7108,7 +7525,8 @@
   },
   "stone_pickaxe": {
     "result": {
-      "item": "minecraft:stone_pickaxe"
+      "count": 1,
+      "id": "minecraft:stone_pickaxe"
     },
     "pattern": [
       "XXX",
@@ -7130,7 +7548,8 @@
   },
   "stone_pressure_plate": {
     "result": {
-      "item": "minecraft:stone_pressure_plate"
+      "count": 1,
+      "id": "minecraft:stone_pressure_plate"
     },
     "pattern": [
       "##"
@@ -7144,7 +7563,8 @@
   },
   "stone_shovel": {
     "result": {
-      "item": "minecraft:stone_shovel"
+      "count": 1,
+      "id": "minecraft:stone_shovel"
     },
     "pattern": [
       "X",
@@ -7166,7 +7586,8 @@
   },
   "stone_sword": {
     "result": {
-      "item": "minecraft:stone_sword"
+      "count": 1,
+      "id": "minecraft:stone_sword"
     },
     "pattern": [
       "X",
@@ -7187,7 +7608,9 @@
     }
   },
   "strength_potion": {
-    "result": "minecraft.potion.effect.strength",
+    "result": {
+      "id": "minecraft.potion.effect.strength"
+    },
     "reagent": {
       "item": "minecraft:blaze_powder"
     },
@@ -7197,7 +7620,9 @@
     }
   },
   "strength_splash_potion": {
-    "result": "minecraft.splash_potion.effect.strength",
+    "result": {
+      "id": "minecraft.splash_potion.effect.strength"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -7208,7 +7633,8 @@
   },
   "sugar_from_sugar_cane": {
     "result": {
-      "item": "minecraft:sugar"
+      "count": 1,
+      "id": "minecraft:sugar"
     },
     "ingredients": [
       {
@@ -7218,7 +7644,9 @@
     "type": "minecraft:crafting_shapeless"
   },
   "swiftness_potion": {
-    "result": "minecraft.potion.effect.swiftness",
+    "result": {
+      "id": "minecraft.potion.effect.swiftness"
+    },
     "reagent": {
       "item": "minecraft:sugar"
     },
@@ -7228,7 +7656,9 @@
     }
   },
   "swiftness_splash_potion": {
-    "result": "minecraft.splash_potion.effect.swiftness",
+    "result": {
+      "id": "minecraft.splash_potion.effect.swiftness"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -7238,7 +7668,9 @@
     }
   },
   "terracotta": {
-    "result": "minecraft:terracotta",
+    "result": {
+      "id": "minecraft:terracotta"
+    },
     "ingredient": {
       "item": "minecraft:clay"
     },
@@ -7246,7 +7678,9 @@
     "experience": 0.35
   },
   "thick_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.thick",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.thick"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -7256,7 +7690,9 @@
     }
   },
   "thick_potion": {
-    "result": "minecraft.potion.effect.thick",
+    "result": {
+      "id": "minecraft.potion.effect.thick"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -7267,8 +7703,8 @@
   },
   "tipped_arrow_thick": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.thick",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.thick"
     },
     "pattern": [
       "AAA",
@@ -7287,7 +7723,8 @@
   },
   "tnt": {
     "result": {
-      "item": "minecraft:tnt"
+      "count": 1,
+      "id": "minecraft:tnt"
     },
     "pattern": [
       "X#X",
@@ -7314,7 +7751,8 @@
   },
   "tnt_minecart": {
     "result": {
-      "item": "minecraft:tnt_minecart"
+      "count": 1,
+      "id": "minecraft:tnt_minecart"
     },
     "ingredients": [
       {
@@ -7333,8 +7771,8 @@
   },
   "torch": {
     "result": {
-      "item": "minecraft:torch",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:torch"
     },
     "pattern": [
       "X",
@@ -7360,7 +7798,8 @@
   },
   "trapped_chest": {
     "result": {
-      "item": "minecraft:trapped_chest"
+      "count": 1,
+      "id": "minecraft:trapped_chest"
     },
     "ingredients": [
       {
@@ -7379,8 +7818,8 @@
   },
   "tripwire_hook": {
     "result": {
-      "item": "minecraft:tripwire_hook",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:tripwire_hook"
     },
     "pattern": [
       "I",
@@ -7404,7 +7843,9 @@
     }
   },
   "water_breathing_potion": {
-    "result": "minecraft.potion.effect.water_breathing",
+    "result": {
+      "id": "minecraft.potion.effect.water_breathing"
+    },
     "reagent": {
       "item": "minecraft:pufferfish"
     },
@@ -7414,7 +7855,9 @@
     }
   },
   "water_breathing_splash_potion": {
-    "result": "minecraft.splash_potion.effect.water_breathing",
+    "result": {
+      "id": "minecraft.splash_potion.effect.water_breathing"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -7424,7 +7867,9 @@
     }
   },
   "weakness_potion": {
-    "result": "minecraft.potion.effect.weakness",
+    "result": {
+      "id": "minecraft.potion.effect.weakness"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -7442,7 +7887,9 @@
     ]
   },
   "weakness_potion_legacy": {
-    "result": "minecraft.potion.effect.weakness",
+    "result": {
+      "id": "minecraft.potion.effect.weakness"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -7463,7 +7910,9 @@
     ]
   },
   "weakness_splash_potion": {
-    "result": "minecraft.splash_potion.effect.weakness",
+    "result": {
+      "id": "minecraft.splash_potion.effect.weakness"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -7474,8 +7923,8 @@
   },
   "wheat": {
     "result": {
-      "item": "minecraft:wheat",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:wheat"
     },
     "ingredients": [
       {
@@ -7486,8 +7935,8 @@
   },
   "white_carpet": {
     "result": {
-      "item": "minecraft:white_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:white_carpet"
     },
     "pattern": [
       "##"
@@ -7501,8 +7950,8 @@
   },
   "white_stained_glass_legacy": {
     "result": {
-      "item": "minecraft:white_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:white_stained_glass"
     },
     "pattern": [
       "###",
@@ -7524,8 +7973,8 @@
   },
   "white_stained_glass_pane": {
     "result": {
-      "item": "minecraft:white_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:white_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -7540,8 +7989,8 @@
   },
   "white_stained_glass_pane_from_glass_pane_legacy": {
     "result": {
-      "item": "minecraft:white_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:white_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -7563,8 +8012,8 @@
   },
   "white_terracotta_legacy": {
     "result": {
-      "item": "minecraft:white_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:white_terracotta"
     },
     "pattern": [
       "###",
@@ -7586,7 +8035,8 @@
   },
   "white_wool_from_string": {
     "result": {
-      "item": "minecraft:white_wool"
+      "count": 1,
+      "id": "minecraft:white_wool"
     },
     "pattern": [
       "##",
@@ -7601,7 +8051,8 @@
   },
   "wooden_axe": {
     "result": {
-      "item": "minecraft:wooden_axe"
+      "count": 1,
+      "id": "minecraft:wooden_axe"
     },
     "pattern": [
       "XX",
@@ -7623,7 +8074,8 @@
   },
   "wooden_hoe": {
     "result": {
-      "item": "minecraft:wooden_hoe"
+      "count": 1,
+      "id": "minecraft:wooden_hoe"
     },
     "pattern": [
       "XX",
@@ -7645,7 +8097,8 @@
   },
   "wooden_pickaxe": {
     "result": {
-      "item": "minecraft:wooden_pickaxe"
+      "count": 1,
+      "id": "minecraft:wooden_pickaxe"
     },
     "pattern": [
       "XXX",
@@ -7667,7 +8120,8 @@
   },
   "wooden_shovel": {
     "result": {
-      "item": "minecraft:wooden_shovel"
+      "count": 1,
+      "id": "minecraft:wooden_shovel"
     },
     "pattern": [
       "X",
@@ -7689,7 +8143,8 @@
   },
   "wooden_sword": {
     "result": {
-      "item": "minecraft:wooden_sword"
+      "count": 1,
+      "id": "minecraft:wooden_sword"
     },
     "pattern": [
       "X",
@@ -7711,7 +8166,8 @@
   },
   "writable_book": {
     "result": {
-      "item": "minecraft:writable_book"
+      "count": 1,
+      "id": "minecraft:writable_book"
     },
     "ingredients": [
       {
@@ -7728,7 +8184,8 @@
   },
   "yellow_banner": {
     "result": {
-      "item": "minecraft:yellow_banner"
+      "count": 1,
+      "id": "minecraft:yellow_banner"
     },
     "pattern": [
       "###",
@@ -7747,8 +8204,8 @@
   },
   "yellow_carpet": {
     "result": {
-      "item": "minecraft:yellow_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:yellow_carpet"
     },
     "pattern": [
       "##"
@@ -7762,7 +8219,8 @@
   },
   "yellow_dye_from_dandelion": {
     "result": {
-      "item": "minecraft:yellow_dye"
+      "count": 1,
+      "id": "minecraft:yellow_dye"
     },
     "ingredients": [
       {
@@ -7773,8 +8231,8 @@
   },
   "yellow_dye_from_sunflower": {
     "result": {
-      "item": "minecraft:yellow_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:yellow_dye"
     },
     "ingredients": [
       {
@@ -7785,8 +8243,8 @@
   },
   "yellow_stained_glass": {
     "result": {
-      "item": "minecraft:yellow_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:yellow_stained_glass"
     },
     "pattern": [
       "###",
@@ -7805,8 +8263,8 @@
   },
   "yellow_stained_glass_pane": {
     "result": {
-      "item": "minecraft:yellow_stained_glass_pane",
-      "count": 16
+      "count": 16,
+      "id": "minecraft:yellow_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -7821,8 +8279,8 @@
   },
   "yellow_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:yellow_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:yellow_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -7841,8 +8299,8 @@
   },
   "yellow_terracotta": {
     "result": {
-      "item": "minecraft:yellow_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:yellow_terracotta"
     },
     "pattern": [
       "###",
@@ -7861,7 +8319,7 @@
   },
   "yellow_wool": {
     "result": {
-      "item": "minecraft:yellow_wool"
+      "id": "minecraft:yellow_wool"
     },
     "ingredients": [
       {
@@ -7878,8 +8336,8 @@
   },
   "acacia_door": {
     "result": {
-      "item": "minecraft:acacia_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:acacia_door"
     },
     "pattern": [
       "##",
@@ -7898,8 +8356,8 @@
   },
   "acacia_fence": {
     "result": {
-      "item": "minecraft:acacia_fence",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:acacia_fence"
     },
     "pattern": [
       "W#W",
@@ -7920,7 +8378,8 @@
   },
   "acacia_fence_gate": {
     "result": {
-      "item": "minecraft:acacia_fence_gate"
+      "count": 1,
+      "id": "minecraft:acacia_fence_gate"
     },
     "pattern": [
       "#W#",
@@ -7940,7 +8399,9 @@
     }
   },
   "amplified_leaping_potion": {
-    "result": "minecraft.potion.effect.leaping.ii",
+    "result": {
+      "id": "minecraft.potion.effect.leaping.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -7953,7 +8414,9 @@
     }
   },
   "amplified_leaping_splash_potion": {
-    "result": "minecraft.splash_potion.effect.leaping.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.leaping.ii"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -7967,8 +8430,8 @@
   },
   "andesite": {
     "result": {
-      "item": "minecraft:andesite",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:andesite"
     },
     "ingredients": [
       {
@@ -7985,7 +8448,8 @@
   },
   "armor_stand": {
     "result": {
-      "item": "minecraft:armor_stand"
+      "count": 1,
+      "id": "minecraft:armor_stand"
     },
     "pattern": [
       "///",
@@ -8007,8 +8471,8 @@
   },
   "birch_door": {
     "result": {
-      "item": "minecraft:birch_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:birch_door"
     },
     "pattern": [
       "##",
@@ -8027,8 +8491,8 @@
   },
   "birch_fence": {
     "result": {
-      "item": "minecraft:birch_fence",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:birch_fence"
     },
     "pattern": [
       "W#W",
@@ -8049,7 +8513,8 @@
   },
   "birch_fence_gate": {
     "result": {
-      "item": "minecraft:birch_fence_gate"
+      "count": 1,
+      "id": "minecraft:birch_fence_gate"
     },
     "pattern": [
       "#W#",
@@ -8070,7 +8535,8 @@
   },
   "chiseled_stone_bricks": {
     "result": {
-      "item": "minecraft:chiseled_stone_bricks"
+      "count": 1,
+      "id": "minecraft:chiseled_stone_bricks"
     },
     "pattern": [
       "#",
@@ -8088,8 +8554,8 @@
   },
   "coarse_dirt": {
     "result": {
-      "item": "minecraft:coarse_dirt",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:coarse_dirt"
     },
     "pattern": [
       "DG",
@@ -8109,7 +8575,9 @@
     }
   },
   "cooked_mutton_from_campfire_cooking": {
-    "result": "minecraft:cooked_mutton",
+    "result": {
+      "id": "minecraft:cooked_mutton"
+    },
     "ingredient": {
       "item": "minecraft:mutton"
     },
@@ -8120,7 +8588,9 @@
     }
   },
   "cooked_mutton_from_smoking": {
-    "result": "minecraft:cooked_mutton",
+    "result": {
+      "id": "minecraft:cooked_mutton"
+    },
     "ingredient": {
       "item": "minecraft:mutton"
     },
@@ -8131,7 +8601,9 @@
     }
   },
   "cracked_stone_bricks": {
-    "result": "minecraft:cracked_stone_bricks",
+    "result": {
+      "id": "minecraft:cracked_stone_bricks"
+    },
     "ingredient": {
       "item": "minecraft:stone_bricks"
     },
@@ -8143,8 +8615,8 @@
   },
   "dark_oak_door": {
     "result": {
-      "item": "minecraft:dark_oak_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:dark_oak_door"
     },
     "pattern": [
       "##",
@@ -8163,8 +8635,8 @@
   },
   "dark_oak_fence": {
     "result": {
-      "item": "minecraft:dark_oak_fence",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:dark_oak_fence"
     },
     "pattern": [
       "W#W",
@@ -8185,7 +8657,8 @@
   },
   "dark_oak_fence_gate": {
     "result": {
-      "item": "minecraft:dark_oak_fence_gate"
+      "count": 1,
+      "id": "minecraft:dark_oak_fence_gate"
     },
     "pattern": [
       "#W#",
@@ -8206,7 +8679,7 @@
   },
   "dark_prismarine_legacy": {
     "result": {
-      "item": "minecraft:dark_prismarine"
+      "id": "minecraft:dark_prismarine"
     },
     "pattern": [
       "SSS",
@@ -8229,8 +8702,8 @@
   },
   "diorite": {
     "result": {
-      "item": "minecraft:diorite",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:diorite"
     },
     "pattern": [
       "CQ",
@@ -8250,7 +8723,9 @@
     }
   },
   "extended_leaping_potion": {
-    "result": "minecraft.potion.effect.leaping.extended",
+    "result": {
+      "id": "minecraft.potion.effect.leaping.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -8263,7 +8738,9 @@
     }
   },
   "extended_leaping_splash_potion": {
-    "result": "minecraft.splash_potion.effect.leaping.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.leaping.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -8277,7 +8754,8 @@
   },
   "granite": {
     "result": {
-      "item": "minecraft:granite"
+      "count": 1,
+      "id": "minecraft:granite"
     },
     "ingredients": [
       {
@@ -8294,7 +8772,8 @@
   },
   "iron_trapdoor": {
     "result": {
-      "item": "minecraft:iron_trapdoor"
+      "count": 1,
+      "id": "minecraft:iron_trapdoor"
     },
     "pattern": [
       "##",
@@ -8312,8 +8791,8 @@
   },
   "jungle_door": {
     "result": {
-      "item": "minecraft:jungle_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:jungle_door"
     },
     "pattern": [
       "##",
@@ -8332,8 +8811,8 @@
   },
   "jungle_fence": {
     "result": {
-      "item": "minecraft:jungle_fence",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:jungle_fence"
     },
     "pattern": [
       "W#W",
@@ -8354,7 +8833,8 @@
   },
   "jungle_fence_gate": {
     "result": {
-      "item": "minecraft:jungle_fence_gate"
+      "count": 1,
+      "id": "minecraft:jungle_fence_gate"
     },
     "pattern": [
       "#W#",
@@ -8374,7 +8854,9 @@
     }
   },
   "leaping_potion": {
-    "result": "minecraft.potion.effect.leaping",
+    "result": {
+      "id": "minecraft.potion.effect.leaping"
+    },
     "reagent": {
       "item": "minecraft:rabbit_foot"
     },
@@ -8387,7 +8869,9 @@
     }
   },
   "leaping_splash_potion": {
-    "result": "minecraft.splash_potion.effect.leaping",
+    "result": {
+      "id": "minecraft.splash_potion.effect.leaping"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -8401,7 +8885,8 @@
   },
   "leather": {
     "result": {
-      "item": "minecraft:leather"
+      "count": 1,
+      "id": "minecraft:leather"
     },
     "pattern": [
       "##",
@@ -8419,7 +8904,8 @@
   },
   "mossy_cobblestone_from_vine": {
     "result": {
-      "item": "minecraft:mossy_cobblestone"
+      "count": 1,
+      "id": "minecraft:mossy_cobblestone"
     },
     "ingredients": [
       {
@@ -8436,7 +8922,8 @@
   },
   "mossy_stone_bricks_from_vine": {
     "result": {
-      "item": "minecraft:mossy_stone_bricks"
+      "count": 1,
+      "id": "minecraft:mossy_stone_bricks"
     },
     "ingredients": [
       {
@@ -8453,8 +8940,8 @@
   },
   "polished_andesite": {
     "result": {
-      "item": "minecraft:polished_andesite",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_andesite"
     },
     "pattern": [
       "SS",
@@ -8472,8 +8959,8 @@
   },
   "polished_diorite": {
     "result": {
-      "item": "minecraft:polished_diorite",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_diorite"
     },
     "pattern": [
       "SS",
@@ -8491,8 +8978,8 @@
   },
   "polished_granite": {
     "result": {
-      "item": "minecraft:polished_granite",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_granite"
     },
     "pattern": [
       "SS",
@@ -8510,7 +8997,8 @@
   },
   "prismarine": {
     "result": {
-      "item": "minecraft:prismarine"
+      "count": 1,
+      "id": "minecraft:prismarine"
     },
     "pattern": [
       "##",
@@ -8528,7 +9016,8 @@
   },
   "prismarine_bricks": {
     "result": {
-      "item": "minecraft:prismarine_bricks"
+      "count": 1,
+      "id": "minecraft:prismarine_bricks"
     },
     "ingredients": [
       {
@@ -8566,7 +9055,8 @@
   },
   "rabbit_stew_from_brown_mushroom": {
     "result": {
-      "item": "minecraft:rabbit_stew"
+      "count": 1,
+      "id": "minecraft:rabbit_stew"
     },
     "ingredients": [
       {
@@ -8597,7 +9087,8 @@
   },
   "rabbit_stew_from_red_mushroom": {
     "result": {
-      "item": "minecraft:rabbit_stew"
+      "count": 1,
+      "id": "minecraft:rabbit_stew"
     },
     "ingredients": [
       {
@@ -8628,7 +9119,8 @@
   },
   "red_sandstone": {
     "result": {
-      "item": "minecraft:red_sandstone"
+      "count": 1,
+      "id": "minecraft:red_sandstone"
     },
     "pattern": [
       "##",
@@ -8646,7 +9138,8 @@
   },
   "sea_lantern": {
     "result": {
-      "item": "minecraft:sea_lantern"
+      "count": 1,
+      "id": "minecraft:sea_lantern"
     },
     "pattern": [
       "SCS",
@@ -8668,8 +9161,8 @@
   },
   "slime_ball": {
     "result": {
-      "item": "minecraft:slime_ball",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:slime_ball"
     },
     "ingredients": [
       {
@@ -8683,7 +9176,8 @@
   },
   "slime_block": {
     "result": {
-      "item": "minecraft:slime_block"
+      "count": 1,
+      "id": "minecraft:slime_block"
     },
     "pattern": [
       "###",
@@ -8701,7 +9195,9 @@
     }
   },
   "smooth_red_sandstone": {
-    "result": "minecraft:smooth_red_sandstone",
+    "result": {
+      "id": "minecraft:smooth_red_sandstone"
+    },
     "ingredient": {
       "item": "minecraft:red_sandstone"
     },
@@ -8712,7 +9208,9 @@
     }
   },
   "splash_amplified_leaping_potion": {
-    "result": "minecraft.splash_potion.effect.leaping.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.leaping.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -8725,7 +9223,9 @@
     }
   },
   "splash_extended_leaping_potion": {
-    "result": "minecraft.splash_potion.effect.leaping.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.leaping.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -8738,7 +9238,9 @@
     }
   },
   "splash_leaping_potion": {
-    "result": "minecraft.splash_potion.effect.leaping",
+    "result": {
+      "id": "minecraft.splash_potion.effect.leaping"
+    },
     "reagent": {
       "item": "minecraft:rabbit_foot"
     },
@@ -8751,11 +9253,13 @@
     }
   },
   "sponge": {
-    "result": "minecraft:sponge",
+    "result": {
+      "id": "minecraft:sponge"
+    },
     "ingredient": {
       "item": "minecraft:wet_sponge"
     },
-    "type": "minecraft.smelting_special_sponge",
+    "type": "minecraft:smelting",
     "experience": 0.15,
     "lang": {
       "en_US": {
@@ -8768,8 +9272,8 @@
   },
   "spruce_door": {
     "result": {
-      "item": "minecraft:spruce_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:spruce_door"
     },
     "pattern": [
       "##",
@@ -8788,8 +9292,8 @@
   },
   "spruce_fence": {
     "result": {
-      "item": "minecraft:spruce_fence",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:spruce_fence"
     },
     "pattern": [
       "W#W",
@@ -8810,7 +9314,8 @@
   },
   "spruce_fence_gate": {
     "result": {
-      "item": "minecraft:spruce_fence_gate"
+      "count": 1,
+      "id": "minecraft:spruce_fence_gate"
     },
     "pattern": [
       "#W#",
@@ -8831,7 +9336,8 @@
   },
   "white_banner": {
     "result": {
-      "item": "minecraft:white_banner"
+      "count": 1,
+      "id": "minecraft:white_banner"
     },
     "pattern": [
       "###",
@@ -8853,7 +9359,8 @@
   },
   "acacia_boat": {
     "result": {
-      "item": "minecraft:acacia_boat"
+      "count": 1,
+      "id": "minecraft:acacia_boat"
     },
     "pattern": [
       "# #",
@@ -8870,7 +9377,9 @@
     }
   },
   "amplified_harming_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.harming.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.harming.ii"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -8883,7 +9392,9 @@
     }
   },
   "amplified_healing_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.healing.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.healing.ii"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -8896,7 +9407,9 @@
     }
   },
   "amplified_leaping_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.leaping.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.leaping.ii"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -8909,7 +9422,9 @@
     }
   },
   "amplified_poison_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.poison.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.poison.ii"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -8922,7 +9437,9 @@
     }
   },
   "amplified_regeneration_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.regeneration.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.regeneration.ii"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -8935,7 +9452,9 @@
     }
   },
   "amplified_strength_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.strength.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.strength.ii"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -8948,7 +9467,9 @@
     }
   },
   "amplified_swiftness_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.swiftness.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.swiftness.ii"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -8961,7 +9482,9 @@
     }
   },
   "awkward_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.awkward",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.awkward"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -8974,7 +9497,9 @@
     }
   },
   "awkward_splash_potion": {
-    "result": "minecraft.splash_potion.effect.awkward",
+    "result": {
+      "id": "minecraft.splash_potion.effect.awkward"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -8988,7 +9513,8 @@
   },
   "beetroot_soup": {
     "result": {
-      "item": "minecraft:beetroot_soup"
+      "count": 1,
+      "id": "minecraft:beetroot_soup"
     },
     "ingredients": [
       {
@@ -9025,7 +9551,8 @@
   },
   "birch_boat": {
     "result": {
-      "item": "minecraft:birch_boat"
+      "count": 1,
+      "id": "minecraft:birch_boat"
     },
     "pattern": [
       "# #",
@@ -9043,7 +9570,8 @@
   },
   "dark_oak_boat": {
     "result": {
-      "item": "minecraft:dark_oak_boat"
+      "count": 1,
+      "id": "minecraft:dark_oak_boat"
     },
     "pattern": [
       "# #",
@@ -9060,7 +9588,9 @@
     }
   },
   "empty_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.empty",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.empty"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9073,7 +9603,9 @@
     }
   },
   "empty_splash_potion": {
-    "result": "minecraft.splash_potion.effect.empty",
+    "result": {
+      "id": "minecraft.splash_potion.effect.empty"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -9087,7 +9619,8 @@
   },
   "end_crystal": {
     "result": {
-      "item": "minecraft:end_crystal"
+      "count": 1,
+      "id": "minecraft:end_crystal"
     },
     "pattern": [
       "GGG",
@@ -9112,8 +9645,8 @@
   },
   "end_rod": {
     "result": {
-      "item": "minecraft:end_rod",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:end_rod"
     },
     "pattern": [
       "/",
@@ -9134,8 +9667,8 @@
   },
   "end_stone_bricks": {
     "result": {
-      "item": "minecraft:end_stone_bricks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:end_stone_bricks"
     },
     "pattern": [
       "##",
@@ -9152,7 +9685,9 @@
     }
   },
   "extended_fire_resistance_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.fire_resistance.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.fire_resistance.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9165,7 +9700,9 @@
     }
   },
   "extended_invisibility_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.invisibility.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.invisibility.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9178,7 +9715,9 @@
     }
   },
   "extended_leaping_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.leaping.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.leaping.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9191,7 +9730,9 @@
     }
   },
   "extended_mundane_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.mundane.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.mundane.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9204,7 +9745,9 @@
     }
   },
   "extended_mundane_splash_potion": {
-    "result": "minecraft.splash_potion.effect.mundane.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.mundane.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -9217,7 +9760,9 @@
     }
   },
   "extended_night_vision_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.night_vision.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.night_vision.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9230,7 +9775,9 @@
     }
   },
   "extended_poison_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.poison.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.poison.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9243,7 +9790,9 @@
     }
   },
   "extended_regeneration_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.regeneration.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.regeneration.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9256,7 +9805,9 @@
     }
   },
   "extended_slowness_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.slowness.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slowness.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9269,7 +9820,9 @@
     }
   },
   "extended_strength_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.strength.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.strength.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9282,7 +9835,9 @@
     }
   },
   "extended_swiftness_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.swiftness.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.swiftness.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9295,7 +9850,9 @@
     }
   },
   "extended_water_breathing_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.water_breathing.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.water_breathing.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9308,7 +9865,9 @@
     }
   },
   "extended_weakness_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.weakness.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.weakness.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9321,7 +9880,9 @@
     }
   },
   "fire_resistance_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.fire_resistance",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.fire_resistance"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9334,7 +9895,9 @@
     }
   },
   "harming_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.harming",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.harming"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9347,7 +9910,9 @@
     }
   },
   "healing_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.healing",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.healing"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9360,7 +9925,9 @@
     }
   },
   "invisibility_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.invisibility",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.invisibility"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9374,7 +9941,8 @@
   },
   "jungle_boat": {
     "result": {
-      "item": "minecraft:jungle_boat"
+      "count": 1,
+      "id": "minecraft:jungle_boat"
     },
     "pattern": [
       "# #",
@@ -9391,7 +9959,9 @@
     }
   },
   "leaping_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.leaping",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.leaping"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -9404,7 +9974,9 @@
     }
   },
   "lingering_amplified_harming_potion": {
-    "result": "minecraft.lingering_potion.effect.harming.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.harming.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -9417,7 +9989,9 @@
     }
   },
   "lingering_amplified_harming_potion_from_corrupt": {
-    "result": "minecraft.lingering_potion.effect.harming.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.harming.ii"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -9435,7 +10009,9 @@
     ]
   },
   "lingering_amplified_healing_potion": {
-    "result": "minecraft.lingering_potion.effect.healing.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.healing.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -9448,7 +10024,9 @@
     }
   },
   "lingering_amplified_leaping_potion": {
-    "result": "minecraft.lingering_potion.effect.leaping.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.leaping.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -9461,7 +10039,9 @@
     }
   },
   "lingering_amplified_poison_potion": {
-    "result": "minecraft.lingering_potion.effect.poison.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.poison.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -9474,7 +10054,9 @@
     }
   },
   "lingering_amplified_regeneration_potion": {
-    "result": "minecraft.lingering_potion.effect.regeneration.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.regeneration.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -9487,7 +10069,9 @@
     }
   },
   "lingering_amplified_strength_potion": {
-    "result": "minecraft.lingering_potion.effect.strength.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.strength.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -9500,7 +10084,9 @@
     }
   },
   "lingering_amplified_swiftness_potion": {
-    "result": "minecraft.lingering_potion.effect.swiftness.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.swiftness.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -9513,7 +10099,9 @@
     }
   },
   "lingering_awkward_potion": {
-    "result": "minecraft.lingering_potion.effect.awkward",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.awkward"
+    },
     "reagent": {
       "item": "minecraft:nether_wart"
     },
@@ -9526,7 +10114,9 @@
     }
   },
   "lingering_extended_fire_resistance_potion": {
-    "result": "minecraft.lingering_potion.effect.fire_resistance.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.fire_resistance.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -9539,7 +10129,9 @@
     }
   },
   "lingering_extended_invisibility_potion": {
-    "result": "minecraft.lingering_potion.effect.invisibility.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.invisibility.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -9552,7 +10144,9 @@
     }
   },
   "lingering_extended_invisibility_potion_from_corrupt": {
-    "result": "minecraft.lingering_potion.effect.invisibility.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.invisibility.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -9565,7 +10159,9 @@
     }
   },
   "lingering_extended_leaping_potion": {
-    "result": "minecraft.lingering_potion.effect.leaping.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.leaping.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -9578,7 +10174,9 @@
     }
   },
   "lingering_extended_night_vision_potion": {
-    "result": "minecraft.lingering_potion.effect.night_vision.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.night_vision.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -9591,7 +10189,9 @@
     }
   },
   "lingering_extended_poison_potion": {
-    "result": "minecraft.lingering_potion.effect.poison.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.poison.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -9604,7 +10204,9 @@
     }
   },
   "lingering_extended_regeneration_potion": {
-    "result": "minecraft.lingering_potion.effect.regeneration.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.regeneration.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -9617,7 +10219,9 @@
     }
   },
   "lingering_extended_slowness_potion": {
-    "result": "minecraft.lingering_potion.effect.slowness.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slowness.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -9630,7 +10234,9 @@
     }
   },
   "lingering_extended_slowness_potion_from_corrupt": {
-    "result": "minecraft.lingering_potion.effect.slowness.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slowness.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -9648,7 +10254,9 @@
     ]
   },
   "lingering_extended_slowness_potion_from_corrupt_legacy": {
-    "result": "minecraft.lingering_potion.effect.slowness.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slowness.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -9661,7 +10269,9 @@
     }
   },
   "lingering_extended_strength_potion": {
-    "result": "minecraft.lingering_potion.effect.strength.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.strength.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -9674,7 +10284,9 @@
     }
   },
   "lingering_extended_swiftness_potion": {
-    "result": "minecraft.lingering_potion.effect.swiftness.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.swiftness.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -9687,7 +10299,9 @@
     }
   },
   "lingering_extended_water_breathing_potion": {
-    "result": "minecraft.lingering_potion.effect.water_breathing.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.water_breathing.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -9700,7 +10314,9 @@
     }
   },
   "lingering_extended_weakness_potion": {
-    "result": "minecraft.lingering_potion.effect.weakness.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.weakness.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -9713,7 +10329,9 @@
     }
   },
   "lingering_extended_weakness_potion_from_corrupt": {
-    "result": "minecraft.lingering_potion.effect.weakness.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.weakness.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -9731,7 +10349,9 @@
     ]
   },
   "lingering_extended_weakness_potion_legacy": {
-    "result": "minecraft.lingering_potion.effect.weakness.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.weakness.extended"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -9744,7 +10364,9 @@
     }
   },
   "lingering_fire_resistance_potion": {
-    "result": "minecraft.lingering_potion.effect.fire_resistance",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.fire_resistance"
+    },
     "reagent": {
       "item": "minecraft:magma_cream"
     },
@@ -9757,7 +10379,9 @@
     }
   },
   "lingering_harming_potion": {
-    "result": "minecraft.lingering_potion.effect.harming",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.harming"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -9775,7 +10399,9 @@
     ]
   },
   "lingering_harming_potion_from_corrupt_legacy": {
-    "result": "minecraft.lingering_potion.effect.harming",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.harming"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -9788,7 +10414,9 @@
     }
   },
   "lingering_healing_potion": {
-    "result": "minecraft.lingering_potion.effect.healing",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.healing"
+    },
     "reagent": {
       "item": "minecraft:glistering_melon_slice"
     },
@@ -9801,7 +10429,9 @@
     }
   },
   "lingering_invisibility_potion": {
-    "result": "minecraft.lingering_potion.effect.invisibility",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.invisibility"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -9814,7 +10444,9 @@
     }
   },
   "lingering_leaping_potion": {
-    "result": "minecraft.lingering_potion.effect.leaping",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.leaping"
+    },
     "reagent": {
       "item": "minecraft:rabbit_foot"
     },
@@ -9827,7 +10459,9 @@
     }
   },
   "lingering_mundane_potion": {
-    "result": "minecraft.lingering_potion.effect.mundane",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.mundane"
+    },
     "reagent": [
       {
         "item": "minecraft:spider_eye"
@@ -9864,7 +10498,9 @@
     }
   },
   "lingering_night_vision_potion": {
-    "result": "minecraft.lingering_potion.effect.night_vision",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.night_vision"
+    },
     "reagent": {
       "item": "minecraft:golden_carrot"
     },
@@ -9877,7 +10513,9 @@
     }
   },
   "lingering_poison_potion": {
-    "result": "minecraft.lingering_potion.effect.poison",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.poison"
+    },
     "reagent": {
       "item": "minecraft:spider_eye"
     },
@@ -9890,7 +10528,9 @@
     }
   },
   "lingering_regeneration_potion": {
-    "result": "minecraft.lingering_potion.effect.regeneration",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.regeneration"
+    },
     "reagent": {
       "item": "minecraft:ghast_tear"
     },
@@ -9903,7 +10543,9 @@
     }
   },
   "lingering_slowness_potion": {
-    "result": "minecraft.lingering_potion.effect.slowness",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slowness"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -9921,7 +10563,9 @@
     ]
   },
   "lingering_slowness_potion_from_corrupt_legacy": {
-    "result": "minecraft.lingering_potion.effect.slowness",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slowness"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -9934,7 +10578,9 @@
     }
   },
   "lingering_strength_potion": {
-    "result": "minecraft.lingering_potion.effect.strength",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.strength"
+    },
     "reagent": {
       "item": "minecraft:blaze_powder"
     },
@@ -9947,7 +10593,9 @@
     }
   },
   "lingering_swiftness_potion": {
-    "result": "minecraft.lingering_potion.effect.swiftness",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.swiftness"
+    },
     "reagent": {
       "item": "minecraft:sugar"
     },
@@ -9960,7 +10608,9 @@
     }
   },
   "lingering_water_breathing_potion": {
-    "result": "minecraft.lingering_potion.effect.water_breathing",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.water_breathing"
+    },
     "reagent": {
       "item": "minecraft:pufferfish"
     },
@@ -9973,7 +10623,9 @@
     }
   },
   "lingering_weakness_potion": {
-    "result": "minecraft.lingering_potion.effect.harming",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.harming"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -9994,7 +10646,9 @@
     ]
   },
   "lingering_weakness_potion_legacy": {
-    "result": "minecraft.lingering_potion.effect.weakness",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.weakness"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -10015,7 +10669,9 @@
     ]
   },
   "mundane_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.mundane",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.mundane"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -10028,7 +10684,9 @@
     }
   },
   "mundane_splash_potion": {
-    "result": "minecraft.splash_potion.effect.mundane",
+    "result": {
+      "id": "minecraft.splash_potion.effect.mundane"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -10041,7 +10699,9 @@
     }
   },
   "night_vision_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.night_vision",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.night_vision"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -10054,7 +10714,9 @@
     }
   },
   "poison_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.poison",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.poison"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -10067,7 +10729,9 @@
     }
   },
   "popped_chorus_fruit": {
-    "result": "minecraft:popped_chorus_fruit",
+    "result": {
+      "id": "minecraft:popped_chorus_fruit"
+    },
     "ingredient": {
       "item": "minecraft:chorus_fruit"
     },
@@ -10079,8 +10743,8 @@
   },
   "purpur_block": {
     "result": {
-      "item": "minecraft:purpur_block",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:purpur_block"
     },
     "pattern": [
       "FF",
@@ -10098,7 +10762,8 @@
   },
   "purpur_pillar": {
     "result": {
-      "item": "minecraft:purpur_pillar"
+      "count": 1,
+      "id": "minecraft:purpur_pillar"
     },
     "pattern": [
       "#",
@@ -10116,8 +10781,8 @@
   },
   "purpur_slab": {
     "result": {
-      "item": "minecraft:purpur_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:purpur_slab"
     },
     "pattern": [
       "###"
@@ -10140,8 +10805,8 @@
   },
   "purpur_stairs": {
     "result": {
-      "item": "minecraft:purpur_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:purpur_stairs"
     },
     "pattern": [
       "#  ",
@@ -10166,7 +10831,8 @@
   },
   "red_dye_from_beetroot": {
     "result": {
-      "item": "minecraft:red_dye"
+      "count": 1,
+      "id": "minecraft:red_dye"
     },
     "ingredients": [
       {
@@ -10179,7 +10845,9 @@
     }
   },
   "regeneration_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.regeneration",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.regeneration"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -10193,7 +10861,8 @@
   },
   "shield": {
     "result": {
-      "item": "minecraft:shield"
+      "count": 1,
+      "id": "minecraft:shield"
     },
     "pattern": [
       "WoW",
@@ -10215,7 +10884,9 @@
     }
   },
   "slowness_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.slowness",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slowness"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -10229,8 +10900,8 @@
   },
   "spectral_arrow": {
     "result": {
-      "item": "minecraft:spectral_arrow",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:spectral_arrow"
     },
     "pattern": [
       " # ",
@@ -10251,7 +10922,9 @@
     }
   },
   "splash_awkward_potion": {
-    "result": "minecraft.splash_potion.effect.awkward",
+    "result": {
+      "id": "minecraft.splash_potion.effect.awkward"
+    },
     "reagent": {
       "item": "minecraft:nether_wart"
     },
@@ -10264,7 +10937,9 @@
     }
   },
   "splash_mundane_potion": {
-    "result": "minecraft.splash_potion.effect.mundane",
+    "result": {
+      "id": "minecraft.splash_potion.effect.mundane"
+    },
     "reagent": [
       {
         "item": "minecraft:spider_eye"
@@ -10301,7 +10976,9 @@
     }
   },
   "splash_thick_potion": {
-    "result": "minecraft.splash_potion.effect.thick",
+    "result": {
+      "id": "minecraft.splash_potion.effect.thick"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -10315,7 +10992,8 @@
   },
   "spruce_boat": {
     "result": {
-      "item": "minecraft:spruce_boat"
+      "count": 1,
+      "id": "minecraft:spruce_boat"
     },
     "pattern": [
       "# #",
@@ -10332,7 +11010,9 @@
     }
   },
   "strength_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.strength",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.strength"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -10345,7 +11025,9 @@
     }
   },
   "swiftness_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.swiftness",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.swiftness"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -10358,7 +11040,9 @@
     }
   },
   "thick_splash_potion": {
-    "result": "minecraft.splash_potion.effect.thick",
+    "result": {
+      "id": "minecraft.splash_potion.effect.thick"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -10372,8 +11056,8 @@
   },
   "tipped_arrow_awkward": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.awkward",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.awkward"
     },
     "pattern": [
       "AAA",
@@ -10395,8 +11079,8 @@
   },
   "tipped_arrow_fire_resistance": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.fire_resistance",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.fire_resistance"
     },
     "pattern": [
       "AAA",
@@ -10418,8 +11102,8 @@
   },
   "tipped_arrow_fire_resistance_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.fire_resistance.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.fire_resistance.extended"
     },
     "pattern": [
       "AAA",
@@ -10441,8 +11125,8 @@
   },
   "tipped_arrow_harming": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.harming",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.harming"
     },
     "pattern": [
       "AAA",
@@ -10464,8 +11148,8 @@
   },
   "tipped_arrow_harming_ii": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.harming.ii",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.harming.ii"
     },
     "pattern": [
       "AAA",
@@ -10487,8 +11171,8 @@
   },
   "tipped_arrow_healing": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.healing",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.healing"
     },
     "pattern": [
       "AAA",
@@ -10510,8 +11194,8 @@
   },
   "tipped_arrow_healing_ii": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.healing.ii",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.healing.ii"
     },
     "pattern": [
       "AAA",
@@ -10533,8 +11217,8 @@
   },
   "tipped_arrow_invisibility": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.invisibility",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.invisibility"
     },
     "pattern": [
       "AAA",
@@ -10556,8 +11240,8 @@
   },
   "tipped_arrow_invisibility_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.invisibility.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.invisibility.extended"
     },
     "pattern": [
       "AAA",
@@ -10579,8 +11263,8 @@
   },
   "tipped_arrow_leaping": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.leaping",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.leaping"
     },
     "pattern": [
       "AAA",
@@ -10602,8 +11286,8 @@
   },
   "tipped_arrow_leaping_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.leaping.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.leaping.extended"
     },
     "pattern": [
       "AAA",
@@ -10625,8 +11309,8 @@
   },
   "tipped_arrow_leaping_ii": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.leaping.ii",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.leaping.ii"
     },
     "pattern": [
       "AAA",
@@ -10648,8 +11332,8 @@
   },
   "tipped_arrow_luck": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.luck",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.luck"
     },
     "pattern": [
       "AAA",
@@ -10671,8 +11355,8 @@
   },
   "tipped_arrow_mundane": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.mundane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.mundane"
     },
     "pattern": [
       "AAA",
@@ -10694,8 +11378,8 @@
   },
   "tipped_arrow_mundane_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.mundane.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.mundane.extended"
     },
     "pattern": [
       "AAA",
@@ -10717,8 +11401,8 @@
   },
   "tipped_arrow_night_vision": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.night_vision",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.night_vision"
     },
     "pattern": [
       "AAA",
@@ -10740,8 +11424,8 @@
   },
   "tipped_arrow_night_vision_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.night_vision.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.night_vision.extended"
     },
     "pattern": [
       "AAA",
@@ -10763,8 +11447,8 @@
   },
   "tipped_arrow_poison": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.poison",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.poison"
     },
     "pattern": [
       "AAA",
@@ -10786,8 +11470,8 @@
   },
   "tipped_arrow_poison_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.poison.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.poison.extended"
     },
     "pattern": [
       "AAA",
@@ -10809,8 +11493,8 @@
   },
   "tipped_arrow_poison_ii": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.poison.ii",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.poison.ii"
     },
     "pattern": [
       "AAA",
@@ -10832,8 +11516,8 @@
   },
   "tipped_arrow_regeneration": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.regeneration",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.regeneration"
     },
     "pattern": [
       "AAA",
@@ -10855,8 +11539,8 @@
   },
   "tipped_arrow_regeneration_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.regeneration.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.regeneration.extended"
     },
     "pattern": [
       "AAA",
@@ -10878,8 +11562,8 @@
   },
   "tipped_arrow_regeneration_ii": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.regeneration.ii",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.regeneration.ii"
     },
     "pattern": [
       "AAA",
@@ -10901,8 +11585,8 @@
   },
   "tipped_arrow_slowness": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.slowness",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.slowness"
     },
     "pattern": [
       "AAA",
@@ -10924,8 +11608,8 @@
   },
   "tipped_arrow_slowness_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.slowness.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.slowness.extended"
     },
     "pattern": [
       "AAA",
@@ -10947,8 +11631,8 @@
   },
   "tipped_arrow_slowness_iv": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.slowness.iv",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.slowness.iv"
     },
     "pattern": [
       "AAA",
@@ -10970,8 +11654,8 @@
   },
   "tipped_arrow_strength": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.strength",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.strength"
     },
     "pattern": [
       "AAA",
@@ -10993,8 +11677,8 @@
   },
   "tipped_arrow_strength_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.strength.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.strength.extended"
     },
     "pattern": [
       "AAA",
@@ -11016,8 +11700,8 @@
   },
   "tipped_arrow_strength_ii": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.strength.ii",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.strength.ii"
     },
     "pattern": [
       "AAA",
@@ -11039,8 +11723,8 @@
   },
   "tipped_arrow_swiftness": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.swiftness",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.swiftness"
     },
     "pattern": [
       "AAA",
@@ -11062,8 +11746,8 @@
   },
   "tipped_arrow_swiftness_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.swiftness.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.swiftness.extended"
     },
     "pattern": [
       "AAA",
@@ -11085,8 +11769,8 @@
   },
   "tipped_arrow_swiftness_ii": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.swiftness.ii",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.swiftness.ii"
     },
     "pattern": [
       "AAA",
@@ -11108,8 +11792,8 @@
   },
   "tipped_arrow_water": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.water",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.water"
     },
     "pattern": [
       "AAA",
@@ -11131,8 +11815,8 @@
   },
   "tipped_arrow_water_breathing": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.water_breathing",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.water_breathing"
     },
     "pattern": [
       "AAA",
@@ -11154,8 +11838,8 @@
   },
   "tipped_arrow_water_breathing_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.water_breathing.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.water_breathing.extended"
     },
     "pattern": [
       "AAA",
@@ -11177,8 +11861,8 @@
   },
   "tipped_arrow_weakness": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.weakness",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.weakness"
     },
     "pattern": [
       "AAA",
@@ -11200,8 +11884,8 @@
   },
   "tipped_arrow_weakness_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.weakness.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.weakness.extended"
     },
     "pattern": [
       "AAA",
@@ -11222,7 +11906,9 @@
     }
   },
   "water_breathing_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.water_breathing",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.water_breathing"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -11235,7 +11921,9 @@
     }
   },
   "water_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.water",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.water"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -11248,7 +11936,9 @@
     }
   },
   "water_splash_potion": {
-    "result": "minecraft.splash_potion.effect.water",
+    "result": {
+      "id": "minecraft.splash_potion.effect.water"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -11261,7 +11951,9 @@
     }
   },
   "weakness_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.weakness",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.weakness"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -11275,7 +11967,8 @@
   },
   "bone_block": {
     "result": {
-      "item": "minecraft:bone_block"
+      "count": 1,
+      "id": "minecraft:bone_block"
     },
     "pattern": [
       "###",
@@ -11294,8 +11987,8 @@
   },
   "bone_meal_from_bone_block": {
     "result": {
-      "item": "minecraft:bone_meal",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:bone_meal"
     },
     "ingredients": [
       {
@@ -11309,7 +12002,8 @@
   },
   "magma_block": {
     "result": {
-      "item": "minecraft:magma_block"
+      "count": 1,
+      "id": "minecraft:magma_block"
     },
     "pattern": [
       "##",
@@ -11327,7 +12021,8 @@
   },
   "nether_wart_block": {
     "result": {
-      "item": "minecraft:nether_wart_block"
+      "count": 1,
+      "id": "minecraft:nether_wart_block"
     },
     "ingredients": [
       {
@@ -11365,7 +12060,8 @@
   },
   "red_nether_bricks": {
     "result": {
-      "item": "minecraft:red_nether_bricks"
+      "count": 1,
+      "id": "minecraft:red_nether_bricks"
     },
     "pattern": [
       "NW",
@@ -11385,7 +12081,9 @@
     }
   },
   "gold_nugget_from_smelting": {
-    "result": "minecraft:gold_nugget",
+    "result": {
+      "id": "minecraft:gold_nugget"
+    },
     "ingredient": [
       {
         "item": "minecraft:golden_pickaxe"
@@ -11427,7 +12125,8 @@
   },
   "iron_ingot_from_nuggets": {
     "result": {
-      "item": "minecraft:iron_ingot"
+      "count": 1,
+      "id": "minecraft:iron_ingot"
     },
     "pattern": [
       "###",
@@ -11446,8 +12145,8 @@
   },
   "iron_nugget": {
     "result": {
-      "item": "minecraft:iron_nugget",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:iron_nugget"
     },
     "ingredients": [
       {
@@ -11460,7 +12159,9 @@
     }
   },
   "iron_nugget_from_blasting": {
-    "result": "minecraft:iron_nugget",
+    "result": {
+      "id": "minecraft:iron_nugget"
+    },
     "ingredient": [
       {
         "item": "minecraft:iron_pickaxe"
@@ -11512,7 +12213,9 @@
     }
   },
   "iron_nugget_from_smelting": {
-    "result": "minecraft:iron_nugget",
+    "result": {
+      "id": "minecraft:iron_nugget"
+    },
     "ingredient": [
       {
         "item": "minecraft:iron_pickaxe"
@@ -11566,7 +12269,8 @@
   },
   "observer": {
     "result": {
-      "item": "minecraft:observer"
+      "count": 1,
+      "id": "minecraft:observer"
     },
     "pattern": [
       "###",
@@ -11591,7 +12295,8 @@
   },
   "shulker_box": {
     "result": {
-      "item": "minecraft:shulker_box"
+      "count": 1,
+      "id": "minecraft:shulker_box"
     },
     "pattern": [
       "-",
@@ -11613,7 +12318,7 @@
   },
   "shulker_box_coloring_black_legacy": {
     "result": {
-      "item": "minecraft:black_shulker_box"
+      "id": "minecraft:black_shulker_box"
     },
     "ingredients": [
       {
@@ -11679,7 +12384,7 @@
   },
   "shulker_box_coloring_blue_legacy": {
     "result": {
-      "item": "minecraft:blue_shulker_box"
+      "id": "minecraft:blue_shulker_box"
     },
     "ingredients": [
       {
@@ -11745,7 +12450,7 @@
   },
   "shulker_box_coloring_brown_legacy": {
     "result": {
-      "item": "minecraft:brown_shulker_box"
+      "id": "minecraft:brown_shulker_box"
     },
     "ingredients": [
       {
@@ -11811,7 +12516,7 @@
   },
   "shulker_box_coloring_cyan": {
     "result": {
-      "item": "minecraft:cyan_shulker_box"
+      "id": "minecraft:cyan_shulker_box"
     },
     "ingredients": [
       {
@@ -11876,7 +12581,7 @@
   },
   "shulker_box_coloring_gray": {
     "result": {
-      "item": "minecraft:gray_shulker_box"
+      "id": "minecraft:gray_shulker_box"
     },
     "ingredients": [
       {
@@ -11941,7 +12646,7 @@
   },
   "shulker_box_coloring_green": {
     "result": {
-      "item": "minecraft:green_shulker_box"
+      "id": "minecraft:green_shulker_box"
     },
     "ingredients": [
       {
@@ -12006,7 +12711,7 @@
   },
   "shulker_box_coloring_light_blue": {
     "result": {
-      "item": "minecraft:light_blue_shulker_box"
+      "id": "minecraft:light_blue_shulker_box"
     },
     "ingredients": [
       {
@@ -12071,7 +12776,7 @@
   },
   "shulker_box_coloring_light_gray": {
     "result": {
-      "item": "minecraft:light_gray_shulker_box"
+      "id": "minecraft:light_gray_shulker_box"
     },
     "ingredients": [
       {
@@ -12136,7 +12841,7 @@
   },
   "shulker_box_coloring_lime": {
     "result": {
-      "item": "minecraft:lime_shulker_box"
+      "id": "minecraft:lime_shulker_box"
     },
     "ingredients": [
       {
@@ -12201,7 +12906,7 @@
   },
   "shulker_box_coloring_magenta": {
     "result": {
-      "item": "minecraft:magenta_shulker_box"
+      "id": "minecraft:magenta_shulker_box"
     },
     "ingredients": [
       {
@@ -12266,7 +12971,7 @@
   },
   "shulker_box_coloring_orange": {
     "result": {
-      "item": "minecraft:orange_shulker_box"
+      "id": "minecraft:orange_shulker_box"
     },
     "ingredients": [
       {
@@ -12331,7 +13036,7 @@
   },
   "shulker_box_coloring_pink": {
     "result": {
-      "item": "minecraft:pink_shulker_box"
+      "id": "minecraft:pink_shulker_box"
     },
     "ingredients": [
       {
@@ -12396,7 +13101,7 @@
   },
   "shulker_box_coloring_red": {
     "result": {
-      "item": "minecraft:red_shulker_box"
+      "id": "minecraft:red_shulker_box"
     },
     "ingredients": [
       {
@@ -12461,7 +13166,7 @@
   },
   "shulker_box_coloring_white_legacy": {
     "result": {
-      "item": "minecraft:white_shulker_box"
+      "id": "minecraft:white_shulker_box"
     },
     "ingredients": [
       {
@@ -12527,7 +13232,7 @@
   },
   "shulker_box_coloring_yellow": {
     "result": {
-      "item": "minecraft:yellow_shulker_box"
+      "id": "minecraft:yellow_shulker_box"
     },
     "ingredients": [
       {
@@ -12592,7 +13297,8 @@
   },
   "black_bed": {
     "result": {
-      "item": "minecraft:black_bed"
+      "count": 1,
+      "id": "minecraft:black_bed"
     },
     "pattern": [
       "###",
@@ -12614,7 +13320,7 @@
   },
   "black_bed_from_white_bed_legacy": {
     "result": {
-      "item": "minecraft:black_bed"
+      "id": "minecraft:black_bed"
     },
     "ingredients": [
       {
@@ -12632,8 +13338,8 @@
   },
   "black_concrete_powder_legacy": {
     "result": {
-      "item": "minecraft:black_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:black_concrete_powder"
     },
     "ingredients": [
       {
@@ -12671,7 +13377,9 @@
     }
   },
   "black_glazed_terracotta": {
-    "result": "minecraft:black_glazed_terracotta",
+    "result": {
+      "id": "minecraft:black_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:black_terracotta"
     },
@@ -12683,7 +13391,8 @@
   },
   "blue_bed": {
     "result": {
-      "item": "minecraft:blue_bed"
+      "count": 1,
+      "id": "minecraft:blue_bed"
     },
     "pattern": [
       "###",
@@ -12705,7 +13414,7 @@
   },
   "blue_bed_from_white_bed_legacy": {
     "result": {
-      "item": "minecraft:blue_bed"
+      "id": "minecraft:blue_bed"
     },
     "ingredients": [
       {
@@ -12723,8 +13432,8 @@
   },
   "blue_concrete_powder_legacy": {
     "result": {
-      "item": "minecraft:blue_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:blue_concrete_powder"
     },
     "ingredients": [
       {
@@ -12762,7 +13471,9 @@
     }
   },
   "blue_glazed_terracotta": {
-    "result": "minecraft:blue_glazed_terracotta",
+    "result": {
+      "id": "minecraft:blue_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:blue_terracotta"
     },
@@ -12774,7 +13485,8 @@
   },
   "brown_bed": {
     "result": {
-      "item": "minecraft:brown_bed"
+      "count": 1,
+      "id": "minecraft:brown_bed"
     },
     "pattern": [
       "###",
@@ -12796,7 +13508,7 @@
   },
   "brown_bed_from_white_bed_legacy": {
     "result": {
-      "item": "minecraft:brown_bed"
+      "id": "minecraft:brown_bed"
     },
     "ingredients": [
       {
@@ -12814,8 +13526,8 @@
   },
   "brown_concrete_powder_legacy": {
     "result": {
-      "item": "minecraft:brown_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:brown_concrete_powder"
     },
     "ingredients": [
       {
@@ -12853,7 +13565,9 @@
     }
   },
   "brown_glazed_terracotta": {
-    "result": "minecraft:brown_glazed_terracotta",
+    "result": {
+      "id": "minecraft:brown_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:brown_terracotta"
     },
@@ -12865,7 +13579,8 @@
   },
   "cyan_bed": {
     "result": {
-      "item": "minecraft:cyan_bed"
+      "count": 1,
+      "id": "minecraft:cyan_bed"
     },
     "pattern": [
       "###",
@@ -12887,7 +13602,7 @@
   },
   "cyan_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:cyan_bed"
+      "id": "minecraft:cyan_bed"
     },
     "ingredients": [
       {
@@ -12905,8 +13620,8 @@
   },
   "cyan_concrete_powder": {
     "result": {
-      "item": "minecraft:cyan_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:cyan_concrete_powder"
     },
     "ingredients": [
       {
@@ -12943,7 +13658,9 @@
     }
   },
   "cyan_glazed_terracotta": {
-    "result": "minecraft:cyan_glazed_terracotta",
+    "result": {
+      "id": "minecraft:cyan_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:cyan_terracotta"
     },
@@ -12955,7 +13672,8 @@
   },
   "gray_bed": {
     "result": {
-      "item": "minecraft:gray_bed"
+      "count": 1,
+      "id": "minecraft:gray_bed"
     },
     "pattern": [
       "###",
@@ -12977,7 +13695,7 @@
   },
   "gray_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:gray_bed"
+      "id": "minecraft:gray_bed"
     },
     "ingredients": [
       {
@@ -12995,8 +13713,8 @@
   },
   "gray_concrete_powder": {
     "result": {
-      "item": "minecraft:gray_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:gray_concrete_powder"
     },
     "ingredients": [
       {
@@ -13033,7 +13751,9 @@
     }
   },
   "gray_glazed_terracotta": {
-    "result": "minecraft:gray_glazed_terracotta",
+    "result": {
+      "id": "minecraft:gray_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:gray_terracotta"
     },
@@ -13045,7 +13765,8 @@
   },
   "green_bed": {
     "result": {
-      "item": "minecraft:green_bed"
+      "count": 1,
+      "id": "minecraft:green_bed"
     },
     "pattern": [
       "###",
@@ -13067,7 +13788,7 @@
   },
   "green_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:green_bed"
+      "id": "minecraft:green_bed"
     },
     "ingredients": [
       {
@@ -13085,8 +13806,8 @@
   },
   "green_concrete_powder": {
     "result": {
-      "item": "minecraft:green_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:green_concrete_powder"
     },
     "ingredients": [
       {
@@ -13123,7 +13844,9 @@
     }
   },
   "green_glazed_terracotta": {
-    "result": "minecraft:green_glazed_terracotta",
+    "result": {
+      "id": "minecraft:green_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:green_terracotta"
     },
@@ -13135,7 +13858,8 @@
   },
   "light_blue_bed": {
     "result": {
-      "item": "minecraft:light_blue_bed"
+      "count": 1,
+      "id": "minecraft:light_blue_bed"
     },
     "pattern": [
       "###",
@@ -13157,7 +13881,7 @@
   },
   "light_blue_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:light_blue_bed"
+      "id": "minecraft:light_blue_bed"
     },
     "ingredients": [
       {
@@ -13175,8 +13899,8 @@
   },
   "light_blue_concrete_powder": {
     "result": {
-      "item": "minecraft:light_blue_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:light_blue_concrete_powder"
     },
     "ingredients": [
       {
@@ -13213,7 +13937,9 @@
     }
   },
   "light_blue_glazed_terracotta": {
-    "result": "minecraft:light_blue_glazed_terracotta",
+    "result": {
+      "id": "minecraft:light_blue_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:light_blue_terracotta"
     },
@@ -13225,7 +13951,8 @@
   },
   "light_gray_bed": {
     "result": {
-      "item": "minecraft:light_gray_bed"
+      "count": 1,
+      "id": "minecraft:light_gray_bed"
     },
     "pattern": [
       "###",
@@ -13247,7 +13974,7 @@
   },
   "light_gray_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:light_gray_bed"
+      "id": "minecraft:light_gray_bed"
     },
     "ingredients": [
       {
@@ -13265,8 +13992,8 @@
   },
   "light_gray_concrete_powder": {
     "result": {
-      "item": "minecraft:light_gray_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:light_gray_concrete_powder"
     },
     "ingredients": [
       {
@@ -13303,7 +14030,9 @@
     }
   },
   "light_gray_glazed_terracotta": {
-    "result": "minecraft:light_gray_glazed_terracotta",
+    "result": {
+      "id": "minecraft:light_gray_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:light_gray_terracotta"
     },
@@ -13315,7 +14044,8 @@
   },
   "lime_bed": {
     "result": {
-      "item": "minecraft:lime_bed"
+      "count": 1,
+      "id": "minecraft:lime_bed"
     },
     "pattern": [
       "###",
@@ -13337,7 +14067,7 @@
   },
   "lime_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:lime_bed"
+      "id": "minecraft:lime_bed"
     },
     "ingredients": [
       {
@@ -13355,8 +14085,8 @@
   },
   "lime_concrete_powder": {
     "result": {
-      "item": "minecraft:lime_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:lime_concrete_powder"
     },
     "ingredients": [
       {
@@ -13393,7 +14123,9 @@
     }
   },
   "lime_glazed_terracotta": {
-    "result": "minecraft:lime_glazed_terracotta",
+    "result": {
+      "id": "minecraft:lime_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:lime_terracotta"
     },
@@ -13405,7 +14137,8 @@
   },
   "magenta_bed": {
     "result": {
-      "item": "minecraft:magenta_bed"
+      "count": 1,
+      "id": "minecraft:magenta_bed"
     },
     "pattern": [
       "###",
@@ -13427,7 +14160,7 @@
   },
   "magenta_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:magenta_bed"
+      "id": "minecraft:magenta_bed"
     },
     "ingredients": [
       {
@@ -13445,8 +14178,8 @@
   },
   "magenta_concrete_powder": {
     "result": {
-      "item": "minecraft:magenta_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:magenta_concrete_powder"
     },
     "ingredients": [
       {
@@ -13483,7 +14216,9 @@
     }
   },
   "magenta_glazed_terracotta": {
-    "result": "minecraft:magenta_glazed_terracotta",
+    "result": {
+      "id": "minecraft:magenta_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:magenta_terracotta"
     },
@@ -13495,7 +14230,8 @@
   },
   "orange_bed": {
     "result": {
-      "item": "minecraft:orange_bed"
+      "count": 1,
+      "id": "minecraft:orange_bed"
     },
     "pattern": [
       "###",
@@ -13517,7 +14253,7 @@
   },
   "orange_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:orange_bed"
+      "id": "minecraft:orange_bed"
     },
     "ingredients": [
       {
@@ -13535,8 +14271,8 @@
   },
   "orange_concrete_powder": {
     "result": {
-      "item": "minecraft:orange_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:orange_concrete_powder"
     },
     "ingredients": [
       {
@@ -13573,7 +14309,9 @@
     }
   },
   "orange_glazed_terracotta": {
-    "result": "minecraft:orange_glazed_terracotta",
+    "result": {
+      "id": "minecraft:orange_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:orange_terracotta"
     },
@@ -13585,7 +14323,8 @@
   },
   "pink_bed": {
     "result": {
-      "item": "minecraft:pink_bed"
+      "count": 1,
+      "id": "minecraft:pink_bed"
     },
     "pattern": [
       "###",
@@ -13607,7 +14346,7 @@
   },
   "pink_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:pink_bed"
+      "id": "minecraft:pink_bed"
     },
     "ingredients": [
       {
@@ -13625,8 +14364,8 @@
   },
   "pink_concrete_powder": {
     "result": {
-      "item": "minecraft:pink_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:pink_concrete_powder"
     },
     "ingredients": [
       {
@@ -13663,7 +14402,9 @@
     }
   },
   "pink_glazed_terracotta": {
-    "result": "minecraft:pink_glazed_terracotta",
+    "result": {
+      "id": "minecraft:pink_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:pink_terracotta"
     },
@@ -13675,7 +14416,8 @@
   },
   "purple_bed": {
     "result": {
-      "item": "minecraft:purple_bed"
+      "count": 1,
+      "id": "minecraft:purple_bed"
     },
     "pattern": [
       "###",
@@ -13697,7 +14439,7 @@
   },
   "purple_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:purple_bed"
+      "id": "minecraft:purple_bed"
     },
     "ingredients": [
       {
@@ -13715,8 +14457,8 @@
   },
   "purple_concrete_powder": {
     "result": {
-      "item": "minecraft:purple_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:purple_concrete_powder"
     },
     "ingredients": [
       {
@@ -13753,7 +14495,9 @@
     }
   },
   "purple_glazed_terracotta": {
-    "result": "minecraft:purple_glazed_terracotta",
+    "result": {
+      "id": "minecraft:purple_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:purple_terracotta"
     },
@@ -13765,7 +14509,8 @@
   },
   "red_bed": {
     "result": {
-      "item": "minecraft:red_bed"
+      "count": 1,
+      "id": "minecraft:red_bed"
     },
     "pattern": [
       "###",
@@ -13787,7 +14532,7 @@
   },
   "red_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:red_bed"
+      "id": "minecraft:red_bed"
     },
     "ingredients": [
       {
@@ -13805,8 +14550,8 @@
   },
   "red_concrete_powder": {
     "result": {
-      "item": "minecraft:red_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:red_concrete_powder"
     },
     "ingredients": [
       {
@@ -13843,7 +14588,9 @@
     }
   },
   "red_glazed_terracotta": {
-    "result": "minecraft:red_glazed_terracotta",
+    "result": {
+      "id": "minecraft:red_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:red_terracotta"
     },
@@ -13855,7 +14602,8 @@
   },
   "white_bed": {
     "result": {
-      "item": "minecraft:white_bed"
+      "count": 1,
+      "id": "minecraft:white_bed"
     },
     "pattern": [
       "###",
@@ -13877,8 +14625,8 @@
   },
   "white_concrete_powder_legacy": {
     "result": {
-      "item": "minecraft:white_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:white_concrete_powder"
     },
     "ingredients": [
       {
@@ -13916,7 +14664,9 @@
     }
   },
   "white_glazed_terracotta": {
-    "result": "minecraft:white_glazed_terracotta",
+    "result": {
+      "id": "minecraft:white_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:white_terracotta"
     },
@@ -13928,7 +14678,8 @@
   },
   "yellow_bed": {
     "result": {
-      "item": "minecraft:yellow_bed"
+      "count": 1,
+      "id": "minecraft:yellow_bed"
     },
     "pattern": [
       "###",
@@ -13950,7 +14701,7 @@
   },
   "yellow_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:yellow_bed"
+      "id": "minecraft:yellow_bed"
     },
     "ingredients": [
       {
@@ -13968,8 +14719,8 @@
   },
   "yellow_concrete_powder": {
     "result": {
-      "item": "minecraft:yellow_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:yellow_concrete_powder"
     },
     "ingredients": [
       {
@@ -14006,7 +14757,9 @@
     }
   },
   "yellow_glazed_terracotta": {
-    "result": "minecraft:yellow_glazed_terracotta",
+    "result": {
+      "id": "minecraft:yellow_glazed_terracotta"
+    },
     "ingredient": {
       "item": "minecraft:yellow_terracotta"
     },
@@ -14018,7 +14771,8 @@
   },
   "acacia_button": {
     "result": {
-      "item": "minecraft:acacia_button"
+      "count": 1,
+      "id": "minecraft:acacia_button"
     },
     "ingredients": [
       {
@@ -14032,7 +14786,8 @@
   },
   "acacia_pressure_plate": {
     "result": {
-      "item": "minecraft:acacia_pressure_plate"
+      "count": 1,
+      "id": "minecraft:acacia_pressure_plate"
     },
     "pattern": [
       "##"
@@ -14049,8 +14804,8 @@
   },
   "acacia_trapdoor": {
     "result": {
-      "item": "minecraft:acacia_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:acacia_trapdoor"
     },
     "pattern": [
       "###",
@@ -14068,8 +14823,8 @@
   },
   "acacia_wood": {
     "result": {
-      "item": "minecraft:acacia_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:acacia_wood"
     },
     "pattern": [
       "##",
@@ -14086,7 +14841,9 @@
     }
   },
   "amplified_slowness_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.slowness.iv",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slowness.iv"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -14099,7 +14856,9 @@
     }
   },
   "amplified_slowness_potion": {
-    "result": "minecraft.potion.effect.slowness.iv",
+    "result": {
+      "id": "minecraft.potion.effect.slowness.iv"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -14112,7 +14871,9 @@
     }
   },
   "amplified_slowness_potion_from_corrupt": {
-    "result": "minecraft.potion.effect.slowness.iv",
+    "result": {
+      "id": "minecraft.potion.effect.slowness.iv"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -14131,7 +14892,9 @@
     ]
   },
   "amplified_slowness_splash_potion": {
-    "result": "minecraft.splash_potion.effect.slowness.iv",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slowness.iv"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -14144,7 +14907,9 @@
     }
   },
   "amplified_turtle_master_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.turtle_master.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.turtle_master.ii"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -14157,7 +14922,9 @@
     }
   },
   "amplified_turtle_master_potion": {
-    "result": "minecraft.potion.effect.turtle_master.ii",
+    "result": {
+      "id": "minecraft.potion.effect.turtle_master.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -14170,7 +14937,9 @@
     }
   },
   "amplified_turtle_master_splash_potion": {
-    "result": "minecraft.splash_potion.effect.turtle_master.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.turtle_master.ii"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -14184,7 +14953,8 @@
   },
   "birch_button": {
     "result": {
-      "item": "minecraft:birch_button"
+      "count": 1,
+      "id": "minecraft:birch_button"
     },
     "ingredients": [
       {
@@ -14198,7 +14968,8 @@
   },
   "birch_pressure_plate": {
     "result": {
-      "item": "minecraft:birch_pressure_plate"
+      "count": 1,
+      "id": "minecraft:birch_pressure_plate"
     },
     "pattern": [
       "##"
@@ -14215,8 +14986,8 @@
   },
   "birch_trapdoor": {
     "result": {
-      "item": "minecraft:birch_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:birch_trapdoor"
     },
     "pattern": [
       "###",
@@ -14234,8 +15005,8 @@
   },
   "birch_wood": {
     "result": {
-      "item": "minecraft:birch_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:birch_wood"
     },
     "pattern": [
       "##",
@@ -14253,7 +15024,8 @@
   },
   "blue_ice": {
     "result": {
-      "item": "minecraft:blue_ice"
+      "count": 1,
+      "id": "minecraft:blue_ice"
     },
     "ingredients": [
       {
@@ -14291,7 +15063,8 @@
   },
   "conduit": {
     "result": {
-      "item": "minecraft:conduit"
+      "count": 1,
+      "id": "minecraft:conduit"
     },
     "pattern": [
       "###",
@@ -14313,8 +15086,8 @@
   },
   "cut_red_sandstone": {
     "result": {
-      "item": "minecraft:cut_red_sandstone",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:cut_red_sandstone"
     },
     "pattern": [
       "##",
@@ -14332,8 +15105,8 @@
   },
   "cut_red_sandstone_slab": {
     "result": {
-      "item": "minecraft:cut_red_sandstone_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:cut_red_sandstone_slab"
     },
     "pattern": [
       "###"
@@ -14350,8 +15123,8 @@
   },
   "cut_sandstone": {
     "result": {
-      "item": "minecraft:cut_sandstone",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:cut_sandstone"
     },
     "pattern": [
       "##",
@@ -14369,8 +15142,8 @@
   },
   "cut_sandstone_slab": {
     "result": {
-      "item": "minecraft:cut_sandstone_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:cut_sandstone_slab"
     },
     "pattern": [
       "###"
@@ -14387,7 +15160,8 @@
   },
   "dark_oak_button": {
     "result": {
-      "item": "minecraft:dark_oak_button"
+      "count": 1,
+      "id": "minecraft:dark_oak_button"
     },
     "ingredients": [
       {
@@ -14401,7 +15175,8 @@
   },
   "dark_oak_pressure_plate": {
     "result": {
-      "item": "minecraft:dark_oak_pressure_plate"
+      "count": 1,
+      "id": "minecraft:dark_oak_pressure_plate"
     },
     "pattern": [
       "##"
@@ -14418,8 +15193,8 @@
   },
   "dark_oak_trapdoor": {
     "result": {
-      "item": "minecraft:dark_oak_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:dark_oak_trapdoor"
     },
     "pattern": [
       "###",
@@ -14437,8 +15212,8 @@
   },
   "dark_oak_wood": {
     "result": {
-      "item": "minecraft:dark_oak_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:dark_oak_wood"
     },
     "pattern": [
       "##",
@@ -14456,8 +15231,8 @@
   },
   "dark_prismarine_slab": {
     "result": {
-      "item": "minecraft:dark_prismarine_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:dark_prismarine_slab"
     },
     "pattern": [
       "###"
@@ -14474,8 +15249,8 @@
   },
   "dark_prismarine_stairs": {
     "result": {
-      "item": "minecraft:dark_prismarine_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:dark_prismarine_stairs"
     },
     "pattern": [
       "#  ",
@@ -14494,8 +15269,8 @@
   },
   "dried_kelp": {
     "result": {
-      "item": "minecraft:dried_kelp",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:dried_kelp"
     },
     "ingredients": [
       {
@@ -14509,7 +15284,8 @@
   },
   "dried_kelp_block": {
     "result": {
-      "item": "minecraft:dried_kelp_block"
+      "count": 1,
+      "id": "minecraft:dried_kelp_block"
     },
     "pattern": [
       "###",
@@ -14527,7 +15303,9 @@
     }
   },
   "dried_kelp_from_campfire_cooking": {
-    "result": "minecraft:dried_kelp",
+    "result": {
+      "id": "minecraft:dried_kelp"
+    },
     "ingredient": {
       "item": "minecraft:kelp"
     },
@@ -14538,7 +15316,9 @@
     }
   },
   "dried_kelp_from_smelting": {
-    "result": "minecraft:dried_kelp",
+    "result": {
+      "id": "minecraft:dried_kelp"
+    },
     "ingredient": {
       "item": "minecraft:kelp"
     },
@@ -14549,7 +15329,9 @@
     }
   },
   "dried_kelp_from_smoking": {
-    "result": "minecraft:dried_kelp",
+    "result": {
+      "id": "minecraft:dried_kelp"
+    },
     "ingredient": {
       "item": "minecraft:kelp"
     },
@@ -14560,7 +15342,9 @@
     }
   },
   "extended_slow_falling_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.slow_falling.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slow_falling.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -14573,7 +15357,9 @@
     }
   },
   "extended_slow_falling_potion": {
-    "result": "minecraft.potion.effect.slow_falling.extended",
+    "result": {
+      "id": "minecraft.potion.effect.slow_falling.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -14586,7 +15372,9 @@
     }
   },
   "extended_slow_falling_splash_potion": {
-    "result": "minecraft.splash_potion.effect.slow_falling.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slow_falling.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -14599,7 +15387,9 @@
     }
   },
   "extended_turtle_master_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.turtle_master.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.turtle_master.extended"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -14612,7 +15402,9 @@
     }
   },
   "extended_turtle_master_potion": {
-    "result": "minecraft.potion.effect.turtle_master.extended",
+    "result": {
+      "id": "minecraft.potion.effect.turtle_master.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -14625,7 +15417,9 @@
     }
   },
   "extended_turtle_master_splash_potion": {
-    "result": "minecraft.splash_potion.effect.turtle_master.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.turtle_master.extended"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -14639,7 +15433,8 @@
   },
   "jungle_button": {
     "result": {
-      "item": "minecraft:jungle_button"
+      "count": 1,
+      "id": "minecraft:jungle_button"
     },
     "ingredients": [
       {
@@ -14653,7 +15448,8 @@
   },
   "jungle_pressure_plate": {
     "result": {
-      "item": "minecraft:jungle_pressure_plate"
+      "count": 1,
+      "id": "minecraft:jungle_pressure_plate"
     },
     "pattern": [
       "##"
@@ -14670,8 +15466,8 @@
   },
   "jungle_trapdoor": {
     "result": {
-      "item": "minecraft:jungle_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:jungle_trapdoor"
     },
     "pattern": [
       "###",
@@ -14689,8 +15485,8 @@
   },
   "jungle_wood": {
     "result": {
-      "item": "minecraft:jungle_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:jungle_wood"
     },
     "pattern": [
       "##",
@@ -14707,7 +15503,9 @@
     }
   },
   "lime_dye_from_smelting": {
-    "result": "minecraft:lime_dye",
+    "result": {
+      "id": "minecraft:lime_dye"
+    },
     "ingredient": {
       "item": "minecraft:sea_pickle"
     },
@@ -14718,7 +15516,9 @@
     }
   },
   "lingering_amplified_slowness_potion": {
-    "result": "minecraft.lingering_potion.effect.slowness.iv",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slowness.iv"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -14731,7 +15531,9 @@
     }
   },
   "lingering_amplified_slowness_potion_from_corrupt": {
-    "result": "minecraft.lingering_potion.effect.slowness.iv",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slowness.iv"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -14749,7 +15551,9 @@
     ]
   },
   "lingering_amplified_turtle_master_potion": {
-    "result": "minecraft.lingering_potion.effect.turtle_master.ii",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.turtle_master.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -14762,7 +15566,9 @@
     }
   },
   "lingering_extended_slow_falling_potion": {
-    "result": "minecraft.lingering_potion.effect.slow_falling.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slow_falling.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -14775,7 +15581,9 @@
     }
   },
   "lingering_extended_turtle_master_potion": {
-    "result": "minecraft.lingering_potion.effect.turtle_master.extended",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.turtle_master.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -14788,7 +15596,9 @@
     }
   },
   "lingering_slow_falling_potion": {
-    "result": "minecraft.lingering_potion.effect.slow_falling",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slow_falling"
+    },
     "reagent": {
       "item": "minecraft:phantom_membrane"
     },
@@ -14801,7 +15611,9 @@
     }
   },
   "lingering_turtle_master_potion": {
-    "result": "minecraft.lingering_potion.effect.turtle_master",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.turtle_master"
+    },
     "reagent": {
       "item": "minecraft:turtle_helmet"
     },
@@ -14815,8 +15627,8 @@
   },
   "oak_wood": {
     "result": {
-      "item": "minecraft:oak_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:oak_wood"
     },
     "pattern": [
       "##",
@@ -14834,7 +15646,8 @@
   },
   "packed_ice": {
     "result": {
-      "item": "minecraft:packed_ice"
+      "count": 1,
+      "id": "minecraft:packed_ice"
     },
     "ingredients": [
       {
@@ -14872,8 +15685,8 @@
   },
   "prismarine_brick_slab": {
     "result": {
-      "item": "minecraft:prismarine_brick_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:prismarine_brick_slab"
     },
     "pattern": [
       "###"
@@ -14890,8 +15703,8 @@
   },
   "prismarine_brick_stairs": {
     "result": {
-      "item": "minecraft:prismarine_brick_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:prismarine_brick_stairs"
     },
     "pattern": [
       "#  ",
@@ -14910,8 +15723,8 @@
   },
   "prismarine_slab": {
     "result": {
-      "item": "minecraft:prismarine_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:prismarine_slab"
     },
     "pattern": [
       "###"
@@ -14928,8 +15741,8 @@
   },
   "prismarine_stairs": {
     "result": {
-      "item": "minecraft:prismarine_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:prismarine_stairs"
     },
     "pattern": [
       "#  ",
@@ -14948,7 +15761,8 @@
   },
   "pumpkin_pie": {
     "result": {
-      "item": "minecraft:pumpkin_pie"
+      "count": 1,
+      "id": "minecraft:pumpkin_pie"
     },
     "ingredients": [
       {
@@ -14968,8 +15782,8 @@
   },
   "pumpkin_seeds": {
     "result": {
-      "item": "minecraft:pumpkin_seeds",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:pumpkin_seeds"
     },
     "ingredients": [
       {
@@ -14983,7 +15797,7 @@
   },
   "shulker_box_coloring_purple": {
     "result": {
-      "item": "minecraft:purple_shulker_box"
+      "id": "minecraft:purple_shulker_box"
     },
     "ingredients": [
       {
@@ -15047,7 +15861,9 @@
     }
   },
   "slow_falling_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.slow_falling",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.slow_falling"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -15060,7 +15876,9 @@
     }
   },
   "slow_falling_potion": {
-    "result": "minecraft.potion.effect.slow_falling",
+    "result": {
+      "id": "minecraft.potion.effect.slow_falling"
+    },
     "reagent": {
       "item": "minecraft:phantom_membrane"
     },
@@ -15073,7 +15891,9 @@
     }
   },
   "slow_falling_splash_potion": {
-    "result": "minecraft.splash_potion.effect.slow_falling",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slow_falling"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -15086,7 +15906,9 @@
     }
   },
   "splash_amplified_slowness_potion": {
-    "result": "minecraft.splash_potion.effect.slowness.iv",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slowness.iv"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -15099,7 +15921,9 @@
     }
   },
   "splash_amplified_slowness_potion_from_corrupt": {
-    "result": "minecraft.splash_potion.effect.slowness.iv",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slowness.iv"
+    },
     "reagent": {
       "item": "minecraft:fermented_spider_eye"
     },
@@ -15118,7 +15942,9 @@
     ]
   },
   "splash_amplified_turtle_master_potion": {
-    "result": "minecraft.splash_potion.effect.turtle_master.ii",
+    "result": {
+      "id": "minecraft.splash_potion.effect.turtle_master.ii"
+    },
     "reagent": {
       "item": "minecraft:glowstone_dust"
     },
@@ -15131,7 +15957,9 @@
     }
   },
   "splash_extended_slow_falling_potion": {
-    "result": "minecraft.splash_potion.effect.slow_falling.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slow_falling.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -15144,7 +15972,9 @@
     }
   },
   "splash_extended_turtle_master_potion": {
-    "result": "minecraft.splash_potion.effect.turtle_master.extended",
+    "result": {
+      "id": "minecraft.splash_potion.effect.turtle_master.extended"
+    },
     "reagent": {
       "item": "minecraft:redstone"
     },
@@ -15157,7 +15987,9 @@
     }
   },
   "splash_slow_falling_potion": {
-    "result": "minecraft.splash_potion.effect.slow_falling",
+    "result": {
+      "id": "minecraft.splash_potion.effect.slow_falling"
+    },
     "reagent": {
       "item": "minecraft:phantom_membrane"
     },
@@ -15170,7 +16002,9 @@
     }
   },
   "splash_turtle_master_potion": {
-    "result": "minecraft.splash_potion.effect.turtle_master",
+    "result": {
+      "id": "minecraft.splash_potion.effect.turtle_master"
+    },
     "reagent": {
       "item": "minecraft:turtle_helmet"
     },
@@ -15184,7 +16018,8 @@
   },
   "spruce_button": {
     "result": {
-      "item": "minecraft:spruce_button"
+      "count": 1,
+      "id": "minecraft:spruce_button"
     },
     "ingredients": [
       {
@@ -15198,7 +16033,8 @@
   },
   "spruce_pressure_plate": {
     "result": {
-      "item": "minecraft:spruce_pressure_plate"
+      "count": 1,
+      "id": "minecraft:spruce_pressure_plate"
     },
     "pattern": [
       "##"
@@ -15215,8 +16051,8 @@
   },
   "spruce_trapdoor": {
     "result": {
-      "item": "minecraft:spruce_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:spruce_trapdoor"
     },
     "pattern": [
       "###",
@@ -15234,8 +16070,8 @@
   },
   "spruce_wood": {
     "result": {
-      "item": "minecraft:spruce_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:spruce_wood"
     },
     "pattern": [
       "##",
@@ -15253,8 +16089,8 @@
   },
   "stone_slab": {
     "result": {
-      "item": "minecraft:stone_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:stone_slab"
     },
     "pattern": [
       "###"
@@ -15271,8 +16107,8 @@
   },
   "tipped_arrow_slow_falling": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.slow_falling",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.slow_falling"
     },
     "pattern": [
       "AAA",
@@ -15294,8 +16130,8 @@
   },
   "tipped_arrow_slow_falling_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.slow_falling.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.slow_falling.extended"
     },
     "pattern": [
       "AAA",
@@ -15317,8 +16153,8 @@
   },
   "tipped_arrow_turtle_master": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.turtle_master",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.turtle_master"
     },
     "pattern": [
       "AAA",
@@ -15340,8 +16176,8 @@
   },
   "tipped_arrow_turtle_master_extended": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.turtle_master.extended",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.turtle_master.extended"
     },
     "pattern": [
       "AAA",
@@ -15363,8 +16199,8 @@
   },
   "tipped_arrow_turtle_master_ii": {
     "result": {
-      "item": "minecraft.tipped_arrow.effect.turtle_master.ii",
-      "count": 8
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.turtle_master.ii"
     },
     "pattern": [
       "AAA",
@@ -15386,7 +16222,8 @@
   },
   "turtle_helmet": {
     "result": {
-      "item": "minecraft:turtle_helmet"
+      "count": 1,
+      "id": "minecraft:turtle_helmet"
     },
     "pattern": [
       "XXX",
@@ -15395,7 +16232,7 @@
     "type": "minecraft:crafting_shaped",
     "key": {
       "X": {
-        "item": "minecraft:scute"
+        "item": "minecraft:turtle_scute"
       }
     },
     "properties": {
@@ -15403,7 +16240,9 @@
     }
   },
   "turtle_master_lingering_potion": {
-    "result": "minecraft.lingering_potion.effect.turtle_master",
+    "result": {
+      "id": "minecraft.lingering_potion.effect.turtle_master"
+    },
     "reagent": {
       "item": "minecraft:dragon_breath"
     },
@@ -15416,7 +16255,9 @@
     }
   },
   "turtle_master_potion": {
-    "result": "minecraft.potion.effect.turtle_master",
+    "result": {
+      "id": "minecraft.potion.effect.turtle_master"
+    },
     "reagent": {
       "item": "minecraft:turtle_helmet"
     },
@@ -15429,7 +16270,9 @@
     }
   },
   "turtle_master_splash_potion": {
-    "result": "minecraft.splash_potion.effect.turtle_master",
+    "result": {
+      "id": "minecraft.splash_potion.effect.turtle_master"
+    },
     "reagent": {
       "item": "minecraft:gunpowder"
     },
@@ -15443,8 +16286,8 @@
   },
   "acacia_sign": {
     "result": {
-      "item": "minecraft:acacia_sign",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:acacia_sign"
     },
     "pattern": [
       "###",
@@ -15466,8 +16309,8 @@
   },
   "andesite_slab": {
     "result": {
-      "item": "minecraft:andesite_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:andesite_slab"
     },
     "pattern": [
       "###"
@@ -15483,11 +16326,13 @@
     }
   },
   "andesite_slab_from_andesite_stonecutting": {
-    "result": "minecraft:andesite_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:andesite_slab"
+    },
     "ingredient": {
       "item": "minecraft:andesite"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -15495,8 +16340,8 @@
   },
   "andesite_stairs": {
     "result": {
-      "item": "minecraft:andesite_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:andesite_stairs"
     },
     "pattern": [
       "#  ",
@@ -15514,11 +16359,13 @@
     }
   },
   "andesite_stairs_from_andesite_stonecutting": {
-    "result": "minecraft:andesite_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:andesite_stairs"
+    },
     "ingredient": {
       "item": "minecraft:andesite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -15526,8 +16373,8 @@
   },
   "andesite_wall": {
     "result": {
-      "item": "minecraft:andesite_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:andesite_wall"
     },
     "pattern": [
       "###",
@@ -15544,11 +16391,13 @@
     }
   },
   "andesite_wall_from_andesite_stonecutting": {
-    "result": "minecraft:andesite_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:andesite_wall"
+    },
     "ingredient": {
       "item": "minecraft:andesite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -15556,7 +16405,8 @@
   },
   "barrel": {
     "result": {
-      "item": "minecraft:barrel"
+      "count": 1,
+      "id": "minecraft:barrel"
     },
     "pattern": [
       "PSP",
@@ -15579,8 +16429,8 @@
   },
   "birch_sign": {
     "result": {
-      "item": "minecraft:birch_sign",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:birch_sign"
     },
     "pattern": [
       "###",
@@ -15602,7 +16452,7 @@
   },
   "black_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:black_bed"
+      "id": "minecraft:black_bed"
     },
     "ingredients": [
       {
@@ -15620,8 +16470,8 @@
   },
   "black_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:black_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:black_carpet"
     },
     "pattern": [
       "###",
@@ -15644,8 +16494,8 @@
   },
   "black_concrete_powder": {
     "result": {
-      "item": "minecraft:black_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:black_concrete_powder"
     },
     "ingredients": [
       {
@@ -15683,7 +16533,8 @@
   },
   "black_dye": {
     "result": {
-      "item": "minecraft:black_dye"
+      "count": 1,
+      "id": "minecraft:black_dye"
     },
     "ingredients": [
       {
@@ -15697,7 +16548,8 @@
   },
   "black_dye_from_wither_rose": {
     "result": {
-      "item": "minecraft:black_dye"
+      "count": 1,
+      "id": "minecraft:black_dye"
     },
     "ingredients": [
       {
@@ -15711,8 +16563,8 @@
   },
   "black_stained_glass": {
     "result": {
-      "item": "minecraft:black_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:black_stained_glass"
     },
     "pattern": [
       "###",
@@ -15734,8 +16586,8 @@
   },
   "black_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:black_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:black_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -15757,8 +16609,8 @@
   },
   "black_terracotta": {
     "result": {
-      "item": "minecraft:black_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:black_terracotta"
     },
     "pattern": [
       "###",
@@ -15780,7 +16632,7 @@
   },
   "black_wool": {
     "result": {
-      "item": "minecraft:black_wool"
+      "id": "minecraft:black_wool"
     },
     "ingredients": [
       {
@@ -15798,7 +16650,8 @@
   },
   "blast_furnace": {
     "result": {
-      "item": "minecraft:blast_furnace"
+      "count": 1,
+      "id": "minecraft:blast_furnace"
     },
     "pattern": [
       "III",
@@ -15823,7 +16676,7 @@
   },
   "blue_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:blue_bed"
+      "id": "minecraft:blue_bed"
     },
     "ingredients": [
       {
@@ -15841,8 +16694,8 @@
   },
   "blue_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:blue_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:blue_carpet"
     },
     "pattern": [
       "###",
@@ -15865,8 +16718,8 @@
   },
   "blue_concrete_powder": {
     "result": {
-      "item": "minecraft:blue_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:blue_concrete_powder"
     },
     "ingredients": [
       {
@@ -15904,7 +16757,8 @@
   },
   "blue_dye": {
     "result": {
-      "item": "minecraft:blue_dye"
+      "count": 1,
+      "id": "minecraft:blue_dye"
     },
     "ingredients": [
       {
@@ -15918,7 +16772,8 @@
   },
   "blue_dye_from_cornflower": {
     "result": {
-      "item": "minecraft:blue_dye"
+      "count": 1,
+      "id": "minecraft:blue_dye"
     },
     "ingredients": [
       {
@@ -15932,8 +16787,8 @@
   },
   "blue_stained_glass": {
     "result": {
-      "item": "minecraft:blue_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:blue_stained_glass"
     },
     "pattern": [
       "###",
@@ -15955,8 +16810,8 @@
   },
   "blue_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:blue_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:blue_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -15978,8 +16833,8 @@
   },
   "blue_terracotta": {
     "result": {
-      "item": "minecraft:blue_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:blue_terracotta"
     },
     "pattern": [
       "###",
@@ -16001,7 +16856,7 @@
   },
   "blue_wool": {
     "result": {
-      "item": "minecraft:blue_wool"
+      "id": "minecraft:blue_wool"
     },
     "ingredients": [
       {
@@ -16018,22 +16873,26 @@
     }
   },
   "brick_slab_from_bricks_stonecutting": {
-    "result": "minecraft:brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:bricks"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "brick_stairs_from_bricks_stonecutting": {
-    "result": "minecraft:brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -16041,8 +16900,8 @@
   },
   "brick_wall": {
     "result": {
-      "item": "minecraft:brick_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:brick_wall"
     },
     "pattern": [
       "###",
@@ -16059,11 +16918,13 @@
     }
   },
   "brick_wall_from_bricks_stonecutting": {
-    "result": "minecraft:brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -16071,7 +16932,7 @@
   },
   "brown_bed_from_white_bed": {
     "result": {
-      "item": "minecraft:brown_bed"
+      "id": "minecraft:brown_bed"
     },
     "ingredients": [
       {
@@ -16089,8 +16950,8 @@
   },
   "brown_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:brown_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:brown_carpet"
     },
     "pattern": [
       "###",
@@ -16113,8 +16974,8 @@
   },
   "brown_concrete_powder": {
     "result": {
-      "item": "minecraft:brown_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:brown_concrete_powder"
     },
     "ingredients": [
       {
@@ -16152,7 +17013,8 @@
   },
   "brown_dye": {
     "result": {
-      "item": "minecraft:brown_dye"
+      "count": 1,
+      "id": "minecraft:brown_dye"
     },
     "ingredients": [
       {
@@ -16166,8 +17028,8 @@
   },
   "brown_stained_glass": {
     "result": {
-      "item": "minecraft:brown_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:brown_stained_glass"
     },
     "pattern": [
       "###",
@@ -16189,8 +17051,8 @@
   },
   "brown_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:brown_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:brown_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -16212,8 +17074,8 @@
   },
   "brown_terracotta": {
     "result": {
-      "item": "minecraft:brown_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:brown_terracotta"
     },
     "pattern": [
       "###",
@@ -16235,7 +17097,7 @@
   },
   "brown_wool": {
     "result": {
-      "item": "minecraft:brown_wool"
+      "id": "minecraft:brown_wool"
     },
     "ingredients": [
       {
@@ -16253,7 +17115,8 @@
   },
   "campfire": {
     "result": {
-      "item": "minecraft:campfire"
+      "count": 1,
+      "id": "minecraft:campfire"
     },
     "pattern": [
       " S ",
@@ -16279,7 +17142,8 @@
   },
   "cartography_table": {
     "result": {
-      "item": "minecraft:cartography_table"
+      "count": 1,
+      "id": "minecraft:cartography_table"
     },
     "pattern": [
       "@@",
@@ -16301,55 +17165,65 @@
     }
   },
   "chiseled_quartz_block_from_quartz_block_stonecutting": {
-    "result": "minecraft:chiseled_quartz_block",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_quartz_block"
+    },
     "ingredient": {
       "item": "minecraft:quartz_block"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "chiseled_red_sandstone_from_red_sandstone_stonecutting": {
-    "result": "minecraft:chiseled_red_sandstone",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_red_sandstone"
+    },
     "ingredient": {
       "item": "minecraft:red_sandstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "chiseled_sandstone_from_sandstone_stonecutting": {
-    "result": "minecraft:chiseled_sandstone",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_sandstone"
+    },
     "ingredient": {
       "item": "minecraft:sandstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "chiseled_stone_bricks_from_stone_bricks_stonecutting": {
-    "result": "minecraft:chiseled_stone_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_stone_bricks"
+    },
     "ingredient": {
       "item": "minecraft:stone_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "chiseled_stone_bricks_stone_from_stonecutting": {
-    "result": "minecraft:chiseled_stone_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_stone_bricks"
+    },
     "ingredient": {
       "item": "minecraft:stone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -16357,8 +17231,8 @@
   },
   "cobblestone_slab": {
     "result": {
-      "item": "minecraft:cobblestone_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:cobblestone_slab"
     },
     "pattern": [
       "###"
@@ -16374,33 +17248,39 @@
     }
   },
   "cobblestone_slab_from_cobblestone_stonecutting": {
-    "result": "minecraft:cobblestone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:cobblestone_slab"
+    },
     "ingredient": {
       "item": "minecraft:cobblestone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "cobblestone_stairs_from_cobblestone_stonecutting": {
-    "result": "minecraft:cobblestone_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:cobblestone_stairs"
+    },
     "ingredient": {
       "item": "minecraft:cobblestone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "cobblestone_wall_from_cobblestone_stonecutting": {
-    "result": "minecraft:cobblestone_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:cobblestone_wall"
+    },
     "ingredient": {
       "item": "minecraft:cobblestone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -16408,7 +17288,7 @@
   },
   "composter_legacy": {
     "result": {
-      "item": "minecraft:composter"
+      "id": "minecraft:composter"
     },
     "pattern": [
       "X X",
@@ -16466,7 +17346,8 @@
   },
   "creeper_banner_pattern": {
     "result": {
-      "item": "minecraft:creeper_banner_pattern"
+      "count": 1,
+      "id": "minecraft:creeper_banner_pattern"
     },
     "ingredients": [
       {
@@ -16483,7 +17364,8 @@
   },
   "crossbow": {
     "result": {
-      "item": "minecraft:crossbow"
+      "count": 1,
+      "id": "minecraft:crossbow"
     },
     "pattern": [
       "#&#",
@@ -16510,66 +17392,78 @@
     }
   },
   "cut_red_sandstone_from_red_sandstone_stonecutting": {
-    "result": "minecraft:cut_red_sandstone",
+    "result": {
+      "count": 1,
+      "id": "minecraft:cut_red_sandstone"
+    },
     "ingredient": {
       "item": "minecraft:red_sandstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "cut_red_sandstone_slab_from_cut_red_sandstone_stonecutting": {
-    "result": "minecraft:cut_red_sandstone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:cut_red_sandstone_slab"
+    },
     "ingredient": {
       "item": "minecraft:cut_red_sandstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "cut_red_sandstone_slab_from_red_sandstone_stonecutting": {
-    "result": "minecraft:cut_red_sandstone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:cut_red_sandstone_slab"
+    },
     "ingredient": {
       "item": "minecraft:red_sandstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "cut_sandstone_from_sandstone_stonecutting": {
-    "result": "minecraft:cut_sandstone",
+    "result": {
+      "count": 1,
+      "id": "minecraft:cut_sandstone"
+    },
     "ingredient": {
       "item": "minecraft:sandstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "cut_sandstone_slab_from_cut_sandstone_stonecutting": {
-    "result": "minecraft:cut_sandstone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:cut_sandstone_slab"
+    },
     "ingredient": {
       "item": "minecraft:cut_sandstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "cut_sandstone_slab_from_sandstone_stonecutting": {
-    "result": "minecraft:cut_sandstone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:cut_sandstone_slab"
+    },
     "ingredient": {
       "item": "minecraft:sandstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -16577,8 +17471,8 @@
   },
   "cyan_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:cyan_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:cyan_carpet"
     },
     "pattern": [
       "###",
@@ -16601,8 +17495,8 @@
   },
   "cyan_dye": {
     "result": {
-      "item": "minecraft:cyan_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:cyan_dye"
     },
     "ingredients": [
       {
@@ -16619,8 +17513,8 @@
   },
   "dark_oak_sign": {
     "result": {
-      "item": "minecraft:dark_oak_sign",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:dark_oak_sign"
     },
     "pattern": [
       "###",
@@ -16641,22 +17535,26 @@
     }
   },
   "dark_prismarine_slab_from_dark_prismarine_stonecutting": {
-    "result": "minecraft:dark_prismarine_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:dark_prismarine_slab"
+    },
     "ingredient": {
       "item": "minecraft:dark_prismarine"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "dark_prismarine_stairs_from_dark_prismarine_stonecutting": {
-    "result": "minecraft:dark_prismarine_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:dark_prismarine_stairs"
+    },
     "ingredient": {
       "item": "minecraft:dark_prismarine"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -16664,8 +17562,8 @@
   },
   "diorite_slab": {
     "result": {
-      "item": "minecraft:diorite_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:diorite_slab"
     },
     "pattern": [
       "###"
@@ -16681,11 +17579,13 @@
     }
   },
   "diorite_slab_from_diorite_stonecutting": {
-    "result": "minecraft:diorite_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:diorite_slab"
+    },
     "ingredient": {
       "item": "minecraft:diorite"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -16693,8 +17593,8 @@
   },
   "diorite_stairs": {
     "result": {
-      "item": "minecraft:diorite_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:diorite_stairs"
     },
     "pattern": [
       "#  ",
@@ -16712,11 +17612,13 @@
     }
   },
   "diorite_stairs_from_diorite_stonecutting": {
-    "result": "minecraft:diorite_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:diorite_stairs"
+    },
     "ingredient": {
       "item": "minecraft:diorite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -16724,8 +17626,8 @@
   },
   "diorite_wall": {
     "result": {
-      "item": "minecraft:diorite_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:diorite_wall"
     },
     "pattern": [
       "###",
@@ -16742,11 +17644,13 @@
     }
   },
   "diorite_wall_from_diorite_stonecutting": {
-    "result": "minecraft:diorite_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:diorite_wall"
+    },
     "ingredient": {
       "item": "minecraft:diorite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -16754,8 +17658,8 @@
   },
   "end_stone_brick_slab": {
     "result": {
-      "item": "minecraft:end_stone_brick_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:end_stone_brick_slab"
     },
     "pattern": [
       "###"
@@ -16771,22 +17675,26 @@
     }
   },
   "end_stone_brick_slab_from_end_stone_brick_stonecutting": {
-    "result": "minecraft:end_stone_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:end_stone_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:end_stone_bricks"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "end_stone_brick_slab_from_end_stone_stonecutting": {
-    "result": "minecraft:end_stone_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:end_stone_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:end_stone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -16794,8 +17702,8 @@
   },
   "end_stone_brick_stairs": {
     "result": {
-      "item": "minecraft:end_stone_brick_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:end_stone_brick_stairs"
     },
     "pattern": [
       "#  ",
@@ -16813,22 +17721,26 @@
     }
   },
   "end_stone_brick_stairs_from_end_stone_brick_stonecutting": {
-    "result": "minecraft:end_stone_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:end_stone_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:end_stone_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "end_stone_brick_stairs_from_end_stone_stonecutting": {
-    "result": "minecraft:end_stone_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:end_stone_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:end_stone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -16836,8 +17748,8 @@
   },
   "end_stone_brick_wall": {
     "result": {
-      "item": "minecraft:end_stone_brick_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:end_stone_brick_wall"
     },
     "pattern": [
       "###",
@@ -16854,33 +17766,39 @@
     }
   },
   "end_stone_brick_wall_from_end_stone_brick_stonecutting": {
-    "result": "minecraft:end_stone_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:end_stone_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:end_stone_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "end_stone_brick_wall_from_end_stone_stonecutting": {
-    "result": "minecraft:end_stone_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:end_stone_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:end_stone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "end_stone_bricks_from_end_stone_stonecutting": {
-    "result": "minecraft:end_stone_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:end_stone_bricks"
+    },
     "ingredient": {
       "item": "minecraft:end_stone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -16888,7 +17806,7 @@
   },
   "firework_star": {
     "result": {
-      "item": "minecraft:firework_star"
+      "id": "minecraft:firework_star"
     },
     "ingredients": [
       {
@@ -16996,7 +17914,7 @@
   },
   "firework_star_fade": {
     "result": {
-      "item": "minecraft:firework_star"
+      "id": "minecraft:firework_star"
     },
     "ingredients": [
       {
@@ -17066,7 +17984,8 @@
   },
   "fletching_table": {
     "result": {
-      "item": "minecraft:fletching_table"
+      "count": 1,
+      "id": "minecraft:fletching_table"
     },
     "pattern": [
       "@@",
@@ -17089,7 +18008,8 @@
   },
   "flower_banner_pattern": {
     "result": {
-      "item": "minecraft:flower_banner_pattern"
+      "count": 1,
+      "id": "minecraft:flower_banner_pattern"
     },
     "ingredients": [
       {
@@ -17106,8 +18026,8 @@
   },
   "granite_slab": {
     "result": {
-      "item": "minecraft:granite_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:granite_slab"
     },
     "pattern": [
       "###"
@@ -17123,11 +18043,13 @@
     }
   },
   "granite_slab_from_granite_stonecutting": {
-    "result": "minecraft:granite_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:granite_slab"
+    },
     "ingredient": {
       "item": "minecraft:granite"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -17135,8 +18057,8 @@
   },
   "granite_stairs": {
     "result": {
-      "item": "minecraft:granite_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:granite_stairs"
     },
     "pattern": [
       "#  ",
@@ -17154,11 +18076,13 @@
     }
   },
   "granite_stairs_from_granite_stonecutting": {
-    "result": "minecraft:granite_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:granite_stairs"
+    },
     "ingredient": {
       "item": "minecraft:granite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -17166,8 +18090,8 @@
   },
   "granite_wall": {
     "result": {
-      "item": "minecraft:granite_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:granite_wall"
     },
     "pattern": [
       "###",
@@ -17184,11 +18108,13 @@
     }
   },
   "granite_wall_from_granite_stonecutting": {
-    "result": "minecraft:granite_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:granite_wall"
+    },
     "ingredient": {
       "item": "minecraft:granite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -17196,8 +18122,8 @@
   },
   "gray_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:gray_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:gray_carpet"
     },
     "pattern": [
       "###",
@@ -17220,8 +18146,8 @@
   },
   "gray_dye": {
     "result": {
-      "item": "minecraft:gray_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:gray_dye"
     },
     "ingredients": [
       {
@@ -17238,8 +18164,8 @@
   },
   "green_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:green_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:green_carpet"
     },
     "pattern": [
       "###",
@@ -17262,7 +18188,8 @@
   },
   "grindstone": {
     "result": {
-      "item": "minecraft:grindstone"
+      "count": 1,
+      "id": "minecraft:grindstone"
     },
     "pattern": [
       "I-I",
@@ -17287,8 +18214,8 @@
   },
   "jungle_sign": {
     "result": {
-      "item": "minecraft:jungle_sign",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:jungle_sign"
     },
     "pattern": [
       "###",
@@ -17310,7 +18237,8 @@
   },
   "lantern": {
     "result": {
-      "item": "minecraft:lantern"
+      "count": 1,
+      "id": "minecraft:lantern"
     },
     "pattern": [
       "XXX",
@@ -17332,7 +18260,8 @@
   },
   "leather_horse_armor": {
     "result": {
-      "item": "minecraft:leather_horse_armor"
+      "count": 1,
+      "id": "minecraft:leather_horse_armor"
     },
     "pattern": [
       "X X",
@@ -17351,7 +18280,8 @@
   },
   "lectern": {
     "result": {
-      "item": "minecraft:lectern"
+      "count": 1,
+      "id": "minecraft:lectern"
     },
     "pattern": [
       "SSS",
@@ -17374,8 +18304,8 @@
   },
   "light_blue_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:light_blue_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:light_blue_carpet"
     },
     "pattern": [
       "###",
@@ -17398,8 +18328,8 @@
   },
   "light_blue_dye_from_blue_white_dye": {
     "result": {
-      "item": "minecraft:light_blue_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:light_blue_dye"
     },
     "ingredients": [
       {
@@ -17416,8 +18346,8 @@
   },
   "light_gray_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:light_gray_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:light_gray_carpet"
     },
     "pattern": [
       "###",
@@ -17440,8 +18370,8 @@
   },
   "light_gray_dye_from_black_white_dye": {
     "result": {
-      "item": "minecraft:light_gray_dye",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:light_gray_dye"
     },
     "ingredients": [
       {
@@ -17461,8 +18391,8 @@
   },
   "light_gray_dye_from_gray_white_dye": {
     "result": {
-      "item": "minecraft:light_gray_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:light_gray_dye"
     },
     "ingredients": [
       {
@@ -17479,8 +18409,8 @@
   },
   "lime_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:lime_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:lime_carpet"
     },
     "pattern": [
       "###",
@@ -17503,8 +18433,8 @@
   },
   "lime_dye": {
     "result": {
-      "item": "minecraft:lime_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:lime_dye"
     },
     "ingredients": [
       {
@@ -17521,7 +18451,8 @@
   },
   "loom": {
     "result": {
-      "item": "minecraft:loom"
+      "count": 1,
+      "id": "minecraft:loom"
     },
     "pattern": [
       "@@",
@@ -17543,8 +18474,8 @@
   },
   "magenta_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:magenta_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:magenta_carpet"
     },
     "pattern": [
       "###",
@@ -17567,8 +18498,8 @@
   },
   "magenta_dye_from_blue_red_pink": {
     "result": {
-      "item": "minecraft:magenta_dye",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:magenta_dye"
     },
     "ingredients": [
       {
@@ -17588,8 +18519,8 @@
   },
   "magenta_dye_from_blue_red_white_dye": {
     "result": {
-      "item": "minecraft:magenta_dye",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:magenta_dye"
     },
     "ingredients": [
       {
@@ -17612,7 +18543,8 @@
   },
   "mojang_banner_pattern": {
     "result": {
-      "item": "minecraft:mojang_banner_pattern"
+      "count": 1,
+      "id": "minecraft:mojang_banner_pattern"
     },
     "ingredients": [
       {
@@ -17629,8 +18561,8 @@
   },
   "mossy_cobblestone_slab": {
     "result": {
-      "item": "minecraft:mossy_cobblestone_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:mossy_cobblestone_slab"
     },
     "pattern": [
       "###"
@@ -17646,11 +18578,13 @@
     }
   },
   "mossy_cobblestone_slab_from_mossy_cobblestone_stonecutting": {
-    "result": "minecraft:mossy_cobblestone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:mossy_cobblestone_slab"
+    },
     "ingredient": {
       "item": "minecraft:mossy_cobblestone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -17658,8 +18592,8 @@
   },
   "mossy_cobblestone_stairs": {
     "result": {
-      "item": "minecraft:mossy_cobblestone_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:mossy_cobblestone_stairs"
     },
     "pattern": [
       "#  ",
@@ -17677,11 +18611,13 @@
     }
   },
   "mossy_cobblestone_stairs_from_mossy_cobblestone_stonecutting": {
-    "result": "minecraft:mossy_cobblestone_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:mossy_cobblestone_stairs"
+    },
     "ingredient": {
       "item": "minecraft:mossy_cobblestone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -17689,8 +18625,8 @@
   },
   "mossy_cobblestone_wall": {
     "result": {
-      "item": "minecraft:mossy_cobblestone_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:mossy_cobblestone_wall"
     },
     "pattern": [
       "###",
@@ -17707,11 +18643,13 @@
     }
   },
   "mossy_cobblestone_wall_from_mossy_cobblestone_stonecutting": {
-    "result": "minecraft:mossy_cobblestone_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:mossy_cobblestone_wall"
+    },
     "ingredient": {
       "item": "minecraft:mossy_cobblestone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -17719,8 +18657,8 @@
   },
   "mossy_stone_brick_slab": {
     "result": {
-      "item": "minecraft:mossy_stone_brick_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:mossy_stone_brick_slab"
     },
     "pattern": [
       "###"
@@ -17736,11 +18674,13 @@
     }
   },
   "mossy_stone_brick_slab_from_mossy_stone_brick_stonecutting": {
-    "result": "minecraft:mossy_stone_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:mossy_stone_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:mossy_stone_bricks"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -17748,8 +18688,8 @@
   },
   "mossy_stone_brick_stairs": {
     "result": {
-      "item": "minecraft:mossy_stone_brick_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:mossy_stone_brick_stairs"
     },
     "pattern": [
       "#  ",
@@ -17767,11 +18707,13 @@
     }
   },
   "mossy_stone_brick_stairs_from_mossy_stone_brick_stonecutting": {
-    "result": "minecraft:mossy_stone_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:mossy_stone_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:mossy_stone_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -17779,8 +18721,8 @@
   },
   "mossy_stone_brick_wall": {
     "result": {
-      "item": "minecraft:mossy_stone_brick_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:mossy_stone_brick_wall"
     },
     "pattern": [
       "###",
@@ -17797,11 +18739,13 @@
     }
   },
   "mossy_stone_brick_wall_from_mossy_stone_brick_stonecutting": {
-    "result": "minecraft:mossy_stone_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:mossy_stone_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:mossy_stone_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -17809,8 +18753,8 @@
   },
   "nether_brick_fence": {
     "result": {
-      "item": "minecraft:nether_brick_fence",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:nether_brick_fence"
     },
     "pattern": [
       "W#W",
@@ -17830,22 +18774,26 @@
     }
   },
   "nether_brick_slab_from_nether_bricks_stonecutting": {
-    "result": "minecraft:nether_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:nether_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:nether_bricks"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "nether_brick_stairs_from_nether_bricks_stonecutting": {
-    "result": "minecraft:nether_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:nether_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:nether_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -17853,8 +18801,8 @@
   },
   "nether_brick_wall": {
     "result": {
-      "item": "minecraft:nether_brick_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:nether_brick_wall"
     },
     "pattern": [
       "###",
@@ -17871,11 +18819,13 @@
     }
   },
   "nether_brick_wall_from_nether_bricks_stonecutting": {
-    "result": "minecraft:nether_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:nether_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:nether_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -17883,8 +18833,8 @@
   },
   "orange_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:orange_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:orange_carpet"
     },
     "pattern": [
       "###",
@@ -17907,8 +18857,8 @@
   },
   "pink_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:pink_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:pink_carpet"
     },
     "pattern": [
       "###",
@@ -17931,8 +18881,8 @@
   },
   "pink_dye_from_red_white_dye": {
     "result": {
-      "item": "minecraft:pink_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:pink_dye"
     },
     "ingredients": [
       {
@@ -17948,11 +18898,13 @@
     }
   },
   "polished_andesite_from_andesite_stonecutting": {
-    "result": "minecraft:polished_andesite",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_andesite"
+    },
     "ingredient": {
       "item": "minecraft:andesite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -17960,8 +18912,8 @@
   },
   "polished_andesite_slab": {
     "result": {
-      "item": "minecraft:polished_andesite_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:polished_andesite_slab"
     },
     "pattern": [
       "###"
@@ -17977,22 +18929,26 @@
     }
   },
   "polished_andesite_slab_from_andesite_stonecutting": {
-    "result": "minecraft:polished_andesite_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_andesite_slab"
+    },
     "ingredient": {
       "item": "minecraft:andesite"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "polished_andesite_slab_from_polished_andesite_stonecutting": {
-    "result": "minecraft:polished_andesite_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_andesite_slab"
+    },
     "ingredient": {
       "item": "minecraft:polished_andesite"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18000,8 +18956,8 @@
   },
   "polished_andesite_stairs": {
     "result": {
-      "item": "minecraft:polished_andesite_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_andesite_stairs"
     },
     "pattern": [
       "#  ",
@@ -18019,33 +18975,39 @@
     }
   },
   "polished_andesite_stairs_from_andesite_stonecutting": {
-    "result": "minecraft:polished_andesite_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_andesite_stairs"
+    },
     "ingredient": {
       "item": "minecraft:andesite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "polished_andesite_stairs_from_polished_andesite_stonecutting": {
-    "result": "minecraft:polished_andesite_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_andesite_stairs"
+    },
     "ingredient": {
       "item": "minecraft:polished_andesite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "polished_diorite_from_diorite_stonecutting": {
-    "result": "minecraft:polished_diorite",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_diorite"
+    },
     "ingredient": {
       "item": "minecraft:diorite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18053,8 +19015,8 @@
   },
   "polished_diorite_slab": {
     "result": {
-      "item": "minecraft:polished_diorite_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:polished_diorite_slab"
     },
     "pattern": [
       "###"
@@ -18070,22 +19032,26 @@
     }
   },
   "polished_diorite_slab_from_diorite_stonecutting": {
-    "result": "minecraft:polished_diorite_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_diorite_slab"
+    },
     "ingredient": {
       "item": "minecraft:diorite"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "polished_diorite_slab_from_polished_diorite_stonecutting": {
-    "result": "minecraft:polished_diorite_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_diorite_slab"
+    },
     "ingredient": {
       "item": "minecraft:polished_diorite"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18093,8 +19059,8 @@
   },
   "polished_diorite_stairs": {
     "result": {
-      "item": "minecraft:polished_diorite_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_diorite_stairs"
     },
     "pattern": [
       "#  ",
@@ -18112,33 +19078,39 @@
     }
   },
   "polished_diorite_stairs_from_diorite_stonecutting": {
-    "result": "minecraft:polished_diorite_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_diorite_stairs"
+    },
     "ingredient": {
       "item": "minecraft:diorite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "polished_diorite_stairs_from_polished_diorite_stonecutting": {
-    "result": "minecraft:polished_diorite_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_diorite_stairs"
+    },
     "ingredient": {
       "item": "minecraft:polished_diorite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "polished_granite_from_granite_stonecutting": {
-    "result": "minecraft:polished_granite",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_granite"
+    },
     "ingredient": {
       "item": "minecraft:granite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18146,8 +19118,8 @@
   },
   "polished_granite_slab": {
     "result": {
-      "item": "minecraft:polished_granite_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:polished_granite_slab"
     },
     "pattern": [
       "###"
@@ -18163,22 +19135,26 @@
     }
   },
   "polished_granite_slab_from_granite_stonecutting": {
-    "result": "minecraft:polished_granite_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_granite_slab"
+    },
     "ingredient": {
       "item": "minecraft:granite"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "polished_granite_slab_from_polished_granite_stonecutting": {
-    "result": "minecraft:polished_granite_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_granite_slab"
+    },
     "ingredient": {
       "item": "minecraft:polished_granite"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18186,8 +19162,8 @@
   },
   "polished_granite_stairs": {
     "result": {
-      "item": "minecraft:polished_granite_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_granite_stairs"
     },
     "pattern": [
       "#  ",
@@ -18205,66 +19181,78 @@
     }
   },
   "polished_granite_stairs_from_granite_stonecutting": {
-    "result": "minecraft:polished_granite_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_granite_stairs"
+    },
     "ingredient": {
       "item": "minecraft:granite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "polished_granite_stairs_from_polished_granite_stonecutting": {
-    "result": "minecraft:polished_granite_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_granite_stairs"
+    },
     "ingredient": {
       "item": "minecraft:polished_granite"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "prismarine_brick_slab_from_prismarine_stonecutting": {
-    "result": "minecraft:prismarine_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:prismarine_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:prismarine_bricks"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "prismarine_brick_stairs_from_prismarine_stonecutting": {
-    "result": "minecraft:prismarine_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:prismarine_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:prismarine_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "prismarine_slab_from_prismarine_stonecutting": {
-    "result": "minecraft:prismarine_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:prismarine_slab"
+    },
     "ingredient": {
       "item": "minecraft:prismarine"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "prismarine_stairs_from_prismarine_stonecutting": {
-    "result": "minecraft:prismarine_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:prismarine_stairs"
+    },
     "ingredient": {
       "item": "minecraft:prismarine"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18272,8 +19260,8 @@
   },
   "prismarine_wall": {
     "result": {
-      "item": "minecraft:prismarine_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:prismarine_wall"
     },
     "pattern": [
       "###",
@@ -18290,11 +19278,13 @@
     }
   },
   "prismarine_wall_from_prismarine_stonecutting": {
-    "result": "minecraft:prismarine_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:prismarine_wall"
+    },
     "ingredient": {
       "item": "minecraft:prismarine"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18302,8 +19292,8 @@
   },
   "purple_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:purple_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:purple_carpet"
     },
     "pattern": [
       "###",
@@ -18326,8 +19316,8 @@
   },
   "purple_dye": {
     "result": {
-      "item": "minecraft:purple_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:purple_dye"
     },
     "ingredients": [
       {
@@ -18343,66 +19333,78 @@
     }
   },
   "purpur_pillar_from_purpur_block_stonecutting": {
-    "result": "minecraft:purpur_pillar",
+    "result": {
+      "count": 1,
+      "id": "minecraft:purpur_pillar"
+    },
     "ingredient": {
       "item": "minecraft:purpur_block"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "purpur_slab_from_purpur_block_stonecutting": {
-    "result": "minecraft:purpur_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:purpur_slab"
+    },
     "ingredient": {
       "item": "minecraft:purpur_block"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "purpur_stairs_from_purpur_block_stonecutting": {
-    "result": "minecraft:purpur_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:purpur_stairs"
+    },
     "ingredient": {
       "item": "minecraft:purpur_block"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "quartz_pillar_from_quartz_block_stonecutting": {
-    "result": "minecraft:quartz_pillar",
+    "result": {
+      "count": 1,
+      "id": "minecraft:quartz_pillar"
+    },
     "ingredient": {
       "item": "minecraft:quartz_block"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "quartz_slab_from_stonecutting": {
-    "result": "minecraft:quartz_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:quartz_slab"
+    },
     "ingredient": {
       "item": "minecraft:quartz_block"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "quartz_stairs_from_quartz_block_stonecutting": {
-    "result": "minecraft:quartz_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:quartz_stairs"
+    },
     "ingredient": {
       "item": "minecraft:quartz_block"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18410,8 +19412,8 @@
   },
   "red_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:red_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:red_carpet"
     },
     "pattern": [
       "###",
@@ -18434,8 +19436,8 @@
   },
   "red_nether_brick_slab": {
     "result": {
-      "item": "minecraft:red_nether_brick_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:red_nether_brick_slab"
     },
     "pattern": [
       "###"
@@ -18451,11 +19453,13 @@
     }
   },
   "red_nether_brick_slab_from_red_nether_bricks_stonecutting": {
-    "result": "minecraft:red_nether_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:red_nether_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:red_nether_bricks"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18463,8 +19467,8 @@
   },
   "red_nether_brick_stairs": {
     "result": {
-      "item": "minecraft:red_nether_brick_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:red_nether_brick_stairs"
     },
     "pattern": [
       "#  ",
@@ -18482,11 +19486,13 @@
     }
   },
   "red_nether_brick_stairs_from_red_nether_bricks_stonecutting": {
-    "result": "minecraft:red_nether_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:red_nether_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:red_nether_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18494,8 +19500,8 @@
   },
   "red_nether_brick_wall": {
     "result": {
-      "item": "minecraft:red_nether_brick_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:red_nether_brick_wall"
     },
     "pattern": [
       "###",
@@ -18512,33 +19518,39 @@
     }
   },
   "red_nether_brick_wall_from_red_nether_bricks_stonecutting": {
-    "result": "minecraft:red_nether_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:red_nether_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:red_nether_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "red_sandstone_slab_from_red_sandstone_stonecutting": {
-    "result": "minecraft:red_sandstone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:red_sandstone_slab"
+    },
     "ingredient": {
       "item": "minecraft:red_sandstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "red_sandstone_stairs_from_red_sandstone_stonecutting": {
-    "result": "minecraft:red_sandstone_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:red_sandstone_stairs"
+    },
     "ingredient": {
       "item": "minecraft:red_sandstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18546,8 +19558,8 @@
   },
   "red_sandstone_wall": {
     "result": {
-      "item": "minecraft:red_sandstone_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:red_sandstone_wall"
     },
     "pattern": [
       "###",
@@ -18564,33 +19576,39 @@
     }
   },
   "red_sandstone_wall_from_red_sandstone_stonecutting": {
-    "result": "minecraft:red_sandstone_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:red_sandstone_wall"
+    },
     "ingredient": {
       "item": "minecraft:red_sandstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "sandstone_slab_from_sandstone_stonecutting": {
-    "result": "minecraft:sandstone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:sandstone_slab"
+    },
     "ingredient": {
       "item": "minecraft:sandstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "sandstone_stairs_from_sandstone_stonecutting": {
-    "result": "minecraft:sandstone_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:sandstone_stairs"
+    },
     "ingredient": {
       "item": "minecraft:sandstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18598,8 +19616,8 @@
   },
   "sandstone_wall": {
     "result": {
-      "item": "minecraft:sandstone_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:sandstone_wall"
     },
     "pattern": [
       "###",
@@ -18616,11 +19634,13 @@
     }
   },
   "sandstone_wall_from_sandstone_stonecutting": {
-    "result": "minecraft:sandstone_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:sandstone_wall"
+    },
     "ingredient": {
       "item": "minecraft:sandstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -18628,8 +19648,8 @@
   },
   "scaffolding": {
     "result": {
-      "item": "minecraft:scaffolding",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:scaffolding"
     },
     "pattern": [
       "I~I",
@@ -18651,7 +19671,7 @@
   },
   "shulker_box_coloring_black": {
     "result": {
-      "item": "minecraft:black_shulker_box"
+      "id": "minecraft:black_shulker_box"
     },
     "ingredients": [
       {
@@ -18716,7 +19736,7 @@
   },
   "shulker_box_coloring_blue": {
     "result": {
-      "item": "minecraft:blue_shulker_box"
+      "id": "minecraft:blue_shulker_box"
     },
     "ingredients": [
       {
@@ -18781,7 +19801,7 @@
   },
   "shulker_box_coloring_brown": {
     "result": {
-      "item": "minecraft:brown_shulker_box"
+      "id": "minecraft:brown_shulker_box"
     },
     "ingredients": [
       {
@@ -18846,7 +19866,7 @@
   },
   "shulker_box_coloring_white": {
     "result": {
-      "item": "minecraft:white_shulker_box"
+      "id": "minecraft:white_shulker_box"
     },
     "ingredients": [
       {
@@ -18911,7 +19931,8 @@
   },
   "skull_banner_pattern": {
     "result": {
-      "item": "minecraft:skull_banner_pattern"
+      "count": 1,
+      "id": "minecraft:skull_banner_pattern"
     },
     "ingredients": [
       {
@@ -18928,7 +19949,8 @@
   },
   "smithing_table": {
     "result": {
-      "item": "minecraft:smithing_table"
+      "count": 1,
+      "id": "minecraft:smithing_table"
     },
     "pattern": [
       "@@",
@@ -18951,7 +19973,8 @@
   },
   "smoker": {
     "result": {
-      "item": "minecraft:smoker"
+      "count": 1,
+      "id": "minecraft:smoker"
     },
     "pattern": [
       " # ",
@@ -18973,7 +19996,9 @@
     }
   },
   "smooth_quartz": {
-    "result": "minecraft:smooth_quartz",
+    "result": {
+      "id": "minecraft:smooth_quartz"
+    },
     "ingredient": {
       "item": "minecraft:quartz_block"
     },
@@ -18985,8 +20010,8 @@
   },
   "smooth_quartz_slab": {
     "result": {
-      "item": "minecraft:smooth_quartz_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:smooth_quartz_slab"
     },
     "pattern": [
       "###"
@@ -19002,11 +20027,13 @@
     }
   },
   "smooth_quartz_slab_from_smooth_quartz_stonecutting": {
-    "result": "minecraft:smooth_quartz_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:smooth_quartz_slab"
+    },
     "ingredient": {
       "item": "minecraft:smooth_quartz"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -19014,8 +20041,8 @@
   },
   "smooth_quartz_stairs": {
     "result": {
-      "item": "minecraft:smooth_quartz_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:smooth_quartz_stairs"
     },
     "pattern": [
       "#  ",
@@ -19033,11 +20060,13 @@
     }
   },
   "smooth_quartz_stairs_from_smooth_quartz_stonecutting": {
-    "result": "minecraft:smooth_quartz_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:smooth_quartz_stairs"
+    },
     "ingredient": {
       "item": "minecraft:smooth_quartz"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -19045,8 +20074,8 @@
   },
   "smooth_red_sandstone_slab": {
     "result": {
-      "item": "minecraft:smooth_red_sandstone_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:smooth_red_sandstone_slab"
     },
     "pattern": [
       "###"
@@ -19062,11 +20091,13 @@
     }
   },
   "smooth_red_sandstone_slab_from_smooth_red_sandstone_stonecutting": {
-    "result": "minecraft:smooth_red_sandstone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:smooth_red_sandstone_slab"
+    },
     "ingredient": {
       "item": "minecraft:smooth_red_sandstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -19074,8 +20105,8 @@
   },
   "smooth_red_sandstone_stairs": {
     "result": {
-      "item": "minecraft:smooth_red_sandstone_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:smooth_red_sandstone_stairs"
     },
     "pattern": [
       "#  ",
@@ -19093,11 +20124,13 @@
     }
   },
   "smooth_red_sandstone_stairs_from_smooth_red_sandstone_stonecutting": {
-    "result": "minecraft:smooth_red_sandstone_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:smooth_red_sandstone_stairs"
+    },
     "ingredient": {
       "item": "minecraft:smooth_red_sandstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -19105,8 +20138,8 @@
   },
   "smooth_sandstone_slab": {
     "result": {
-      "item": "minecraft:smooth_sandstone_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:smooth_sandstone_slab"
     },
     "pattern": [
       "###"
@@ -19122,11 +20155,13 @@
     }
   },
   "smooth_sandstone_slab_from_smooth_sandstone_stonecutting": {
-    "result": "minecraft:smooth_sandstone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:smooth_sandstone_slab"
+    },
     "ingredient": {
       "item": "minecraft:smooth_sandstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -19134,8 +20169,8 @@
   },
   "smooth_sandstone_stairs": {
     "result": {
-      "item": "minecraft:smooth_sandstone_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:smooth_sandstone_stairs"
     },
     "pattern": [
       "#  ",
@@ -19153,18 +20188,22 @@
     }
   },
   "smooth_sandstone_stairs_from_smooth_sandstone_stonecutting": {
-    "result": "minecraft:smooth_sandstone_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:smooth_sandstone_stairs"
+    },
     "ingredient": {
       "item": "minecraft:smooth_sandstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "smooth_stone": {
-    "result": "minecraft:smooth_stone",
+    "result": {
+      "id": "minecraft:smooth_stone"
+    },
     "ingredient": {
       "item": "minecraft:stone"
     },
@@ -19175,11 +20214,13 @@
     }
   },
   "smooth_stone_slab_from_smooth_stone_stonecutting": {
-    "result": "minecraft:smooth_stone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:smooth_stone_slab"
+    },
     "ingredient": {
       "item": "minecraft:smooth_stone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -19187,8 +20228,8 @@
   },
   "spruce_sign": {
     "result": {
-      "item": "minecraft:spruce_sign",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:spruce_sign"
     },
     "pattern": [
       "###",
@@ -19210,7 +20251,8 @@
   },
   "stick_from_bamboo_item": {
     "result": {
-      "item": "minecraft:stick"
+      "count": 1,
+      "id": "minecraft:stick"
     },
     "pattern": [
       "#",
@@ -19227,44 +20269,52 @@
     }
   },
   "stone_brick_slab_from_stone_bricks_stonecutting": {
-    "result": "minecraft:stone_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:stone_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:stone_bricks"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "stone_brick_slab_from_stone_stonecutting": {
-    "result": "minecraft:stone_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:stone_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:stone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "stone_brick_stairs_from_stone_bricks_stonecutting": {
-    "result": "minecraft:stone_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:stone_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:stone_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "stone_brick_stairs_from_stone_stonecutting": {
-    "result": "minecraft:stone_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:stone_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:stone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -19272,8 +20322,8 @@
   },
   "stone_brick_wall": {
     "result": {
-      "item": "minecraft:stone_brick_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:stone_brick_wall"
     },
     "pattern": [
       "###",
@@ -19290,44 +20340,52 @@
     }
   },
   "stone_brick_wall_from_stone_bricks_stonecutting": {
-    "result": "minecraft:stone_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:stone_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:stone_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "stone_brick_walls_from_stone_stonecutting": {
-    "result": "minecraft:stone_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:stone_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:stone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "stone_bricks_from_stone_stonecutting": {
-    "result": "minecraft:stone_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:stone_bricks"
+    },
     "ingredient": {
       "item": "minecraft:stone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
     }
   },
   "stone_slab_from_stone_stonecutting": {
-    "result": "minecraft:stone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:stone_slab"
+    },
     "ingredient": {
       "item": "minecraft:stone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -19335,8 +20393,8 @@
   },
   "stone_stairs": {
     "result": {
-      "item": "minecraft:stone_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:stone_stairs"
     },
     "pattern": [
       "#  ",
@@ -19354,11 +20412,13 @@
     }
   },
   "stone_stairs_from_stone_stonecutting": {
-    "result": "minecraft:stone_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:stone_stairs"
+    },
     "ingredient": {
       "item": "minecraft:stone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.14"
@@ -19366,7 +20426,8 @@
   },
   "stonecutter": {
     "result": {
-      "item": "minecraft:stonecutter"
+      "count": 1,
+      "id": "minecraft:stonecutter"
     },
     "pattern": [
       " I ",
@@ -19387,7 +20448,7 @@
   },
   "suspicious_stew": {
     "result": {
-      "item": "minecraft:suspicious_stew"
+      "id": "minecraft:suspicious_stew"
     },
     "ingredients": [
       {
@@ -19457,8 +20518,8 @@
   },
   "white_concrete_powder": {
     "result": {
-      "item": "minecraft:white_concrete_powder",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:white_concrete_powder"
     },
     "ingredients": [
       {
@@ -19496,7 +20557,8 @@
   },
   "white_dye": {
     "result": {
-      "item": "minecraft:white_dye"
+      "count": 1,
+      "id": "minecraft:white_dye"
     },
     "ingredients": [
       {
@@ -19510,7 +20572,8 @@
   },
   "white_dye_from_lily_of_the_valley": {
     "result": {
-      "item": "minecraft:white_dye"
+      "count": 1,
+      "id": "minecraft:white_dye"
     },
     "ingredients": [
       {
@@ -19524,8 +20587,8 @@
   },
   "white_stained_glass": {
     "result": {
-      "item": "minecraft:white_stained_glass",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:white_stained_glass"
     },
     "pattern": [
       "###",
@@ -19547,8 +20610,8 @@
   },
   "white_stained_glass_pane_from_glass_pane": {
     "result": {
-      "item": "minecraft:white_stained_glass_pane",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:white_stained_glass_pane"
     },
     "pattern": [
       "###",
@@ -19570,8 +20633,8 @@
   },
   "white_terracotta": {
     "result": {
-      "item": "minecraft:white_terracotta",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:white_terracotta"
     },
     "pattern": [
       "###",
@@ -19593,8 +20656,8 @@
   },
   "yellow_carpet_from_white_carpet": {
     "result": {
-      "item": "minecraft:yellow_carpet",
-      "count": 8
+      "count": 8,
+      "id": "minecraft:yellow_carpet"
     },
     "pattern": [
       "###",
@@ -19617,7 +20680,8 @@
   },
   "beehive": {
     "result": {
-      "item": "minecraft:beehive"
+      "count": 1,
+      "id": "minecraft:beehive"
     },
     "pattern": [
       "PPP",
@@ -19640,7 +20704,8 @@
   },
   "composter": {
     "result": {
-      "item": "minecraft:composter"
+      "count": 1,
+      "id": "minecraft:composter"
     },
     "pattern": [
       "# #",
@@ -19660,7 +20725,8 @@
   },
   "dark_prismarine": {
     "result": {
-      "item": "minecraft:dark_prismarine"
+      "count": 1,
+      "id": "minecraft:dark_prismarine"
     },
     "pattern": [
       "SSS",
@@ -19682,7 +20748,8 @@
   },
   "honey_block": {
     "result": {
-      "item": "minecraft:honey_block"
+      "count": 1,
+      "id": "minecraft:honey_block"
     },
     "pattern": [
       "##",
@@ -19705,8 +20772,8 @@
   },
   "honey_bottle": {
     "result": {
-      "item": "minecraft:honey_bottle",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:honey_bottle"
     },
     "ingredients": [
       {
@@ -19732,7 +20799,8 @@
   },
   "honeycomb_block": {
     "result": {
-      "item": "minecraft:honeycomb_block"
+      "count": 1,
+      "id": "minecraft:honeycomb_block"
     },
     "pattern": [
       "##",
@@ -19750,8 +20818,8 @@
   },
   "stripped_acacia_wood": {
     "result": {
-      "item": "minecraft:stripped_acacia_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:stripped_acacia_wood"
     },
     "pattern": [
       "##",
@@ -19769,8 +20837,8 @@
   },
   "stripped_birch_wood": {
     "result": {
-      "item": "minecraft:stripped_birch_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:stripped_birch_wood"
     },
     "pattern": [
       "##",
@@ -19788,8 +20856,8 @@
   },
   "stripped_dark_oak_wood": {
     "result": {
-      "item": "minecraft:stripped_dark_oak_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:stripped_dark_oak_wood"
     },
     "pattern": [
       "##",
@@ -19807,8 +20875,8 @@
   },
   "stripped_jungle_wood": {
     "result": {
-      "item": "minecraft:stripped_jungle_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:stripped_jungle_wood"
     },
     "pattern": [
       "##",
@@ -19826,8 +20894,8 @@
   },
   "stripped_oak_wood": {
     "result": {
-      "item": "minecraft:stripped_oak_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:stripped_oak_wood"
     },
     "pattern": [
       "##",
@@ -19845,8 +20913,8 @@
   },
   "stripped_spruce_wood": {
     "result": {
-      "item": "minecraft:stripped_spruce_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:stripped_spruce_wood"
     },
     "pattern": [
       "##",
@@ -19864,8 +20932,8 @@
   },
   "sugar_from_honey_bottle": {
     "result": {
-      "item": "minecraft:sugar",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:sugar"
     },
     "ingredients": [
       {
@@ -19879,8 +20947,8 @@
   },
   "blackstone_slab": {
     "result": {
-      "item": "minecraft:blackstone_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:blackstone_slab"
     },
     "pattern": [
       "###"
@@ -19896,11 +20964,13 @@
     }
   },
   "blackstone_slab_from_blackstone_stonecutting": {
-    "result": "minecraft:blackstone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:blackstone_slab"
+    },
     "ingredient": {
       "item": "minecraft:blackstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -19908,8 +20978,8 @@
   },
   "blackstone_stairs": {
     "result": {
-      "item": "minecraft:blackstone_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:blackstone_stairs"
     },
     "pattern": [
       "#  ",
@@ -19927,11 +20997,13 @@
     }
   },
   "blackstone_stairs_from_blackstone_stonecutting": {
-    "result": "minecraft:blackstone_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:blackstone_stairs"
+    },
     "ingredient": {
       "item": "minecraft:blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -19939,8 +21011,8 @@
   },
   "blackstone_wall": {
     "result": {
-      "item": "minecraft:blackstone_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:blackstone_wall"
     },
     "pattern": [
       "###",
@@ -19957,11 +21029,13 @@
     }
   },
   "blackstone_wall_from_blackstone_stonecutting": {
-    "result": "minecraft:blackstone_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:blackstone_wall"
+    },
     "ingredient": {
       "item": "minecraft:blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -19969,7 +21043,8 @@
   },
   "chain": {
     "result": {
-      "item": "minecraft:chain"
+      "count": 1,
+      "id": "minecraft:chain"
     },
     "pattern": [
       "N",
@@ -19991,7 +21066,8 @@
   },
   "chiseled_nether_bricks": {
     "result": {
-      "item": "minecraft:chiseled_nether_bricks"
+      "count": 1,
+      "id": "minecraft:chiseled_nether_bricks"
     },
     "pattern": [
       "#",
@@ -20008,11 +21084,13 @@
     }
   },
   "chiseled_nether_bricks_from_nether_bricks_stonecutting": {
-    "result": "minecraft:chiseled_nether_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_nether_bricks"
+    },
     "ingredient": {
       "item": "minecraft:nether_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -20020,7 +21098,8 @@
   },
   "chiseled_polished_blackstone": {
     "result": {
-      "item": "minecraft:chiseled_polished_blackstone"
+      "count": 1,
+      "id": "minecraft:chiseled_polished_blackstone"
     },
     "pattern": [
       "#",
@@ -20037,29 +21116,35 @@
     }
   },
   "chiseled_polished_blackstone_from_blackstone_stonecutting": {
-    "result": "minecraft:chiseled_polished_blackstone",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_polished_blackstone"
+    },
     "ingredient": {
       "item": "minecraft:blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
     }
   },
   "chiseled_polished_blackstone_from_polished_blackstone_stonecutting": {
-    "result": "minecraft:chiseled_polished_blackstone",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_polished_blackstone"
+    },
     "ingredient": {
       "item": "minecraft:polished_blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
     }
   },
   "cracked_nether_bricks": {
-    "result": "minecraft:cracked_nether_bricks",
+    "result": {
+      "id": "minecraft:cracked_nether_bricks"
+    },
     "ingredient": {
       "item": "minecraft:nether_bricks"
     },
@@ -20070,7 +21155,9 @@
     }
   },
   "cracked_polished_blackstone_bricks": {
-    "result": "minecraft:cracked_polished_blackstone_bricks",
+    "result": {
+      "id": "minecraft:cracked_polished_blackstone_bricks"
+    },
     "ingredient": {
       "item": "minecraft:polished_blackstone_bricks"
     },
@@ -20082,7 +21169,8 @@
   },
   "crimson_button": {
     "result": {
-      "item": "minecraft:crimson_button"
+      "count": 1,
+      "id": "minecraft:crimson_button"
     },
     "ingredients": [
       {
@@ -20096,8 +21184,8 @@
   },
   "crimson_door": {
     "result": {
-      "item": "minecraft:crimson_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:crimson_door"
     },
     "pattern": [
       "##",
@@ -20116,8 +21204,8 @@
   },
   "crimson_fence": {
     "result": {
-      "item": "minecraft:crimson_fence",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:crimson_fence"
     },
     "pattern": [
       "W#W",
@@ -20138,7 +21226,8 @@
   },
   "crimson_fence_gate": {
     "result": {
-      "item": "minecraft:crimson_fence_gate"
+      "count": 1,
+      "id": "minecraft:crimson_fence_gate"
     },
     "pattern": [
       "#W#",
@@ -20159,8 +21248,8 @@
   },
   "crimson_hyphae": {
     "result": {
-      "item": "minecraft:crimson_hyphae",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:crimson_hyphae"
     },
     "pattern": [
       "##",
@@ -20178,8 +21267,8 @@
   },
   "crimson_planks": {
     "result": {
-      "item": "minecraft:crimson_planks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:crimson_planks"
     },
     "ingredients": [
       {
@@ -20194,7 +21283,8 @@
   },
   "crimson_pressure_plate": {
     "result": {
-      "item": "minecraft:crimson_pressure_plate"
+      "count": 1,
+      "id": "minecraft:crimson_pressure_plate"
     },
     "pattern": [
       "##"
@@ -20211,8 +21301,8 @@
   },
   "crimson_sign": {
     "result": {
-      "item": "minecraft:crimson_sign",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:crimson_sign"
     },
     "pattern": [
       "###",
@@ -20234,8 +21324,8 @@
   },
   "crimson_slab": {
     "result": {
-      "item": "minecraft:crimson_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:crimson_slab"
     },
     "pattern": [
       "###"
@@ -20252,8 +21342,8 @@
   },
   "crimson_stairs": {
     "result": {
-      "item": "minecraft:crimson_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:crimson_stairs"
     },
     "pattern": [
       "#  ",
@@ -20272,8 +21362,8 @@
   },
   "crimson_trapdoor": {
     "result": {
-      "item": "minecraft:crimson_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:crimson_trapdoor"
     },
     "pattern": [
       "###",
@@ -20290,7 +21380,9 @@
     }
   },
   "gold_ingot_from_blasting_nether_gold_ore": {
-    "result": "minecraft:gold_ingot",
+    "result": {
+      "id": "minecraft:gold_ingot"
+    },
     "ingredient": {
       "item": "minecraft:nether_gold_ore"
     },
@@ -20301,7 +21393,9 @@
     }
   },
   "gold_ingot_from_smelting_nether_gold_ore": {
-    "result": "minecraft:gold_ingot",
+    "result": {
+      "id": "minecraft:gold_ingot"
+    },
     "ingredient": {
       "item": "minecraft:nether_gold_ore"
     },
@@ -20313,7 +21407,8 @@
   },
   "lodestone": {
     "result": {
-      "item": "minecraft:lodestone"
+      "count": 1,
+      "id": "minecraft:lodestone"
     },
     "pattern": [
       "SSS",
@@ -20335,14 +21430,14 @@
   },
   "netherite_axe_smithing_legacy": {
     "result": {
-      "item": "minecraft:netherite_axe"
+      "id": "minecraft:netherite_axe"
     },
     "type": "minecraft:smithing",
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16",
-      "removed": "1.20"
+      "removed": "1.20",
+      "version": "1.16"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -20353,7 +21448,8 @@
   },
   "netherite_block": {
     "result": {
-      "item": "minecraft:netherite_block"
+      "count": 1,
+      "id": "minecraft:netherite_block"
     },
     "pattern": [
       "###",
@@ -20372,14 +21468,14 @@
   },
   "netherite_boots_smithing_legacy": {
     "result": {
-      "item": "minecraft:netherite_boots"
+      "id": "minecraft:netherite_boots"
     },
     "type": "minecraft:smithing",
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16",
-      "removed": "1.20"
+      "removed": "1.20",
+      "version": "1.16"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -20390,14 +21486,14 @@
   },
   "netherite_chestplate_smithing_legacy": {
     "result": {
-      "item": "minecraft:netherite_chestplate"
+      "id": "minecraft:netherite_chestplate"
     },
     "type": "minecraft:smithing",
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16",
-      "removed": "1.20"
+      "removed": "1.20",
+      "version": "1.16"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -20408,14 +21504,14 @@
   },
   "netherite_helmet_smithing_legacy": {
     "result": {
-      "item": "minecraft:netherite_helmet"
+      "id": "minecraft:netherite_helmet"
     },
     "type": "minecraft:smithing",
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16",
-      "removed": "1.20"
+      "removed": "1.20",
+      "version": "1.16"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -20426,14 +21522,14 @@
   },
   "netherite_hoe_smithing_legacy": {
     "result": {
-      "item": "minecraft:netherite_hoe"
+      "id": "minecraft:netherite_hoe"
     },
     "type": "minecraft:smithing",
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16",
-      "removed": "1.20"
+      "removed": "1.20",
+      "version": "1.16"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -20444,7 +21540,8 @@
   },
   "netherite_ingot": {
     "result": {
-      "item": "minecraft:netherite_ingot"
+      "count": 1,
+      "id": "minecraft:netherite_ingot"
     },
     "ingredients": [
       {
@@ -20479,8 +21576,8 @@
   },
   "netherite_ingot_from_netherite_block": {
     "result": {
-      "item": "minecraft:netherite_ingot",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:netherite_ingot"
     },
     "ingredients": [
       {
@@ -20494,14 +21591,14 @@
   },
   "netherite_leggings_smithing_legacy": {
     "result": {
-      "item": "minecraft:netherite_leggings"
+      "id": "minecraft:netherite_leggings"
     },
     "type": "minecraft:smithing",
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16",
-      "removed": "1.20"
+      "removed": "1.20",
+      "version": "1.16"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -20512,14 +21609,14 @@
   },
   "netherite_pickaxe_smithing_legacy": {
     "result": {
-      "item": "minecraft:netherite_pickaxe"
+      "id": "minecraft:netherite_pickaxe"
     },
     "type": "minecraft:smithing",
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16",
-      "removed": "1.20"
+      "removed": "1.20",
+      "version": "1.16"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -20529,7 +21626,9 @@
     }
   },
   "netherite_scrap": {
-    "result": "minecraft:netherite_scrap",
+    "result": {
+      "id": "minecraft:netherite_scrap"
+    },
     "ingredient": {
       "item": "minecraft:ancient_debris"
     },
@@ -20540,7 +21639,9 @@
     }
   },
   "netherite_scrap_from_blasting": {
-    "result": "minecraft:netherite_scrap",
+    "result": {
+      "id": "minecraft:netherite_scrap"
+    },
     "ingredient": {
       "item": "minecraft:ancient_debris"
     },
@@ -20552,14 +21653,14 @@
   },
   "netherite_shovel_smithing_legacy": {
     "result": {
-      "item": "minecraft:netherite_shovel"
+      "id": "minecraft:netherite_shovel"
     },
     "type": "minecraft:smithing",
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16",
-      "removed": "1.20"
+      "removed": "1.20",
+      "version": "1.16"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -20570,14 +21671,14 @@
   },
   "netherite_sword_smithing_legacy": {
     "result": {
-      "item": "minecraft:netherite_sword"
+      "id": "minecraft:netherite_sword"
     },
     "type": "minecraft:smithing",
     "properties": {
       "flag_removed_version": "1.19.4",
       "removed_in_flag": "1.20",
-      "version": "1.16",
-      "removed": "1.20"
+      "removed": "1.20",
+      "version": "1.16"
     },
     "addition": {
       "item": "minecraft:netherite_ingot"
@@ -20588,8 +21689,8 @@
   },
   "polished_basalt": {
     "result": {
-      "item": "minecraft:polished_basalt",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_basalt"
     },
     "pattern": [
       "SS",
@@ -20606,11 +21707,13 @@
     }
   },
   "polished_basalt_from_basalt_stonecutting": {
-    "result": "minecraft:polished_basalt",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_basalt"
+    },
     "ingredient": {
       "item": "minecraft:basalt"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -20618,8 +21721,8 @@
   },
   "polished_blackstone": {
     "result": {
-      "item": "minecraft:polished_blackstone",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_blackstone"
     },
     "pattern": [
       "SS",
@@ -20637,8 +21740,8 @@
   },
   "polished_blackstone_brick_slab": {
     "result": {
-      "item": "minecraft:polished_blackstone_brick_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:polished_blackstone_brick_slab"
     },
     "pattern": [
       "###"
@@ -20654,33 +21757,39 @@
     }
   },
   "polished_blackstone_brick_slab_from_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_blackstone_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:blackstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
     }
   },
   "polished_blackstone_brick_slab_from_polished_blackstone_bricks_stonecutting": {
-    "result": "minecraft:polished_blackstone_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_blackstone_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:polished_blackstone_bricks"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
     }
   },
   "polished_blackstone_brick_slab_from_polished_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_blackstone_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:polished_blackstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -20688,8 +21797,8 @@
   },
   "polished_blackstone_brick_stairs": {
     "result": {
-      "item": "minecraft:polished_blackstone_brick_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_blackstone_brick_stairs"
     },
     "pattern": [
       "#  ",
@@ -20707,33 +21816,39 @@
     }
   },
   "polished_blackstone_brick_stairs_from_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
     }
   },
   "polished_blackstone_brick_stairs_from_polished_blackstone_bricks_stonecutting": {
-    "result": "minecraft:polished_blackstone_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:polished_blackstone_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
     }
   },
   "polished_blackstone_brick_stairs_from_polished_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:polished_blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -20741,8 +21856,8 @@
   },
   "polished_blackstone_brick_wall": {
     "result": {
-      "item": "minecraft:polished_blackstone_brick_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:polished_blackstone_brick_wall"
     },
     "pattern": [
       "###",
@@ -20759,33 +21874,39 @@
     }
   },
   "polished_blackstone_brick_wall_from_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
     }
   },
   "polished_blackstone_brick_wall_from_polished_blackstone_bricks_stonecutting": {
-    "result": "minecraft:polished_blackstone_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:polished_blackstone_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
     }
   },
   "polished_blackstone_brick_wall_from_polished_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:polished_blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -20793,8 +21914,8 @@
   },
   "polished_blackstone_bricks": {
     "result": {
-      "item": "minecraft:polished_blackstone_bricks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_blackstone_bricks"
     },
     "pattern": [
       "SS",
@@ -20811,22 +21932,26 @@
     }
   },
   "polished_blackstone_bricks_from_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone_bricks"
+    },
     "ingredient": {
       "item": "minecraft:blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
     }
   },
   "polished_blackstone_bricks_from_polished_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone_bricks"
+    },
     "ingredient": {
       "item": "minecraft:polished_blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -20834,7 +21959,8 @@
   },
   "polished_blackstone_button": {
     "result": {
-      "item": "minecraft:polished_blackstone_button"
+      "count": 1,
+      "id": "minecraft:polished_blackstone_button"
     },
     "ingredients": [
       {
@@ -20847,11 +21973,13 @@
     }
   },
   "polished_blackstone_from_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone"
+    },
     "ingredient": {
       "item": "minecraft:blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -20859,7 +21987,8 @@
   },
   "polished_blackstone_pressure_plate": {
     "result": {
-      "item": "minecraft:polished_blackstone_pressure_plate"
+      "count": 1,
+      "id": "minecraft:polished_blackstone_pressure_plate"
     },
     "pattern": [
       "##"
@@ -20876,8 +22005,8 @@
   },
   "polished_blackstone_slab": {
     "result": {
-      "item": "minecraft:polished_blackstone_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:polished_blackstone_slab"
     },
     "pattern": [
       "###"
@@ -20893,22 +22022,26 @@
     }
   },
   "polished_blackstone_slab_from_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_blackstone_slab"
+    },
     "ingredient": {
       "item": "minecraft:blackstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
     }
   },
   "polished_blackstone_slab_from_polished_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_blackstone_slab"
+    },
     "ingredient": {
       "item": "minecraft:polished_blackstone"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -20916,8 +22049,8 @@
   },
   "polished_blackstone_stairs": {
     "result": {
-      "item": "minecraft:polished_blackstone_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_blackstone_stairs"
     },
     "pattern": [
       "#  ",
@@ -20935,22 +22068,26 @@
     }
   },
   "polished_blackstone_stairs_from_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone_stairs"
+    },
     "ingredient": {
       "item": "minecraft:blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
     }
   },
   "polished_blackstone_stairs_from_polished_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone_stairs"
+    },
     "ingredient": {
       "item": "minecraft:polished_blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -20958,8 +22095,8 @@
   },
   "polished_blackstone_wall": {
     "result": {
-      "item": "minecraft:polished_blackstone_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:polished_blackstone_wall"
     },
     "pattern": [
       "###",
@@ -20976,22 +22113,26 @@
     }
   },
   "polished_blackstone_wall_from_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone_wall"
+    },
     "ingredient": {
       "item": "minecraft:blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
     }
   },
   "polished_blackstone_wall_from_polished_blackstone_stonecutting": {
-    "result": "minecraft:polished_blackstone_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_blackstone_wall"
+    },
     "ingredient": {
       "item": "minecraft:polished_blackstone"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -20999,8 +22140,8 @@
   },
   "quartz_bricks": {
     "result": {
-      "item": "minecraft:quartz_bricks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:quartz_bricks"
     },
     "pattern": [
       "##",
@@ -21017,11 +22158,13 @@
     }
   },
   "quartz_bricks_from_quartz_block_stonecutting": {
-    "result": "minecraft:quartz_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:quartz_bricks"
+    },
     "ingredient": {
       "item": "minecraft:quartz_block"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.16"
@@ -21029,7 +22172,8 @@
   },
   "respawn_anchor": {
     "result": {
-      "item": "minecraft:respawn_anchor"
+      "count": 1,
+      "id": "minecraft:respawn_anchor"
     },
     "pattern": [
       "OOO",
@@ -21051,7 +22195,8 @@
   },
   "soul_campfire": {
     "result": {
-      "item": "minecraft:soul_campfire"
+      "count": 1,
+      "id": "minecraft:soul_campfire"
     },
     "pattern": [
       " S ",
@@ -21077,7 +22222,8 @@
   },
   "soul_lantern": {
     "result": {
-      "item": "minecraft:soul_lantern"
+      "count": 1,
+      "id": "minecraft:soul_lantern"
     },
     "pattern": [
       "XXX",
@@ -21099,8 +22245,8 @@
   },
   "soul_torch": {
     "result": {
-      "item": "minecraft:soul_torch",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:soul_torch"
     },
     "pattern": [
       "X",
@@ -21131,8 +22277,8 @@
   },
   "stripped_crimson_hyphae": {
     "result": {
-      "item": "minecraft:stripped_crimson_hyphae",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:stripped_crimson_hyphae"
     },
     "pattern": [
       "##",
@@ -21150,8 +22296,8 @@
   },
   "stripped_warped_hyphae": {
     "result": {
-      "item": "minecraft:stripped_warped_hyphae",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:stripped_warped_hyphae"
     },
     "pattern": [
       "##",
@@ -21169,7 +22315,8 @@
   },
   "target": {
     "result": {
-      "item": "minecraft:target"
+      "count": 1,
+      "id": "minecraft:target"
     },
     "pattern": [
       " R ",
@@ -21191,7 +22338,8 @@
   },
   "warped_button": {
     "result": {
-      "item": "minecraft:warped_button"
+      "count": 1,
+      "id": "minecraft:warped_button"
     },
     "ingredients": [
       {
@@ -21205,8 +22353,8 @@
   },
   "warped_door": {
     "result": {
-      "item": "minecraft:warped_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:warped_door"
     },
     "pattern": [
       "##",
@@ -21225,8 +22373,8 @@
   },
   "warped_fence": {
     "result": {
-      "item": "minecraft:warped_fence",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:warped_fence"
     },
     "pattern": [
       "W#W",
@@ -21247,7 +22395,8 @@
   },
   "warped_fence_gate": {
     "result": {
-      "item": "minecraft:warped_fence_gate"
+      "count": 1,
+      "id": "minecraft:warped_fence_gate"
     },
     "pattern": [
       "#W#",
@@ -21268,7 +22417,8 @@
   },
   "warped_fungus_on_a_stick": {
     "result": {
-      "item": "minecraft:warped_fungus_on_a_stick"
+      "count": 1,
+      "id": "minecraft:warped_fungus_on_a_stick"
     },
     "pattern": [
       "# ",
@@ -21289,8 +22439,8 @@
   },
   "warped_hyphae": {
     "result": {
-      "item": "minecraft:warped_hyphae",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:warped_hyphae"
     },
     "pattern": [
       "##",
@@ -21308,8 +22458,8 @@
   },
   "warped_planks": {
     "result": {
-      "item": "minecraft:warped_planks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:warped_planks"
     },
     "ingredients": [
       {
@@ -21324,7 +22474,8 @@
   },
   "warped_pressure_plate": {
     "result": {
-      "item": "minecraft:warped_pressure_plate"
+      "count": 1,
+      "id": "minecraft:warped_pressure_plate"
     },
     "pattern": [
       "##"
@@ -21341,8 +22492,8 @@
   },
   "warped_sign": {
     "result": {
-      "item": "minecraft:warped_sign",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:warped_sign"
     },
     "pattern": [
       "###",
@@ -21364,8 +22515,8 @@
   },
   "warped_slab": {
     "result": {
-      "item": "minecraft:warped_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:warped_slab"
     },
     "pattern": [
       "###"
@@ -21382,8 +22533,8 @@
   },
   "warped_stairs": {
     "result": {
-      "item": "minecraft:warped_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:warped_stairs"
     },
     "pattern": [
       "#  ",
@@ -21402,8 +22553,8 @@
   },
   "warped_trapdoor": {
     "result": {
-      "item": "minecraft:warped_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:warped_trapdoor"
     },
     "pattern": [
       "###",
@@ -21421,7 +22572,7 @@
   },
   "brewing_stand_from_blackstone": {
     "result": {
-      "item": "minecraft:brewing_stand"
+      "id": "minecraft:brewing_stand"
     },
     "pattern": [
       " B ",
@@ -21442,7 +22593,8 @@
   },
   "amethyst_block": {
     "result": {
-      "item": "minecraft:amethyst_block"
+      "count": 1,
+      "id": "minecraft:amethyst_block"
     },
     "pattern": [
       "##",
@@ -21460,7 +22612,8 @@
   },
   "black_candle": {
     "result": {
-      "item": "minecraft:black_candle"
+      "count": 1,
+      "id": "minecraft:black_candle"
     },
     "ingredients": [
       {
@@ -21477,7 +22630,8 @@
   },
   "blue_candle": {
     "result": {
-      "item": "minecraft:blue_candle"
+      "count": 1,
+      "id": "minecraft:blue_candle"
     },
     "ingredients": [
       {
@@ -21494,7 +22648,7 @@
   },
   "brewing_stand_from_cobbled_deepslate": {
     "result": {
-      "item": "minecraft:brewing_stand"
+      "id": "minecraft:brewing_stand"
     },
     "pattern": [
       " B ",
@@ -21515,7 +22669,8 @@
   },
   "brown_candle": {
     "result": {
-      "item": "minecraft:brown_candle"
+      "count": 1,
+      "id": "minecraft:brown_candle"
     },
     "ingredients": [
       {
@@ -21532,7 +22687,8 @@
   },
   "candle": {
     "result": {
-      "item": "minecraft:candle"
+      "count": 1,
+      "id": "minecraft:candle"
     },
     "pattern": [
       "S",
@@ -21553,7 +22709,8 @@
   },
   "chiseled_deepslate": {
     "result": {
-      "item": "minecraft:chiseled_deepslate"
+      "count": 1,
+      "id": "minecraft:chiseled_deepslate"
     },
     "pattern": [
       "#",
@@ -21570,18 +22727,22 @@
     }
   },
   "chiseled_deepslate_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:chiseled_deepslate",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_deepslate"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "coal_from_blasting_coal_ore": {
-    "result": "minecraft:coal",
+    "result": {
+      "id": "minecraft:coal"
+    },
     "ingredient": {
       "item": "minecraft:coal_ore"
     },
@@ -21592,7 +22753,9 @@
     }
   },
   "coal_from_blasting_deepslate_coal_ore": {
-    "result": "minecraft:coal",
+    "result": {
+      "id": "minecraft:coal"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_coal_ore"
     },
@@ -21603,7 +22766,9 @@
     }
   },
   "coal_from_smelting_deepslate_coal_ore": {
-    "result": "minecraft:coal",
+    "result": {
+      "id": "minecraft:coal"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_coal_ore"
     },
@@ -21615,8 +22780,8 @@
   },
   "cobbled_deepslate_slab": {
     "result": {
-      "item": "minecraft:cobbled_deepslate_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:cobbled_deepslate_slab"
     },
     "pattern": [
       "###"
@@ -21632,11 +22797,13 @@
     }
   },
   "cobbled_deepslate_slab_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:cobbled_deepslate_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:cobbled_deepslate_slab"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -21644,8 +22811,8 @@
   },
   "cobbled_deepslate_stairs": {
     "result": {
-      "item": "minecraft:cobbled_deepslate_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:cobbled_deepslate_stairs"
     },
     "pattern": [
       "#  ",
@@ -21663,11 +22830,13 @@
     }
   },
   "cobbled_deepslate_stairs_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:cobbled_deepslate_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:cobbled_deepslate_stairs"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -21675,8 +22844,8 @@
   },
   "cobbled_deepslate_wall": {
     "result": {
-      "item": "minecraft:cobbled_deepslate_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:cobbled_deepslate_wall"
     },
     "pattern": [
       "###",
@@ -21693,11 +22862,13 @@
     }
   },
   "cobbled_deepslate_wall_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:cobbled_deepslate_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:cobbled_deepslate_wall"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -21705,7 +22876,8 @@
   },
   "copper_block": {
     "result": {
-      "item": "minecraft:copper_block"
+      "count": 1,
+      "id": "minecraft:copper_block"
     },
     "pattern": [
       "###",
@@ -21724,8 +22896,8 @@
   },
   "copper_ingot": {
     "result": {
-      "item": "minecraft:copper_ingot",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:copper_ingot"
     },
     "ingredients": [
       {
@@ -21738,7 +22910,9 @@
     }
   },
   "copper_ingot_from_blasting_copper_ore": {
-    "result": "minecraft:copper_ingot",
+    "result": {
+      "id": "minecraft:copper_ingot"
+    },
     "ingredient": {
       "item": "minecraft:copper_ore"
     },
@@ -21749,7 +22923,9 @@
     }
   },
   "copper_ingot_from_blasting_deepslate_copper_ore": {
-    "result": "minecraft:copper_ingot",
+    "result": {
+      "id": "minecraft:copper_ingot"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_copper_ore"
     },
@@ -21760,7 +22936,9 @@
     }
   },
   "copper_ingot_from_blasting_raw_copper": {
-    "result": "minecraft:copper_ingot",
+    "result": {
+      "id": "minecraft:copper_ingot"
+    },
     "ingredient": {
       "item": "minecraft:raw_copper"
     },
@@ -21771,7 +22949,9 @@
     }
   },
   "copper_ingot_from_smelting_copper_ore": {
-    "result": "minecraft:copper_ingot",
+    "result": {
+      "id": "minecraft:copper_ingot"
+    },
     "ingredient": {
       "item": "minecraft:copper_ore"
     },
@@ -21782,7 +22962,9 @@
     }
   },
   "copper_ingot_from_smelting_deepslate_copper_ore": {
-    "result": "minecraft:copper_ingot",
+    "result": {
+      "id": "minecraft:copper_ingot"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_copper_ore"
     },
@@ -21793,7 +22975,9 @@
     }
   },
   "copper_ingot_from_smelting_raw_copper": {
-    "result": "minecraft:copper_ingot",
+    "result": {
+      "id": "minecraft:copper_ingot"
+    },
     "ingredient": {
       "item": "minecraft:raw_copper"
     },
@@ -21805,8 +22989,8 @@
   },
   "copper_ingot_from_waxed_copper_block": {
     "result": {
-      "item": "minecraft:copper_ingot",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:copper_ingot"
     },
     "ingredients": [
       {
@@ -21819,7 +23003,9 @@
     }
   },
   "cracked_deepslate_bricks": {
-    "result": "minecraft:cracked_deepslate_bricks",
+    "result": {
+      "id": "minecraft:cracked_deepslate_bricks"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_bricks"
     },
@@ -21830,7 +23016,9 @@
     }
   },
   "cracked_deepslate_tiles": {
-    "result": "minecraft:cracked_deepslate_tiles",
+    "result": {
+      "id": "minecraft:cracked_deepslate_tiles"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_tiles"
     },
@@ -21842,8 +23030,8 @@
   },
   "cut_copper": {
     "result": {
-      "item": "minecraft:cut_copper",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:cut_copper"
     },
     "pattern": [
       "##",
@@ -21860,11 +23048,13 @@
     }
   },
   "cut_copper_from_copper_block_stonecutting": {
-    "result": "minecraft:cut_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:cut_copper"
+    },
     "ingredient": {
       "item": "minecraft:copper_block"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -21877,8 +23067,8 @@
   },
   "cut_copper_slab": {
     "result": {
-      "item": "minecraft:cut_copper_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:cut_copper_slab"
     },
     "pattern": [
       "###"
@@ -21894,11 +23084,13 @@
     }
   },
   "cut_copper_slab_from_copper_block_stonecutting": {
-    "result": "minecraft:cut_copper_slab",
+    "result": {
+      "count": 8,
+      "id": "minecraft:cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:copper_block"
     },
-    "count": 8,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -21910,11 +23102,13 @@
     }
   },
   "cut_copper_slab_from_cut_copper_stonecutting": {
-    "result": "minecraft:cut_copper_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:cut_copper"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -21922,8 +23116,8 @@
   },
   "cut_copper_stairs": {
     "result": {
-      "item": "minecraft:cut_copper_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:cut_copper_stairs"
     },
     "pattern": [
       "#  ",
@@ -21941,11 +23135,13 @@
     }
   },
   "cut_copper_stairs_from_copper_block_stonecutting": {
-    "result": "minecraft:cut_copper_stairs",
+    "result": {
+      "count": 4,
+      "id": "minecraft:cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:copper_block"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -21957,11 +23153,13 @@
     }
   },
   "cut_copper_stairs_from_cut_copper_stonecutting": {
-    "result": "minecraft:cut_copper_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -21969,7 +23167,8 @@
   },
   "cyan_candle": {
     "result": {
-      "item": "minecraft:cyan_candle"
+      "count": 1,
+      "id": "minecraft:cyan_candle"
     },
     "ingredients": [
       {
@@ -21985,7 +23184,9 @@
     }
   },
   "deepslate": {
-    "result": "minecraft:deepslate",
+    "result": {
+      "id": "minecraft:deepslate"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
@@ -21997,8 +23198,8 @@
   },
   "deepslate_brick_slab": {
     "result": {
-      "item": "minecraft:deepslate_brick_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:deepslate_brick_slab"
     },
     "pattern": [
       "###"
@@ -22014,33 +23215,39 @@
     }
   },
   "deepslate_brick_slab_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:deepslate_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_brick_slab_from_deepslate_bricks_stonecutting": {
-    "result": "minecraft:deepslate_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:deepslate_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_bricks"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_brick_slab_from_polished_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:deepslate_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:polished_deepslate"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -22048,8 +23255,8 @@
   },
   "deepslate_brick_stairs": {
     "result": {
-      "item": "minecraft:deepslate_brick_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:deepslate_brick_stairs"
     },
     "pattern": [
       "#  ",
@@ -22067,33 +23274,39 @@
     }
   },
   "deepslate_brick_stairs_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_brick_stairs_from_deepslate_bricks_stonecutting": {
-    "result": "minecraft:deepslate_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_brick_stairs_from_polished_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:polished_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -22101,8 +23314,8 @@
   },
   "deepslate_brick_wall": {
     "result": {
-      "item": "minecraft:deepslate_brick_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:deepslate_brick_wall"
     },
     "pattern": [
       "###",
@@ -22119,33 +23332,39 @@
     }
   },
   "deepslate_brick_wall_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_brick_wall_from_deepslate_bricks_stonecutting": {
-    "result": "minecraft:deepslate_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_brick_wall_from_polished_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:polished_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -22153,8 +23372,8 @@
   },
   "deepslate_bricks": {
     "result": {
-      "item": "minecraft:deepslate_bricks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:deepslate_bricks"
     },
     "pattern": [
       "SS",
@@ -22171,22 +23390,26 @@
     }
   },
   "deepslate_bricks_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_bricks"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_bricks_from_polished_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_bricks"
+    },
     "ingredient": {
       "item": "minecraft:polished_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -22194,8 +23417,8 @@
   },
   "deepslate_tile_slab": {
     "result": {
-      "item": "minecraft:deepslate_tile_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:deepslate_tile_slab"
     },
     "pattern": [
       "###"
@@ -22211,44 +23434,52 @@
     }
   },
   "deepslate_tile_slab_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_tile_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:deepslate_tile_slab"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_tile_slab_from_deepslate_bricks_stonecutting": {
-    "result": "minecraft:deepslate_tile_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:deepslate_tile_slab"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_bricks"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_tile_slab_from_deepslate_tiles_stonecutting": {
-    "result": "minecraft:deepslate_tile_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:deepslate_tile_slab"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_tiles"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_tile_slab_from_polished_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_tile_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:deepslate_tile_slab"
+    },
     "ingredient": {
       "item": "minecraft:polished_deepslate"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -22256,8 +23487,8 @@
   },
   "deepslate_tile_stairs": {
     "result": {
-      "item": "minecraft:deepslate_tile_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:deepslate_tile_stairs"
     },
     "pattern": [
       "#  ",
@@ -22275,44 +23506,52 @@
     }
   },
   "deepslate_tile_stairs_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_tile_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_tile_stairs"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_tile_stairs_from_deepslate_bricks_stonecutting": {
-    "result": "minecraft:deepslate_tile_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_tile_stairs"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_tile_stairs_from_deepslate_tiles_stonecutting": {
-    "result": "minecraft:deepslate_tile_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_tile_stairs"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_tiles"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_tile_stairs_from_polished_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_tile_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_tile_stairs"
+    },
     "ingredient": {
       "item": "minecraft:polished_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -22320,8 +23559,8 @@
   },
   "deepslate_tile_wall": {
     "result": {
-      "item": "minecraft:deepslate_tile_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:deepslate_tile_wall"
     },
     "pattern": [
       "###",
@@ -22338,44 +23577,52 @@
     }
   },
   "deepslate_tile_wall_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_tile_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_tile_wall"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_tile_wall_from_deepslate_bricks_stonecutting": {
-    "result": "minecraft:deepslate_tile_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_tile_wall"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_tile_wall_from_deepslate_tiles_stonecutting": {
-    "result": "minecraft:deepslate_tile_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_tile_wall"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_tiles"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_tile_wall_from_polished_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_tile_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_tile_wall"
+    },
     "ingredient": {
       "item": "minecraft:polished_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -22383,8 +23630,8 @@
   },
   "deepslate_tiles": {
     "result": {
-      "item": "minecraft:deepslate_tiles",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:deepslate_tiles"
     },
     "pattern": [
       "SS",
@@ -22401,40 +23648,48 @@
     }
   },
   "deepslate_tiles_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_tiles",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_tiles"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_tiles_from_deepslate_bricks_stonecutting": {
-    "result": "minecraft:deepslate_tiles",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_tiles"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "deepslate_tiles_from_polished_deepslate_stonecutting": {
-    "result": "minecraft:deepslate_tiles",
+    "result": {
+      "count": 1,
+      "id": "minecraft:deepslate_tiles"
+    },
     "ingredient": {
       "item": "minecraft:polished_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "diamond_from_blasting_deepslate_diamond_ore": {
-    "result": "minecraft:diamond",
+    "result": {
+      "id": "minecraft:diamond"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_diamond_ore"
     },
@@ -22445,7 +23700,9 @@
     }
   },
   "diamond_from_smelting_deepslate_diamond_ore": {
-    "result": "minecraft:diamond",
+    "result": {
+      "id": "minecraft:diamond"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_diamond_ore"
     },
@@ -22457,7 +23714,8 @@
   },
   "dripstone_block": {
     "result": {
-      "item": "minecraft:dripstone_block"
+      "count": 1,
+      "id": "minecraft:dripstone_block"
     },
     "pattern": [
       "##",
@@ -22474,7 +23732,9 @@
     }
   },
   "emerald_from_blasting_deepslate_emerald_ore": {
-    "result": "minecraft:emerald",
+    "result": {
+      "id": "minecraft:emerald"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_emerald_ore"
     },
@@ -22485,7 +23745,9 @@
     }
   },
   "emerald_from_smelting_deepslate_emerald_ore": {
-    "result": "minecraft:emerald",
+    "result": {
+      "id": "minecraft:emerald"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_emerald_ore"
     },
@@ -22497,8 +23759,8 @@
   },
   "exposed_cut_copper": {
     "result": {
-      "item": "minecraft:exposed_cut_copper",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:exposed_cut_copper"
     },
     "pattern": [
       "##",
@@ -22515,11 +23777,13 @@
     }
   },
   "exposed_cut_copper_from_exposed_copper_stonecutting": {
-    "result": "minecraft:exposed_cut_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:exposed_cut_copper"
+    },
     "ingredient": {
       "item": "minecraft:exposed_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -22532,8 +23796,8 @@
   },
   "exposed_cut_copper_slab": {
     "result": {
-      "item": "minecraft:exposed_cut_copper_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:exposed_cut_copper_slab"
     },
     "pattern": [
       "###"
@@ -22549,11 +23813,13 @@
     }
   },
   "exposed_cut_copper_slab_from_exposed_copper_stonecutting": {
-    "result": "minecraft:exposed_cut_copper_slab",
+    "result": {
+      "count": 8,
+      "id": "minecraft:exposed_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:exposed_copper"
     },
-    "count": 8,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -22565,11 +23831,13 @@
     }
   },
   "exposed_cut_copper_slab_from_exposed_cut_copper_stonecutting": {
-    "result": "minecraft:exposed_cut_copper_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:exposed_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:exposed_cut_copper"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -22577,8 +23845,8 @@
   },
   "exposed_cut_copper_stairs": {
     "result": {
-      "item": "minecraft:exposed_cut_copper_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:exposed_cut_copper_stairs"
     },
     "pattern": [
       "#  ",
@@ -22596,11 +23864,13 @@
     }
   },
   "exposed_cut_copper_stairs_from_exposed_copper_stonecutting": {
-    "result": "minecraft:exposed_cut_copper_stairs",
+    "result": {
+      "count": 4,
+      "id": "minecraft:exposed_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:exposed_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -22612,11 +23882,13 @@
     }
   },
   "exposed_cut_copper_stairs_from_exposed_cut_copper_stonecutting": {
-    "result": "minecraft:exposed_cut_copper_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:exposed_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:exposed_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -22624,7 +23896,8 @@
   },
   "glow_item_frame": {
     "result": {
-      "item": "minecraft:glow_item_frame"
+      "count": 1,
+      "id": "minecraft:glow_item_frame"
     },
     "ingredients": [
       {
@@ -22640,7 +23913,9 @@
     }
   },
   "gold_ingot_from_blasting_deepslate_gold_ore": {
-    "result": "minecraft:gold_ingot",
+    "result": {
+      "id": "minecraft:gold_ingot"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_gold_ore"
     },
@@ -22651,7 +23926,9 @@
     }
   },
   "gold_ingot_from_blasting_raw_gold": {
-    "result": "minecraft:gold_ingot",
+    "result": {
+      "id": "minecraft:gold_ingot"
+    },
     "ingredient": {
       "item": "minecraft:raw_gold"
     },
@@ -22662,7 +23939,9 @@
     }
   },
   "gold_ingot_from_smelting_deepslate_gold_ore": {
-    "result": "minecraft:gold_ingot",
+    "result": {
+      "id": "minecraft:gold_ingot"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_gold_ore"
     },
@@ -22673,7 +23952,9 @@
     }
   },
   "gold_ingot_from_smelting_raw_gold": {
-    "result": "minecraft:gold_ingot",
+    "result": {
+      "id": "minecraft:gold_ingot"
+    },
     "ingredient": {
       "item": "minecraft:raw_gold"
     },
@@ -22685,7 +23966,8 @@
   },
   "gray_candle": {
     "result": {
-      "item": "minecraft:gray_candle"
+      "count": 1,
+      "id": "minecraft:gray_candle"
     },
     "ingredients": [
       {
@@ -22702,7 +23984,8 @@
   },
   "green_candle": {
     "result": {
-      "item": "minecraft:green_candle"
+      "count": 1,
+      "id": "minecraft:green_candle"
     },
     "ingredients": [
       {
@@ -22718,7 +24001,9 @@
     }
   },
   "iron_ingot_from_blasting_deepslate_iron_ore": {
-    "result": "minecraft:iron_ingot",
+    "result": {
+      "id": "minecraft:iron_ingot"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_iron_ore"
     },
@@ -22729,7 +24014,9 @@
     }
   },
   "iron_ingot_from_blasting_raw_iron": {
-    "result": "minecraft:iron_ingot",
+    "result": {
+      "id": "minecraft:iron_ingot"
+    },
     "ingredient": {
       "item": "minecraft:raw_iron"
     },
@@ -22740,7 +24027,9 @@
     }
   },
   "iron_ingot_from_smelting_deepslate_iron_ore": {
-    "result": "minecraft:iron_ingot",
+    "result": {
+      "id": "minecraft:iron_ingot"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_iron_ore"
     },
@@ -22751,7 +24040,9 @@
     }
   },
   "iron_ingot_from_smelting_raw_iron": {
-    "result": "minecraft:iron_ingot",
+    "result": {
+      "id": "minecraft:iron_ingot"
+    },
     "ingredient": {
       "item": "minecraft:raw_iron"
     },
@@ -22762,7 +24053,9 @@
     }
   },
   "lapis_lazuli_from_blasting_deepslate_lapis_ore": {
-    "result": "minecraft:lapis_lazuli",
+    "result": {
+      "id": "minecraft:lapis_lazuli"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_lapis_ore"
     },
@@ -22773,7 +24066,9 @@
     }
   },
   "lapis_lazuli_from_smelting_deepslate_lapis_ore": {
-    "result": "minecraft:lapis_lazuli",
+    "result": {
+      "id": "minecraft:lapis_lazuli"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_lapis_ore"
     },
@@ -22785,7 +24080,8 @@
   },
   "light_blue_candle": {
     "result": {
-      "item": "minecraft:light_blue_candle"
+      "count": 1,
+      "id": "minecraft:light_blue_candle"
     },
     "ingredients": [
       {
@@ -22802,7 +24098,8 @@
   },
   "light_gray_candle": {
     "result": {
-      "item": "minecraft:light_gray_candle"
+      "count": 1,
+      "id": "minecraft:light_gray_candle"
     },
     "ingredients": [
       {
@@ -22819,7 +24116,8 @@
   },
   "lightning_rod": {
     "result": {
-      "item": "minecraft:lightning_rod"
+      "count": 1,
+      "id": "minecraft:lightning_rod"
     },
     "pattern": [
       "#",
@@ -22838,7 +24136,8 @@
   },
   "lime_candle": {
     "result": {
-      "item": "minecraft:lime_candle"
+      "count": 1,
+      "id": "minecraft:lime_candle"
     },
     "ingredients": [
       {
@@ -22855,7 +24154,8 @@
   },
   "magenta_candle": {
     "result": {
-      "item": "minecraft:magenta_candle"
+      "count": 1,
+      "id": "minecraft:magenta_candle"
     },
     "ingredients": [
       {
@@ -22872,8 +24172,8 @@
   },
   "moss_carpet": {
     "result": {
-      "item": "minecraft:moss_carpet",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:moss_carpet"
     },
     "pattern": [
       "##"
@@ -22890,7 +24190,8 @@
   },
   "mossy_cobblestone_from_moss_block": {
     "result": {
-      "item": "minecraft:mossy_cobblestone"
+      "count": 1,
+      "id": "minecraft:mossy_cobblestone"
     },
     "ingredients": [
       {
@@ -22907,7 +24208,8 @@
   },
   "mossy_stone_bricks_from_moss_block": {
     "result": {
-      "item": "minecraft:mossy_stone_bricks"
+      "count": 1,
+      "id": "minecraft:mossy_stone_bricks"
     },
     "ingredients": [
       {
@@ -22924,7 +24226,8 @@
   },
   "orange_candle": {
     "result": {
-      "item": "minecraft:orange_candle"
+      "count": 1,
+      "id": "minecraft:orange_candle"
     },
     "ingredients": [
       {
@@ -22941,8 +24244,8 @@
   },
   "oxidized_cut_copper": {
     "result": {
-      "item": "minecraft:oxidized_cut_copper",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:oxidized_cut_copper"
     },
     "pattern": [
       "##",
@@ -22959,11 +24262,13 @@
     }
   },
   "oxidized_cut_copper_from_oxidized_copper_stonecutting": {
-    "result": "minecraft:oxidized_cut_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:oxidized_cut_copper"
+    },
     "ingredient": {
       "item": "minecraft:oxidized_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -22976,8 +24281,8 @@
   },
   "oxidized_cut_copper_slab": {
     "result": {
-      "item": "minecraft:oxidized_cut_copper_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:oxidized_cut_copper_slab"
     },
     "pattern": [
       "###"
@@ -22993,11 +24298,13 @@
     }
   },
   "oxidized_cut_copper_slab_from_oxidized_copper_stonecutting": {
-    "result": "minecraft:oxidized_cut_copper_slab",
+    "result": {
+      "count": 8,
+      "id": "minecraft:oxidized_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:oxidized_copper"
     },
-    "count": 8,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -23009,11 +24316,13 @@
     }
   },
   "oxidized_cut_copper_slab_from_oxidized_cut_copper_stonecutting": {
-    "result": "minecraft:oxidized_cut_copper_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:oxidized_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:oxidized_cut_copper"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -23021,8 +24330,8 @@
   },
   "oxidized_cut_copper_stairs": {
     "result": {
-      "item": "minecraft:oxidized_cut_copper_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:oxidized_cut_copper_stairs"
     },
     "pattern": [
       "#  ",
@@ -23040,11 +24349,13 @@
     }
   },
   "oxidized_cut_copper_stairs_from_oxidized_copper_stonecutting": {
-    "result": "minecraft:oxidized_cut_copper_stairs",
+    "result": {
+      "count": 4,
+      "id": "minecraft:oxidized_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:oxidized_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -23056,11 +24367,13 @@
     }
   },
   "oxidized_cut_copper_stairs_from_oxidized_cut_copper_stonecutting": {
-    "result": "minecraft:oxidized_cut_copper_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:oxidized_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:oxidized_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -23068,7 +24381,8 @@
   },
   "pink_candle": {
     "result": {
-      "item": "minecraft:pink_candle"
+      "count": 1,
+      "id": "minecraft:pink_candle"
     },
     "ingredients": [
       {
@@ -23085,8 +24399,8 @@
   },
   "polished_deepslate": {
     "result": {
-      "item": "minecraft:polished_deepslate",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_deepslate"
     },
     "pattern": [
       "SS",
@@ -23103,11 +24417,13 @@
     }
   },
   "polished_deepslate_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:polished_deepslate",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_deepslate"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -23115,8 +24431,8 @@
   },
   "polished_deepslate_slab": {
     "result": {
-      "item": "minecraft:polished_deepslate_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:polished_deepslate_slab"
     },
     "pattern": [
       "###"
@@ -23132,22 +24448,26 @@
     }
   },
   "polished_deepslate_slab_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:polished_deepslate_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_deepslate_slab"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "polished_deepslate_slab_from_polished_deepslate_stonecutting": {
-    "result": "minecraft:polished_deepslate_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_deepslate_slab"
+    },
     "ingredient": {
       "item": "minecraft:polished_deepslate"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -23155,8 +24475,8 @@
   },
   "polished_deepslate_stairs": {
     "result": {
-      "item": "minecraft:polished_deepslate_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_deepslate_stairs"
     },
     "pattern": [
       "#  ",
@@ -23174,22 +24494,26 @@
     }
   },
   "polished_deepslate_stairs_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:polished_deepslate_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_deepslate_stairs"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "polished_deepslate_stairs_from_polished_deepslate_stonecutting": {
-    "result": "minecraft:polished_deepslate_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_deepslate_stairs"
+    },
     "ingredient": {
       "item": "minecraft:polished_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -23197,8 +24521,8 @@
   },
   "polished_deepslate_wall": {
     "result": {
-      "item": "minecraft:polished_deepslate_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:polished_deepslate_wall"
     },
     "pattern": [
       "###",
@@ -23215,22 +24539,26 @@
     }
   },
   "polished_deepslate_wall_from_cobbled_deepslate_stonecutting": {
-    "result": "minecraft:polished_deepslate_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_deepslate_wall"
+    },
     "ingredient": {
       "item": "minecraft:cobbled_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
     }
   },
   "polished_deepslate_wall_from_polished_deepslate_stonecutting": {
-    "result": "minecraft:polished_deepslate_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_deepslate_wall"
+    },
     "ingredient": {
       "item": "minecraft:polished_deepslate"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -23238,7 +24566,8 @@
   },
   "purple_candle": {
     "result": {
-      "item": "minecraft:purple_candle"
+      "count": 1,
+      "id": "minecraft:purple_candle"
     },
     "ingredients": [
       {
@@ -23255,8 +24584,8 @@
   },
   "raw_copper": {
     "result": {
-      "item": "minecraft:raw_copper",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:raw_copper"
     },
     "ingredients": [
       {
@@ -23270,7 +24599,8 @@
   },
   "raw_copper_block": {
     "result": {
-      "item": "minecraft:raw_copper_block"
+      "count": 1,
+      "id": "minecraft:raw_copper_block"
     },
     "pattern": [
       "###",
@@ -23289,8 +24619,8 @@
   },
   "raw_gold": {
     "result": {
-      "item": "minecraft:raw_gold",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:raw_gold"
     },
     "ingredients": [
       {
@@ -23304,7 +24634,8 @@
   },
   "raw_gold_block": {
     "result": {
-      "item": "minecraft:raw_gold_block"
+      "count": 1,
+      "id": "minecraft:raw_gold_block"
     },
     "pattern": [
       "###",
@@ -23323,8 +24654,8 @@
   },
   "raw_iron": {
     "result": {
-      "item": "minecraft:raw_iron",
-      "count": 9
+      "count": 9,
+      "id": "minecraft:raw_iron"
     },
     "ingredients": [
       {
@@ -23338,7 +24669,8 @@
   },
   "raw_iron_block": {
     "result": {
-      "item": "minecraft:raw_iron_block"
+      "count": 1,
+      "id": "minecraft:raw_iron_block"
     },
     "pattern": [
       "###",
@@ -23357,7 +24689,8 @@
   },
   "red_candle": {
     "result": {
-      "item": "minecraft:red_candle"
+      "count": 1,
+      "id": "minecraft:red_candle"
     },
     "ingredients": [
       {
@@ -23373,7 +24706,9 @@
     }
   },
   "redstone_from_blasting_deepslate_redstone_ore": {
-    "result": "minecraft:redstone",
+    "result": {
+      "id": "minecraft:redstone"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_redstone_ore"
     },
@@ -23384,7 +24719,9 @@
     }
   },
   "redstone_from_smelting_deepslate_redstone_ore": {
-    "result": "minecraft:redstone",
+    "result": {
+      "id": "minecraft:redstone"
+    },
     "ingredient": {
       "item": "minecraft:deepslate_redstone_ore"
     },
@@ -23395,7 +24732,9 @@
     }
   },
   "smooth_basalt": {
-    "result": "minecraft:smooth_basalt",
+    "result": {
+      "id": "minecraft:smooth_basalt"
+    },
     "ingredient": {
       "item": "minecraft:basalt"
     },
@@ -23407,7 +24746,8 @@
   },
   "spyglass": {
     "result": {
-      "item": "minecraft:spyglass"
+      "count": 1,
+      "id": "minecraft:spyglass"
     },
     "pattern": [
       " # ",
@@ -23429,8 +24769,8 @@
   },
   "tinted_glass": {
     "result": {
-      "item": "minecraft:tinted_glass",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:tinted_glass"
     },
     "pattern": [
       " S ",
@@ -23452,7 +24792,8 @@
   },
   "waxed_copper_block_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_copper_block"
+      "count": 1,
+      "id": "minecraft:waxed_copper_block"
     },
     "ingredients": [
       {
@@ -23469,8 +24810,8 @@
   },
   "waxed_cut_copper": {
     "result": {
-      "item": "minecraft:waxed_cut_copper",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_cut_copper"
     },
     "pattern": [
       "##",
@@ -23488,7 +24829,8 @@
   },
   "waxed_cut_copper_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_cut_copper"
+      "count": 1,
+      "id": "minecraft:waxed_cut_copper"
     },
     "ingredients": [
       {
@@ -23504,11 +24846,13 @@
     }
   },
   "waxed_cut_copper_from_waxed_copper_block_stonecutting": {
-    "result": "minecraft:waxed_cut_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_cut_copper"
+    },
     "ingredient": {
       "item": "minecraft:waxed_copper_block"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -23521,8 +24865,8 @@
   },
   "waxed_cut_copper_slab": {
     "result": {
-      "item": "minecraft:waxed_cut_copper_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:waxed_cut_copper_slab"
     },
     "pattern": [
       "###"
@@ -23539,7 +24883,8 @@
   },
   "waxed_cut_copper_slab_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_cut_copper_slab"
+      "count": 1,
+      "id": "minecraft:waxed_cut_copper_slab"
     },
     "ingredients": [
       {
@@ -23555,11 +24900,13 @@
     }
   },
   "waxed_cut_copper_slab_from_waxed_copper_block_stonecutting": {
-    "result": "minecraft:waxed_cut_copper_slab",
+    "result": {
+      "count": 8,
+      "id": "minecraft:waxed_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:waxed_copper_block"
     },
-    "count": 8,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -23571,11 +24918,13 @@
     }
   },
   "waxed_cut_copper_slab_from_waxed_cut_copper_stonecutting": {
-    "result": "minecraft:waxed_cut_copper_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:waxed_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:waxed_cut_copper"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -23583,8 +24932,8 @@
   },
   "waxed_cut_copper_stairs": {
     "result": {
-      "item": "minecraft:waxed_cut_copper_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_cut_copper_stairs"
     },
     "pattern": [
       "#  ",
@@ -23603,7 +24952,8 @@
   },
   "waxed_cut_copper_stairs_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_cut_copper_stairs"
+      "count": 1,
+      "id": "minecraft:waxed_cut_copper_stairs"
     },
     "ingredients": [
       {
@@ -23619,11 +24969,13 @@
     }
   },
   "waxed_cut_copper_stairs_from_waxed_copper_block_stonecutting": {
-    "result": "minecraft:waxed_cut_copper_stairs",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:waxed_copper_block"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -23635,11 +24987,13 @@
     }
   },
   "waxed_cut_copper_stairs_from_waxed_cut_copper_stonecutting": {
-    "result": "minecraft:waxed_cut_copper_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:waxed_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:waxed_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -23647,7 +25001,8 @@
   },
   "waxed_exposed_copper_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_exposed_copper"
+      "count": 1,
+      "id": "minecraft:waxed_exposed_copper"
     },
     "ingredients": [
       {
@@ -23664,8 +25019,8 @@
   },
   "waxed_exposed_cut_copper": {
     "result": {
-      "item": "minecraft:waxed_exposed_cut_copper",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_exposed_cut_copper"
     },
     "pattern": [
       "##",
@@ -23683,7 +25038,8 @@
   },
   "waxed_exposed_cut_copper_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_exposed_cut_copper"
+      "count": 1,
+      "id": "minecraft:waxed_exposed_cut_copper"
     },
     "ingredients": [
       {
@@ -23699,11 +25055,13 @@
     }
   },
   "waxed_exposed_cut_copper_from_waxed_exposed_copper_stonecutting": {
-    "result": "minecraft:waxed_exposed_cut_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_exposed_cut_copper"
+    },
     "ingredient": {
       "item": "minecraft:waxed_exposed_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -23716,8 +25074,8 @@
   },
   "waxed_exposed_cut_copper_slab": {
     "result": {
-      "item": "minecraft:waxed_exposed_cut_copper_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:waxed_exposed_cut_copper_slab"
     },
     "pattern": [
       "###"
@@ -23734,7 +25092,8 @@
   },
   "waxed_exposed_cut_copper_slab_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_exposed_cut_copper_slab"
+      "count": 1,
+      "id": "minecraft:waxed_exposed_cut_copper_slab"
     },
     "ingredients": [
       {
@@ -23750,11 +25109,13 @@
     }
   },
   "waxed_exposed_cut_copper_slab_from_waxed_exposed_copper_stonecutting": {
-    "result": "minecraft:waxed_exposed_cut_copper_slab",
+    "result": {
+      "count": 8,
+      "id": "minecraft:waxed_exposed_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:waxed_exposed_copper"
     },
-    "count": 8,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -23766,11 +25127,13 @@
     }
   },
   "waxed_exposed_cut_copper_slab_from_waxed_exposed_cut_copper_stonecutting": {
-    "result": "minecraft:waxed_exposed_cut_copper_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:waxed_exposed_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:waxed_exposed_cut_copper"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -23778,8 +25141,8 @@
   },
   "waxed_exposed_cut_copper_stairs": {
     "result": {
-      "item": "minecraft:waxed_exposed_cut_copper_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_exposed_cut_copper_stairs"
     },
     "pattern": [
       "#  ",
@@ -23798,7 +25161,8 @@
   },
   "waxed_exposed_cut_copper_stairs_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_exposed_cut_copper_stairs"
+      "count": 1,
+      "id": "minecraft:waxed_exposed_cut_copper_stairs"
     },
     "ingredients": [
       {
@@ -23814,11 +25178,13 @@
     }
   },
   "waxed_exposed_cut_copper_stairs_from_waxed_exposed_copper_stonecutting": {
-    "result": "minecraft:waxed_exposed_cut_copper_stairs",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_exposed_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:waxed_exposed_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -23830,11 +25196,13 @@
     }
   },
   "waxed_exposed_cut_copper_stairs_from_waxed_exposed_cut_copper_stonecutting": {
-    "result": "minecraft:waxed_exposed_cut_copper_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:waxed_exposed_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:waxed_exposed_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -23842,7 +25210,8 @@
   },
   "waxed_oxidized_copper_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_oxidized_copper"
+      "count": 1,
+      "id": "minecraft:waxed_oxidized_copper"
     },
     "ingredients": [
       {
@@ -23859,8 +25228,8 @@
   },
   "waxed_oxidized_cut_copper": {
     "result": {
-      "item": "minecraft:waxed_oxidized_cut_copper",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_oxidized_cut_copper"
     },
     "pattern": [
       "##",
@@ -23878,7 +25247,8 @@
   },
   "waxed_oxidized_cut_copper_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_oxidized_cut_copper"
+      "count": 1,
+      "id": "minecraft:waxed_oxidized_cut_copper"
     },
     "ingredients": [
       {
@@ -23894,11 +25264,13 @@
     }
   },
   "waxed_oxidized_cut_copper_from_waxed_oxidized_copper_stonecutting": {
-    "result": "minecraft:waxed_oxidized_cut_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_oxidized_cut_copper"
+    },
     "ingredient": {
       "item": "minecraft:waxed_oxidized_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -23911,8 +25283,8 @@
   },
   "waxed_oxidized_cut_copper_slab": {
     "result": {
-      "item": "minecraft:waxed_oxidized_cut_copper_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:waxed_oxidized_cut_copper_slab"
     },
     "pattern": [
       "###"
@@ -23929,7 +25301,8 @@
   },
   "waxed_oxidized_cut_copper_slab_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_oxidized_cut_copper_slab"
+      "count": 1,
+      "id": "minecraft:waxed_oxidized_cut_copper_slab"
     },
     "ingredients": [
       {
@@ -23945,11 +25318,13 @@
     }
   },
   "waxed_oxidized_cut_copper_slab_from_waxed_oxidized_copper_stonecutting": {
-    "result": "minecraft:waxed_oxidized_cut_copper_slab",
+    "result": {
+      "count": 8,
+      "id": "minecraft:waxed_oxidized_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:waxed_oxidized_copper"
     },
-    "count": 8,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -23961,11 +25336,13 @@
     }
   },
   "waxed_oxidized_cut_copper_slab_from_waxed_oxidized_cut_copper_stonecutting": {
-    "result": "minecraft:waxed_oxidized_cut_copper_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:waxed_oxidized_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:waxed_oxidized_cut_copper"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -23973,8 +25350,8 @@
   },
   "waxed_oxidized_cut_copper_stairs": {
     "result": {
-      "item": "minecraft:waxed_oxidized_cut_copper_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_oxidized_cut_copper_stairs"
     },
     "pattern": [
       "#  ",
@@ -23993,7 +25370,8 @@
   },
   "waxed_oxidized_cut_copper_stairs_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_oxidized_cut_copper_stairs"
+      "count": 1,
+      "id": "minecraft:waxed_oxidized_cut_copper_stairs"
     },
     "ingredients": [
       {
@@ -24009,11 +25387,13 @@
     }
   },
   "waxed_oxidized_cut_copper_stairs_from_waxed_oxidized_copper_stonecutting": {
-    "result": "minecraft:waxed_oxidized_cut_copper_stairs",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_oxidized_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:waxed_oxidized_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -24025,11 +25405,13 @@
     }
   },
   "waxed_oxidized_cut_copper_stairs_from_waxed_oxidized_cut_copper_stonecutting": {
-    "result": "minecraft:waxed_oxidized_cut_copper_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:waxed_oxidized_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:waxed_oxidized_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -24037,7 +25419,8 @@
   },
   "waxed_weathered_copper_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_weathered_copper"
+      "count": 1,
+      "id": "minecraft:waxed_weathered_copper"
     },
     "ingredients": [
       {
@@ -24054,8 +25437,8 @@
   },
   "waxed_weathered_cut_copper": {
     "result": {
-      "item": "minecraft:waxed_weathered_cut_copper",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_weathered_cut_copper"
     },
     "pattern": [
       "##",
@@ -24073,7 +25456,8 @@
   },
   "waxed_weathered_cut_copper_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_weathered_cut_copper"
+      "count": 1,
+      "id": "minecraft:waxed_weathered_cut_copper"
     },
     "ingredients": [
       {
@@ -24089,11 +25473,13 @@
     }
   },
   "waxed_weathered_cut_copper_from_waxed_weathered_copper_stonecutting": {
-    "result": "minecraft:waxed_weathered_cut_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_weathered_cut_copper"
+    },
     "ingredient": {
       "item": "minecraft:waxed_weathered_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -24106,8 +25492,8 @@
   },
   "waxed_weathered_cut_copper_slab": {
     "result": {
-      "item": "minecraft:waxed_weathered_cut_copper_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:waxed_weathered_cut_copper_slab"
     },
     "pattern": [
       "###"
@@ -24124,7 +25510,8 @@
   },
   "waxed_weathered_cut_copper_slab_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_weathered_cut_copper_slab"
+      "count": 1,
+      "id": "minecraft:waxed_weathered_cut_copper_slab"
     },
     "ingredients": [
       {
@@ -24140,11 +25527,13 @@
     }
   },
   "waxed_weathered_cut_copper_slab_from_waxed_weathered_copper_stonecutting": {
-    "result": "minecraft:waxed_weathered_cut_copper_slab",
+    "result": {
+      "count": 8,
+      "id": "minecraft:waxed_weathered_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:waxed_weathered_copper"
     },
-    "count": 8,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -24156,11 +25545,13 @@
     }
   },
   "waxed_weathered_cut_copper_slab_from_waxed_weathered_cut_copper_stonecutting": {
-    "result": "minecraft:waxed_weathered_cut_copper_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:waxed_weathered_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:waxed_weathered_cut_copper"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -24168,8 +25559,8 @@
   },
   "waxed_weathered_cut_copper_stairs": {
     "result": {
-      "item": "minecraft:waxed_weathered_cut_copper_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_weathered_cut_copper_stairs"
     },
     "pattern": [
       "#  ",
@@ -24188,7 +25579,8 @@
   },
   "waxed_weathered_cut_copper_stairs_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_weathered_cut_copper_stairs"
+      "count": 1,
+      "id": "minecraft:waxed_weathered_cut_copper_stairs"
     },
     "ingredients": [
       {
@@ -24204,11 +25596,13 @@
     }
   },
   "waxed_weathered_cut_copper_stairs_from_waxed_weathered_copper_stonecutting": {
-    "result": "minecraft:waxed_weathered_cut_copper_stairs",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_weathered_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:waxed_weathered_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -24220,11 +25614,13 @@
     }
   },
   "waxed_weathered_cut_copper_stairs_from_waxed_weathered_cut_copper_stonecutting": {
-    "result": "minecraft:waxed_weathered_cut_copper_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:waxed_weathered_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:waxed_weathered_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -24232,8 +25628,8 @@
   },
   "weathered_cut_copper": {
     "result": {
-      "item": "minecraft:weathered_cut_copper",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:weathered_cut_copper"
     },
     "pattern": [
       "##",
@@ -24250,11 +25646,13 @@
     }
   },
   "weathered_cut_copper_from_weathered_copper_stonecutting": {
-    "result": "minecraft:weathered_cut_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:weathered_cut_copper"
+    },
     "ingredient": {
       "item": "minecraft:weathered_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -24267,8 +25665,8 @@
   },
   "weathered_cut_copper_slab": {
     "result": {
-      "item": "minecraft:weathered_cut_copper_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:weathered_cut_copper_slab"
     },
     "pattern": [
       "###"
@@ -24284,11 +25682,13 @@
     }
   },
   "weathered_cut_copper_slab_from_weathered_copper_stonecutting": {
-    "result": "minecraft:weathered_cut_copper_slab",
+    "result": {
+      "count": 8,
+      "id": "minecraft:weathered_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:weathered_copper"
     },
-    "count": 8,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -24300,11 +25700,13 @@
     }
   },
   "weathered_cut_copper_slab_from_weathered_cut_copper_stonecutting": {
-    "result": "minecraft:weathered_cut_copper_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:weathered_cut_copper_slab"
+    },
     "ingredient": {
       "item": "minecraft:weathered_cut_copper"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -24312,8 +25714,8 @@
   },
   "weathered_cut_copper_stairs": {
     "result": {
-      "item": "minecraft:weathered_cut_copper_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:weathered_cut_copper_stairs"
     },
     "pattern": [
       "#  ",
@@ -24331,11 +25733,13 @@
     }
   },
   "weathered_cut_copper_stairs_from_weathered_copper_stonecutting": {
-    "result": "minecraft:weathered_cut_copper_stairs",
+    "result": {
+      "count": 4,
+      "id": "minecraft:weathered_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:weathered_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "lang": {
       "en_US": {
@@ -24347,11 +25751,13 @@
     }
   },
   "weathered_cut_copper_stairs_from_weathered_cut_copper_stonecutting": {
-    "result": "minecraft:weathered_cut_copper_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:weathered_cut_copper_stairs"
+    },
     "ingredient": {
       "item": "minecraft:weathered_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.17"
@@ -24359,7 +25765,8 @@
   },
   "white_candle": {
     "result": {
-      "item": "minecraft:white_candle"
+      "count": 1,
+      "id": "minecraft:white_candle"
     },
     "ingredients": [
       {
@@ -24376,7 +25783,8 @@
   },
   "yellow_candle": {
     "result": {
-      "item": "minecraft:yellow_candle"
+      "count": 1,
+      "id": "minecraft:yellow_candle"
     },
     "ingredients": [
       {
@@ -24393,7 +25801,8 @@
   },
   "acacia_chest_boat": {
     "result": {
-      "item": "minecraft:acacia_chest_boat"
+      "count": 1,
+      "id": "minecraft:acacia_chest_boat"
     },
     "ingredients": [
       {
@@ -24410,7 +25819,8 @@
   },
   "birch_chest_boat": {
     "result": {
-      "item": "minecraft:birch_chest_boat"
+      "count": 1,
+      "id": "minecraft:birch_chest_boat"
     },
     "ingredients": [
       {
@@ -24427,7 +25837,8 @@
   },
   "dark_oak_chest_boat": {
     "result": {
-      "item": "minecraft:dark_oak_chest_boat"
+      "count": 1,
+      "id": "minecraft:dark_oak_chest_boat"
     },
     "ingredients": [
       {
@@ -24444,7 +25855,8 @@
   },
   "jungle_chest_boat": {
     "result": {
-      "item": "minecraft:jungle_chest_boat"
+      "count": 1,
+      "id": "minecraft:jungle_chest_boat"
     },
     "ingredients": [
       {
@@ -24461,7 +25873,8 @@
   },
   "mangrove_boat": {
     "result": {
-      "item": "minecraft:mangrove_boat"
+      "count": 1,
+      "id": "minecraft:mangrove_boat"
     },
     "pattern": [
       "# #",
@@ -24479,7 +25892,8 @@
   },
   "mangrove_button": {
     "result": {
-      "item": "minecraft:mangrove_button"
+      "count": 1,
+      "id": "minecraft:mangrove_button"
     },
     "ingredients": [
       {
@@ -24493,7 +25907,8 @@
   },
   "mangrove_chest_boat": {
     "result": {
-      "item": "minecraft:mangrove_chest_boat"
+      "count": 1,
+      "id": "minecraft:mangrove_chest_boat"
     },
     "ingredients": [
       {
@@ -24510,8 +25925,8 @@
   },
   "mangrove_door": {
     "result": {
-      "item": "minecraft:mangrove_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:mangrove_door"
     },
     "pattern": [
       "##",
@@ -24530,8 +25945,8 @@
   },
   "mangrove_fence": {
     "result": {
-      "item": "minecraft:mangrove_fence",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:mangrove_fence"
     },
     "pattern": [
       "W#W",
@@ -24552,7 +25967,8 @@
   },
   "mangrove_fence_gate": {
     "result": {
-      "item": "minecraft:mangrove_fence_gate"
+      "count": 1,
+      "id": "minecraft:mangrove_fence_gate"
     },
     "pattern": [
       "#W#",
@@ -24573,8 +25989,8 @@
   },
   "mangrove_planks": {
     "result": {
-      "item": "minecraft:mangrove_planks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:mangrove_planks"
     },
     "ingredients": [
       {
@@ -24589,7 +26005,8 @@
   },
   "mangrove_pressure_plate": {
     "result": {
-      "item": "minecraft:mangrove_pressure_plate"
+      "count": 1,
+      "id": "minecraft:mangrove_pressure_plate"
     },
     "pattern": [
       "##"
@@ -24606,8 +26023,8 @@
   },
   "mangrove_sign": {
     "result": {
-      "item": "minecraft:mangrove_sign",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:mangrove_sign"
     },
     "pattern": [
       "###",
@@ -24629,8 +26046,8 @@
   },
   "mangrove_slab": {
     "result": {
-      "item": "minecraft:mangrove_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:mangrove_slab"
     },
     "pattern": [
       "###"
@@ -24647,8 +26064,8 @@
   },
   "mangrove_stairs": {
     "result": {
-      "item": "minecraft:mangrove_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:mangrove_stairs"
     },
     "pattern": [
       "#  ",
@@ -24667,8 +26084,8 @@
   },
   "mangrove_trapdoor": {
     "result": {
-      "item": "minecraft:mangrove_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:mangrove_trapdoor"
     },
     "pattern": [
       "###",
@@ -24686,8 +26103,8 @@
   },
   "mangrove_wood": {
     "result": {
-      "item": "minecraft:mangrove_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:mangrove_wood"
     },
     "pattern": [
       "##",
@@ -24705,8 +26122,8 @@
   },
   "mud_brick_slab": {
     "result": {
-      "item": "minecraft:mud_brick_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:mud_brick_slab"
     },
     "pattern": [
       "###"
@@ -24722,11 +26139,13 @@
     }
   },
   "mud_brick_slab_from_mud_bricks_stonecutting": {
-    "result": "minecraft:mud_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:mud_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:mud_bricks"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.19"
@@ -24734,8 +26153,8 @@
   },
   "mud_brick_stairs": {
     "result": {
-      "item": "minecraft:mud_brick_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:mud_brick_stairs"
     },
     "pattern": [
       "#  ",
@@ -24753,11 +26172,13 @@
     }
   },
   "mud_brick_stairs_from_mud_bricks_stonecutting": {
-    "result": "minecraft:mud_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:mud_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:mud_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.19"
@@ -24765,8 +26186,8 @@
   },
   "mud_brick_wall": {
     "result": {
-      "item": "minecraft:mud_brick_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:mud_brick_wall"
     },
     "pattern": [
       "###",
@@ -24783,11 +26204,13 @@
     }
   },
   "mud_brick_wall_from_mud_bricks_stonecutting": {
-    "result": "minecraft:mud_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:mud_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:mud_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "version": "1.19"
@@ -24795,8 +26218,8 @@
   },
   "mud_bricks": {
     "result": {
-      "item": "minecraft:mud_bricks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:mud_bricks"
     },
     "pattern": [
       "##",
@@ -24814,7 +26237,8 @@
   },
   "muddy_mangrove_roots": {
     "result": {
-      "item": "minecraft:muddy_mangrove_roots"
+      "count": 1,
+      "id": "minecraft:muddy_mangrove_roots"
     },
     "ingredients": [
       {
@@ -24831,7 +26255,8 @@
   },
   "music_disc_5": {
     "result": {
-      "item": "minecraft:music_disc_5"
+      "count": 1,
+      "id": "minecraft:music_disc_5"
     },
     "ingredients": [
       {
@@ -24869,7 +26294,8 @@
   },
   "oak_chest_boat": {
     "result": {
-      "item": "minecraft:oak_chest_boat"
+      "count": 1,
+      "id": "minecraft:oak_chest_boat"
     },
     "ingredients": [
       {
@@ -24886,7 +26312,8 @@
   },
   "packed_mud": {
     "result": {
-      "item": "minecraft:packed_mud"
+      "count": 1,
+      "id": "minecraft:packed_mud"
     },
     "ingredients": [
       {
@@ -24903,7 +26330,8 @@
   },
   "recovery_compass": {
     "result": {
-      "item": "minecraft:recovery_compass"
+      "count": 1,
+      "id": "minecraft:recovery_compass"
     },
     "pattern": [
       "SSS",
@@ -24925,7 +26353,8 @@
   },
   "spruce_chest_boat": {
     "result": {
-      "item": "minecraft:spruce_chest_boat"
+      "count": 1,
+      "id": "minecraft:spruce_chest_boat"
     },
     "ingredients": [
       {
@@ -24942,8 +26371,8 @@
   },
   "stripped_mangrove_wood": {
     "result": {
-      "item": "minecraft:stripped_mangrove_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:stripped_mangrove_wood"
     },
     "pattern": [
       "##",
@@ -24961,7 +26390,8 @@
   },
   "bundle": {
     "result": {
-      "item": "minecraft:bundle"
+      "count": 1,
+      "id": "minecraft:bundle"
     },
     "pattern": [
       "-#-",
@@ -24984,8 +26414,8 @@
   },
   "acacia_hanging_sign": {
     "result": {
-      "item": "minecraft:acacia_hanging_sign",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:acacia_hanging_sign"
     },
     "pattern": [
       "X X",
@@ -25008,7 +26438,8 @@
   },
   "bamboo_block": {
     "result": {
-      "item": "minecraft:bamboo_block"
+      "count": 1,
+      "id": "minecraft:bamboo_block"
     },
     "ingredients": [
       {
@@ -25047,7 +26478,8 @@
   },
   "bamboo_button": {
     "result": {
-      "item": "minecraft:bamboo_button"
+      "count": 1,
+      "id": "minecraft:bamboo_button"
     },
     "ingredients": [
       {
@@ -25062,7 +26494,8 @@
   },
   "bamboo_chest_raft": {
     "result": {
-      "item": "minecraft:bamboo_chest_raft"
+      "count": 1,
+      "id": "minecraft:bamboo_chest_raft"
     },
     "ingredients": [
       {
@@ -25080,8 +26513,8 @@
   },
   "bamboo_door": {
     "result": {
-      "item": "minecraft:bamboo_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:bamboo_door"
     },
     "pattern": [
       "##",
@@ -25101,8 +26534,8 @@
   },
   "bamboo_fence": {
     "result": {
-      "item": "minecraft:bamboo_fence",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:bamboo_fence"
     },
     "pattern": [
       "W#W",
@@ -25124,7 +26557,8 @@
   },
   "bamboo_fence_gate": {
     "result": {
-      "item": "minecraft:bamboo_fence_gate"
+      "count": 1,
+      "id": "minecraft:bamboo_fence_gate"
     },
     "pattern": [
       "#W#",
@@ -25146,8 +26580,8 @@
   },
   "bamboo_hanging_sign": {
     "result": {
-      "item": "minecraft:bamboo_hanging_sign",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:bamboo_hanging_sign"
     },
     "pattern": [
       "X X",
@@ -25170,7 +26604,8 @@
   },
   "bamboo_mosaic": {
     "result": {
-      "item": "minecraft:bamboo_mosaic"
+      "count": 1,
+      "id": "minecraft:bamboo_mosaic"
     },
     "pattern": [
       "#",
@@ -25189,8 +26624,8 @@
   },
   "bamboo_mosaic_slab": {
     "result": {
-      "item": "minecraft:bamboo_mosaic_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:bamboo_mosaic_slab"
     },
     "pattern": [
       "###"
@@ -25208,8 +26643,8 @@
   },
   "bamboo_mosaic_stairs": {
     "result": {
-      "item": "minecraft:bamboo_mosaic_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:bamboo_mosaic_stairs"
     },
     "pattern": [
       "#  ",
@@ -25229,8 +26664,8 @@
   },
   "bamboo_planks": {
     "result": {
-      "item": "minecraft:bamboo_planks",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:bamboo_planks"
     },
     "ingredients": [
       {
@@ -25246,7 +26681,8 @@
   },
   "bamboo_pressure_plate": {
     "result": {
-      "item": "minecraft:bamboo_pressure_plate"
+      "count": 1,
+      "id": "minecraft:bamboo_pressure_plate"
     },
     "pattern": [
       "##"
@@ -25264,7 +26700,8 @@
   },
   "bamboo_raft": {
     "result": {
-      "item": "minecraft:bamboo_raft"
+      "count": 1,
+      "id": "minecraft:bamboo_raft"
     },
     "pattern": [
       "# #",
@@ -25283,8 +26720,8 @@
   },
   "bamboo_sign": {
     "result": {
-      "item": "minecraft:bamboo_sign",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:bamboo_sign"
     },
     "pattern": [
       "###",
@@ -25307,8 +26744,8 @@
   },
   "bamboo_slab": {
     "result": {
-      "item": "minecraft:bamboo_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:bamboo_slab"
     },
     "pattern": [
       "###"
@@ -25326,8 +26763,8 @@
   },
   "bamboo_stairs": {
     "result": {
-      "item": "minecraft:bamboo_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:bamboo_stairs"
     },
     "pattern": [
       "#  ",
@@ -25347,8 +26784,8 @@
   },
   "bamboo_trapdoor": {
     "result": {
-      "item": "minecraft:bamboo_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:bamboo_trapdoor"
     },
     "pattern": [
       "###",
@@ -25367,8 +26804,8 @@
   },
   "birch_hanging_sign": {
     "result": {
-      "item": "minecraft:birch_hanging_sign",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:birch_hanging_sign"
     },
     "pattern": [
       "X X",
@@ -25391,7 +26828,8 @@
   },
   "chiseled_bookshelf": {
     "result": {
-      "item": "minecraft:chiseled_bookshelf"
+      "count": 1,
+      "id": "minecraft:chiseled_bookshelf"
     },
     "pattern": [
       "###",
@@ -25415,8 +26853,8 @@
   },
   "crimson_hanging_sign": {
     "result": {
-      "item": "minecraft:crimson_hanging_sign",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:crimson_hanging_sign"
     },
     "pattern": [
       "X X",
@@ -25439,8 +26877,8 @@
   },
   "dark_oak_hanging_sign": {
     "result": {
-      "item": "minecraft:dark_oak_hanging_sign",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:dark_oak_hanging_sign"
     },
     "pattern": [
       "X X",
@@ -25463,8 +26901,8 @@
   },
   "jungle_hanging_sign": {
     "result": {
-      "item": "minecraft:jungle_hanging_sign",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:jungle_hanging_sign"
     },
     "pattern": [
       "X X",
@@ -25487,8 +26925,8 @@
   },
   "mangrove_hanging_sign": {
     "result": {
-      "item": "minecraft:mangrove_hanging_sign",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:mangrove_hanging_sign"
     },
     "pattern": [
       "X X",
@@ -25511,8 +26949,8 @@
   },
   "oak_hanging_sign": {
     "result": {
-      "item": "minecraft:oak_hanging_sign",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:oak_hanging_sign"
     },
     "pattern": [
       "X X",
@@ -25535,8 +26973,8 @@
   },
   "spruce_hanging_sign": {
     "result": {
-      "item": "minecraft:spruce_hanging_sign",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:spruce_hanging_sign"
     },
     "pattern": [
       "X X",
@@ -25559,8 +26997,8 @@
   },
   "warped_hanging_sign": {
     "result": {
-      "item": "minecraft:warped_hanging_sign",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:warped_hanging_sign"
     },
     "pattern": [
       "X X",
@@ -25583,7 +27021,8 @@
   },
   "brush": {
     "result": {
-      "item": "minecraft:brush"
+      "count": 1,
+      "id": "minecraft:brush"
     },
     "pattern": [
       "X",
@@ -25609,7 +27048,8 @@
   },
   "cherry_boat": {
     "result": {
-      "item": "minecraft:cherry_boat"
+      "count": 1,
+      "id": "minecraft:cherry_boat"
     },
     "pattern": [
       "# #",
@@ -25628,7 +27068,8 @@
   },
   "cherry_button": {
     "result": {
-      "item": "minecraft:cherry_button"
+      "count": 1,
+      "id": "minecraft:cherry_button"
     },
     "ingredients": [
       {
@@ -25643,7 +27084,8 @@
   },
   "cherry_chest_boat": {
     "result": {
-      "item": "minecraft:cherry_chest_boat"
+      "count": 1,
+      "id": "minecraft:cherry_chest_boat"
     },
     "ingredients": [
       {
@@ -25661,8 +27103,8 @@
   },
   "cherry_door": {
     "result": {
-      "item": "minecraft:cherry_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:cherry_door"
     },
     "pattern": [
       "##",
@@ -25682,8 +27124,8 @@
   },
   "cherry_fence": {
     "result": {
-      "item": "minecraft:cherry_fence",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:cherry_fence"
     },
     "pattern": [
       "W#W",
@@ -25705,7 +27147,8 @@
   },
   "cherry_fence_gate": {
     "result": {
-      "item": "minecraft:cherry_fence_gate"
+      "count": 1,
+      "id": "minecraft:cherry_fence_gate"
     },
     "pattern": [
       "#W#",
@@ -25727,8 +27170,8 @@
   },
   "cherry_hanging_sign": {
     "result": {
-      "item": "minecraft:cherry_hanging_sign",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:cherry_hanging_sign"
     },
     "pattern": [
       "X X",
@@ -25751,8 +27194,8 @@
   },
   "cherry_planks": {
     "result": {
-      "item": "minecraft:cherry_planks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:cherry_planks"
     },
     "ingredients": [
       {
@@ -25768,7 +27211,8 @@
   },
   "cherry_pressure_plate": {
     "result": {
-      "item": "minecraft:cherry_pressure_plate"
+      "count": 1,
+      "id": "minecraft:cherry_pressure_plate"
     },
     "pattern": [
       "##"
@@ -25786,8 +27230,8 @@
   },
   "cherry_sign": {
     "result": {
-      "item": "minecraft:cherry_sign",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:cherry_sign"
     },
     "pattern": [
       "###",
@@ -25810,8 +27254,8 @@
   },
   "cherry_slab": {
     "result": {
-      "item": "minecraft:cherry_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:cherry_slab"
     },
     "pattern": [
       "###"
@@ -25829,8 +27273,8 @@
   },
   "cherry_stairs": {
     "result": {
-      "item": "minecraft:cherry_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:cherry_stairs"
     },
     "pattern": [
       "#  ",
@@ -25850,8 +27294,8 @@
   },
   "cherry_trapdoor": {
     "result": {
-      "item": "minecraft:cherry_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:cherry_trapdoor"
     },
     "pattern": [
       "###",
@@ -25870,8 +27314,8 @@
   },
   "cherry_wood": {
     "result": {
-      "item": "minecraft:cherry_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:cherry_wood"
     },
     "pattern": [
       "##",
@@ -25890,8 +27334,8 @@
   },
   "coast_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:coast_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:coast_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -25917,7 +27361,7 @@
   },
   "decorated_pot": {
     "result": {
-      "item": "minecraft:decorated_pot"
+      "id": "minecraft:decorated_pot"
     },
     "pattern": [
       " # ",
@@ -25938,8 +27382,8 @@
   },
   "dune_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:dune_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:dune_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -25965,8 +27409,8 @@
   },
   "eye_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:eye_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:eye_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -25992,7 +27436,8 @@
   },
   "netherite_axe_smithing": {
     "result": {
-      "item": "minecraft:netherite_axe"
+      "count": 1,
+      "id": "minecraft:netherite_axe"
     },
     "template": {
       "item": "minecraft:netherite_upgrade_smithing_template"
@@ -26011,7 +27456,8 @@
   },
   "netherite_boots_smithing": {
     "result": {
-      "item": "minecraft:netherite_boots"
+      "count": 1,
+      "id": "minecraft:netherite_boots"
     },
     "template": {
       "item": "minecraft:netherite_upgrade_smithing_template"
@@ -26030,7 +27476,8 @@
   },
   "netherite_chestplate_smithing": {
     "result": {
-      "item": "minecraft:netherite_chestplate"
+      "count": 1,
+      "id": "minecraft:netherite_chestplate"
     },
     "template": {
       "item": "minecraft:netherite_upgrade_smithing_template"
@@ -26049,7 +27496,8 @@
   },
   "netherite_helmet_smithing": {
     "result": {
-      "item": "minecraft:netherite_helmet"
+      "count": 1,
+      "id": "minecraft:netherite_helmet"
     },
     "template": {
       "item": "minecraft:netherite_upgrade_smithing_template"
@@ -26068,7 +27516,8 @@
   },
   "netherite_hoe_smithing": {
     "result": {
-      "item": "minecraft:netherite_hoe"
+      "count": 1,
+      "id": "minecraft:netherite_hoe"
     },
     "template": {
       "item": "minecraft:netherite_upgrade_smithing_template"
@@ -26087,7 +27536,8 @@
   },
   "netherite_leggings_smithing": {
     "result": {
-      "item": "minecraft:netherite_leggings"
+      "count": 1,
+      "id": "minecraft:netherite_leggings"
     },
     "template": {
       "item": "minecraft:netherite_upgrade_smithing_template"
@@ -26106,7 +27556,8 @@
   },
   "netherite_pickaxe_smithing": {
     "result": {
-      "item": "minecraft:netherite_pickaxe"
+      "count": 1,
+      "id": "minecraft:netherite_pickaxe"
     },
     "template": {
       "item": "minecraft:netherite_upgrade_smithing_template"
@@ -26125,7 +27576,8 @@
   },
   "netherite_shovel_smithing": {
     "result": {
-      "item": "minecraft:netherite_shovel"
+      "count": 1,
+      "id": "minecraft:netherite_shovel"
     },
     "template": {
       "item": "minecraft:netherite_upgrade_smithing_template"
@@ -26144,7 +27596,8 @@
   },
   "netherite_sword_smithing": {
     "result": {
-      "item": "minecraft:netherite_sword"
+      "count": 1,
+      "id": "minecraft:netherite_sword"
     },
     "template": {
       "item": "minecraft:netherite_upgrade_smithing_template"
@@ -26163,8 +27616,8 @@
   },
   "netherite_upgrade_smithing_template": {
     "result": {
-      "item": "minecraft:netherite_upgrade_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:netherite_upgrade_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -26190,7 +27643,8 @@
   },
   "orange_dye_from_torchflower": {
     "result": {
-      "item": "minecraft:orange_dye"
+      "count": 1,
+      "id": "minecraft:orange_dye"
     },
     "ingredients": [
       {
@@ -26205,7 +27659,8 @@
   },
   "pink_dye_from_pink_petals": {
     "result": {
-      "item": "minecraft:pink_dye"
+      "count": 1,
+      "id": "minecraft:pink_dye"
     },
     "ingredients": [
       {
@@ -26220,8 +27675,8 @@
   },
   "rib_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:rib_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:rib_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -26247,8 +27702,8 @@
   },
   "sentry_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:sentry_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:sentry_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -26277,7 +27732,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:chainmail_boots"
+      "id": "minecraft:chainmail_boots"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26297,7 +27752,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:chainmail_chestplate"
+      "id": "minecraft:chainmail_chestplate"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26317,7 +27772,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:chainmail_helmet"
+      "id": "minecraft:chainmail_helmet"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26337,7 +27792,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:chainmail_leggings"
+      "id": "minecraft:chainmail_leggings"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26357,7 +27812,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:diamond_boots"
+      "id": "minecraft:diamond_boots"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26377,7 +27832,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:diamond_chestplate"
+      "id": "minecraft:diamond_chestplate"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26397,7 +27852,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:diamond_helmet"
+      "id": "minecraft:diamond_helmet"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26417,7 +27872,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:diamond_leggings"
+      "id": "minecraft:diamond_leggings"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26437,7 +27892,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:golden_boots"
+      "id": "minecraft:golden_boots"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26457,7 +27912,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:golden_chestplate"
+      "id": "minecraft:golden_chestplate"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26477,7 +27932,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:golden_helmet"
+      "id": "minecraft:golden_helmet"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26497,7 +27952,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:golden_leggings"
+      "id": "minecraft:golden_leggings"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26517,7 +27972,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:iron_boots"
+      "id": "minecraft:iron_boots"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26537,7 +27992,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:iron_chestplate"
+      "id": "minecraft:iron_chestplate"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26557,7 +28012,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:iron_helmet"
+      "id": "minecraft:iron_helmet"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26577,7 +28032,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:iron_leggings"
+      "id": "minecraft:iron_leggings"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26597,7 +28052,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:leather_boots"
+      "id": "minecraft:leather_boots"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26617,7 +28072,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:leather_chestplate"
+      "id": "minecraft:leather_chestplate"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26637,7 +28092,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:leather_helmet"
+      "id": "minecraft:leather_helmet"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26657,7 +28112,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:leather_leggings"
+      "id": "minecraft:leather_leggings"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26677,7 +28132,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:netherite_boots"
+      "id": "minecraft:netherite_boots"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26697,7 +28152,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:netherite_chestplate"
+      "id": "minecraft:netherite_chestplate"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26717,7 +28172,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:netherite_helmet"
+      "id": "minecraft:netherite_helmet"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26737,7 +28192,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:netherite_leggings"
+      "id": "minecraft:netherite_leggings"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26757,7 +28212,7 @@
       "tag": "minecraft:trim_templates"
     },
     "result": {
-      "item": "minecraft:turtle_helmet"
+      "id": "minecraft:turtle_helmet"
     },
     "type": "minecraft:smithing_trim",
     "properties": {
@@ -26774,8 +28229,8 @@
   },
   "snout_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:snout_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:snout_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -26801,8 +28256,8 @@
   },
   "spire_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:spire_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:spire_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -26828,8 +28283,8 @@
   },
   "stripped_cherry_wood": {
     "result": {
-      "item": "minecraft:stripped_cherry_wood",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:stripped_cherry_wood"
     },
     "pattern": [
       "##",
@@ -26848,8 +28303,8 @@
   },
   "tide_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:tide_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:tide_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -26875,8 +28330,8 @@
   },
   "vex_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:vex_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:vex_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -26902,8 +28357,8 @@
   },
   "ward_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:ward_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:ward_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -26929,8 +28384,8 @@
   },
   "wild_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:wild_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:wild_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -26956,7 +28411,8 @@
   },
   "calibrated_sculk_sensor": {
     "result": {
-      "item": "minecraft:calibrated_sculk_sensor"
+      "count": 1,
+      "id": "minecraft:calibrated_sculk_sensor"
     },
     "pattern": [
       " # ",
@@ -26977,8 +28433,8 @@
   },
   "cyan_dye_from_pitcher_plant": {
     "result": {
-      "item": "minecraft:cyan_dye",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:cyan_dye"
     },
     "ingredients": [
       {
@@ -26992,7 +28448,8 @@
   },
   "dye_black_bed": {
     "result": {
-      "item": "minecraft:black_bed"
+      "count": 1,
+      "id": "minecraft:black_bed"
     },
     "ingredients": [
       {
@@ -27054,7 +28511,8 @@
   },
   "dye_black_carpet": {
     "result": {
-      "item": "minecraft:black_carpet"
+      "count": 1,
+      "id": "minecraft:black_carpet"
     },
     "ingredients": [
       {
@@ -27116,7 +28574,8 @@
   },
   "dye_black_wool": {
     "result": {
-      "item": "minecraft:black_wool"
+      "count": 1,
+      "id": "minecraft:black_wool"
     },
     "ingredients": [
       {
@@ -27178,7 +28637,8 @@
   },
   "dye_blue_bed": {
     "result": {
-      "item": "minecraft:blue_bed"
+      "count": 1,
+      "id": "minecraft:blue_bed"
     },
     "ingredients": [
       {
@@ -27240,7 +28700,8 @@
   },
   "dye_blue_carpet": {
     "result": {
-      "item": "minecraft:blue_carpet"
+      "count": 1,
+      "id": "minecraft:blue_carpet"
     },
     "ingredients": [
       {
@@ -27302,7 +28763,8 @@
   },
   "dye_blue_wool": {
     "result": {
-      "item": "minecraft:blue_wool"
+      "count": 1,
+      "id": "minecraft:blue_wool"
     },
     "ingredients": [
       {
@@ -27364,7 +28826,8 @@
   },
   "dye_brown_bed": {
     "result": {
-      "item": "minecraft:brown_bed"
+      "count": 1,
+      "id": "minecraft:brown_bed"
     },
     "ingredients": [
       {
@@ -27426,7 +28889,8 @@
   },
   "dye_brown_carpet": {
     "result": {
-      "item": "minecraft:brown_carpet"
+      "count": 1,
+      "id": "minecraft:brown_carpet"
     },
     "ingredients": [
       {
@@ -27488,7 +28952,8 @@
   },
   "dye_brown_wool": {
     "result": {
-      "item": "minecraft:brown_wool"
+      "count": 1,
+      "id": "minecraft:brown_wool"
     },
     "ingredients": [
       {
@@ -27550,7 +29015,8 @@
   },
   "dye_cyan_bed": {
     "result": {
-      "item": "minecraft:cyan_bed"
+      "count": 1,
+      "id": "minecraft:cyan_bed"
     },
     "ingredients": [
       {
@@ -27612,7 +29078,8 @@
   },
   "dye_cyan_carpet": {
     "result": {
-      "item": "minecraft:cyan_carpet"
+      "count": 1,
+      "id": "minecraft:cyan_carpet"
     },
     "ingredients": [
       {
@@ -27674,7 +29141,8 @@
   },
   "dye_cyan_wool": {
     "result": {
-      "item": "minecraft:cyan_wool"
+      "count": 1,
+      "id": "minecraft:cyan_wool"
     },
     "ingredients": [
       {
@@ -27736,7 +29204,8 @@
   },
   "dye_gray_bed": {
     "result": {
-      "item": "minecraft:gray_bed"
+      "count": 1,
+      "id": "minecraft:gray_bed"
     },
     "ingredients": [
       {
@@ -27798,7 +29267,8 @@
   },
   "dye_gray_carpet": {
     "result": {
-      "item": "minecraft:gray_carpet"
+      "count": 1,
+      "id": "minecraft:gray_carpet"
     },
     "ingredients": [
       {
@@ -27860,7 +29330,8 @@
   },
   "dye_gray_wool": {
     "result": {
-      "item": "minecraft:gray_wool"
+      "count": 1,
+      "id": "minecraft:gray_wool"
     },
     "ingredients": [
       {
@@ -27922,7 +29393,8 @@
   },
   "dye_green_bed": {
     "result": {
-      "item": "minecraft:green_bed"
+      "count": 1,
+      "id": "minecraft:green_bed"
     },
     "ingredients": [
       {
@@ -27984,7 +29456,8 @@
   },
   "dye_green_carpet": {
     "result": {
-      "item": "minecraft:green_carpet"
+      "count": 1,
+      "id": "minecraft:green_carpet"
     },
     "ingredients": [
       {
@@ -28046,7 +29519,8 @@
   },
   "dye_green_wool": {
     "result": {
-      "item": "minecraft:green_wool"
+      "count": 1,
+      "id": "minecraft:green_wool"
     },
     "ingredients": [
       {
@@ -28108,7 +29582,8 @@
   },
   "dye_light_blue_bed": {
     "result": {
-      "item": "minecraft:light_blue_bed"
+      "count": 1,
+      "id": "minecraft:light_blue_bed"
     },
     "ingredients": [
       {
@@ -28170,7 +29645,8 @@
   },
   "dye_light_blue_carpet": {
     "result": {
-      "item": "minecraft:light_blue_carpet"
+      "count": 1,
+      "id": "minecraft:light_blue_carpet"
     },
     "ingredients": [
       {
@@ -28232,7 +29708,8 @@
   },
   "dye_light_blue_wool": {
     "result": {
-      "item": "minecraft:light_blue_wool"
+      "count": 1,
+      "id": "minecraft:light_blue_wool"
     },
     "ingredients": [
       {
@@ -28294,7 +29771,8 @@
   },
   "dye_light_gray_bed": {
     "result": {
-      "item": "minecraft:light_gray_bed"
+      "count": 1,
+      "id": "minecraft:light_gray_bed"
     },
     "ingredients": [
       {
@@ -28356,7 +29834,8 @@
   },
   "dye_light_gray_carpet": {
     "result": {
-      "item": "minecraft:light_gray_carpet"
+      "count": 1,
+      "id": "minecraft:light_gray_carpet"
     },
     "ingredients": [
       {
@@ -28418,7 +29897,8 @@
   },
   "dye_light_gray_wool": {
     "result": {
-      "item": "minecraft:light_gray_wool"
+      "count": 1,
+      "id": "minecraft:light_gray_wool"
     },
     "ingredients": [
       {
@@ -28480,7 +29960,8 @@
   },
   "dye_lime_bed": {
     "result": {
-      "item": "minecraft:lime_bed"
+      "count": 1,
+      "id": "minecraft:lime_bed"
     },
     "ingredients": [
       {
@@ -28542,7 +30023,8 @@
   },
   "dye_lime_carpet": {
     "result": {
-      "item": "minecraft:lime_carpet"
+      "count": 1,
+      "id": "minecraft:lime_carpet"
     },
     "ingredients": [
       {
@@ -28604,7 +30086,8 @@
   },
   "dye_lime_wool": {
     "result": {
-      "item": "minecraft:lime_wool"
+      "count": 1,
+      "id": "minecraft:lime_wool"
     },
     "ingredients": [
       {
@@ -28666,7 +30149,8 @@
   },
   "dye_magenta_bed": {
     "result": {
-      "item": "minecraft:magenta_bed"
+      "count": 1,
+      "id": "minecraft:magenta_bed"
     },
     "ingredients": [
       {
@@ -28728,7 +30212,8 @@
   },
   "dye_magenta_carpet": {
     "result": {
-      "item": "minecraft:magenta_carpet"
+      "count": 1,
+      "id": "minecraft:magenta_carpet"
     },
     "ingredients": [
       {
@@ -28790,7 +30275,8 @@
   },
   "dye_magenta_wool": {
     "result": {
-      "item": "minecraft:magenta_wool"
+      "count": 1,
+      "id": "minecraft:magenta_wool"
     },
     "ingredients": [
       {
@@ -28852,7 +30338,8 @@
   },
   "dye_orange_bed": {
     "result": {
-      "item": "minecraft:orange_bed"
+      "count": 1,
+      "id": "minecraft:orange_bed"
     },
     "ingredients": [
       {
@@ -28914,7 +30401,8 @@
   },
   "dye_orange_carpet": {
     "result": {
-      "item": "minecraft:orange_carpet"
+      "count": 1,
+      "id": "minecraft:orange_carpet"
     },
     "ingredients": [
       {
@@ -28976,7 +30464,8 @@
   },
   "dye_orange_wool": {
     "result": {
-      "item": "minecraft:orange_wool"
+      "count": 1,
+      "id": "minecraft:orange_wool"
     },
     "ingredients": [
       {
@@ -29038,7 +30527,8 @@
   },
   "dye_pink_bed": {
     "result": {
-      "item": "minecraft:pink_bed"
+      "count": 1,
+      "id": "minecraft:pink_bed"
     },
     "ingredients": [
       {
@@ -29100,7 +30590,8 @@
   },
   "dye_pink_carpet": {
     "result": {
-      "item": "minecraft:pink_carpet"
+      "count": 1,
+      "id": "minecraft:pink_carpet"
     },
     "ingredients": [
       {
@@ -29162,7 +30653,8 @@
   },
   "dye_pink_wool": {
     "result": {
-      "item": "minecraft:pink_wool"
+      "count": 1,
+      "id": "minecraft:pink_wool"
     },
     "ingredients": [
       {
@@ -29224,7 +30716,8 @@
   },
   "dye_purple_bed": {
     "result": {
-      "item": "minecraft:purple_bed"
+      "count": 1,
+      "id": "minecraft:purple_bed"
     },
     "ingredients": [
       {
@@ -29286,7 +30779,8 @@
   },
   "dye_purple_carpet": {
     "result": {
-      "item": "minecraft:purple_carpet"
+      "count": 1,
+      "id": "minecraft:purple_carpet"
     },
     "ingredients": [
       {
@@ -29348,7 +30842,8 @@
   },
   "dye_purple_wool": {
     "result": {
-      "item": "minecraft:purple_wool"
+      "count": 1,
+      "id": "minecraft:purple_wool"
     },
     "ingredients": [
       {
@@ -29410,7 +30905,8 @@
   },
   "dye_red_bed": {
     "result": {
-      "item": "minecraft:red_bed"
+      "count": 1,
+      "id": "minecraft:red_bed"
     },
     "ingredients": [
       {
@@ -29472,7 +30968,8 @@
   },
   "dye_red_carpet": {
     "result": {
-      "item": "minecraft:red_carpet"
+      "count": 1,
+      "id": "minecraft:red_carpet"
     },
     "ingredients": [
       {
@@ -29534,7 +31031,8 @@
   },
   "dye_red_wool": {
     "result": {
-      "item": "minecraft:red_wool"
+      "count": 1,
+      "id": "minecraft:red_wool"
     },
     "ingredients": [
       {
@@ -29596,7 +31094,8 @@
   },
   "dye_white_bed": {
     "result": {
-      "item": "minecraft:white_bed"
+      "count": 1,
+      "id": "minecraft:white_bed"
     },
     "ingredients": [
       {
@@ -29658,7 +31157,8 @@
   },
   "dye_white_carpet": {
     "result": {
-      "item": "minecraft:white_carpet"
+      "count": 1,
+      "id": "minecraft:white_carpet"
     },
     "ingredients": [
       {
@@ -29720,7 +31220,8 @@
   },
   "dye_white_wool": {
     "result": {
-      "item": "minecraft:white_wool"
+      "count": 1,
+      "id": "minecraft:white_wool"
     },
     "ingredients": [
       {
@@ -29782,7 +31283,8 @@
   },
   "dye_yellow_bed": {
     "result": {
-      "item": "minecraft:yellow_bed"
+      "count": 1,
+      "id": "minecraft:yellow_bed"
     },
     "ingredients": [
       {
@@ -29844,7 +31346,8 @@
   },
   "dye_yellow_carpet": {
     "result": {
-      "item": "minecraft:yellow_carpet"
+      "count": 1,
+      "id": "minecraft:yellow_carpet"
     },
     "ingredients": [
       {
@@ -29906,7 +31409,8 @@
   },
   "dye_yellow_wool": {
     "result": {
-      "item": "minecraft:yellow_wool"
+      "count": 1,
+      "id": "minecraft:yellow_wool"
     },
     "ingredients": [
       {
@@ -29968,8 +31472,8 @@
   },
   "host_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:host_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:host_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -29994,8 +31498,8 @@
   },
   "raiser_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:raiser_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:raiser_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -30020,8 +31524,8 @@
   },
   "shaper_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:shaper_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:shaper_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -30046,8 +31550,8 @@
   },
   "silence_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:silence_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:silence_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -30072,8 +31576,8 @@
   },
   "wayfinder_armor_trim_smithing_template": {
     "result": {
-      "item": "minecraft:wayfinder_armor_trim_smithing_template",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:wayfinder_armor_trim_smithing_template"
     },
     "pattern": [
       "#S#",
@@ -30098,7 +31602,8 @@
   },
   "chiseled_copper": {
     "result": {
-      "item": "minecraft:chiseled_copper"
+      "count": 1,
+      "id": "minecraft:chiseled_copper"
     },
     "pattern": [
       "#",
@@ -30116,11 +31621,13 @@
     }
   },
   "chiseled_copper_from_copper_block_stonecutting": {
-    "result": "minecraft:chiseled_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:copper_block"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30128,11 +31635,13 @@
     }
   },
   "chiseled_copper_from_cut_copper_stonecutting": {
-    "result": "minecraft:chiseled_copper",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30141,7 +31650,8 @@
   },
   "chiseled_tuff": {
     "result": {
-      "item": "minecraft:chiseled_tuff"
+      "count": 1,
+      "id": "minecraft:chiseled_tuff"
     },
     "pattern": [
       "#",
@@ -30160,7 +31670,8 @@
   },
   "chiseled_tuff_bricks": {
     "result": {
-      "item": "minecraft:chiseled_tuff_bricks"
+      "count": 1,
+      "id": "minecraft:chiseled_tuff_bricks"
     },
     "pattern": [
       "#",
@@ -30178,11 +31689,13 @@
     }
   },
   "chiseled_tuff_bricks_from_polished_tuff_stonecutting": {
-    "result": "minecraft:chiseled_tuff_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_tuff_bricks"
+    },
     "ingredient": {
       "item": "minecraft:polished_tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30190,11 +31703,13 @@
     }
   },
   "chiseled_tuff_bricks_from_tuff_bricks_stonecutting": {
-    "result": "minecraft:chiseled_tuff_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_tuff_bricks"
+    },
     "ingredient": {
       "item": "minecraft:tuff_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30202,11 +31717,13 @@
     }
   },
   "chiseled_tuff_bricks_from_tuff_stonecutting": {
-    "result": "minecraft:chiseled_tuff_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_tuff_bricks"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30214,11 +31731,13 @@
     }
   },
   "chiseled_tuff_from_tuff_stonecutting": {
-    "result": "minecraft:chiseled_tuff",
+    "result": {
+      "count": 1,
+      "id": "minecraft:chiseled_tuff"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30227,8 +31746,8 @@
   },
   "copper_bulb": {
     "result": {
-      "item": "minecraft:copper_bulb",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:copper_bulb"
     },
     "pattern": [
       " C ",
@@ -30254,8 +31773,8 @@
   },
   "copper_door": {
     "result": {
-      "item": "minecraft:copper_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:copper_door"
     },
     "pattern": [
       "##",
@@ -30275,8 +31794,8 @@
   },
   "copper_grate": {
     "result": {
-      "item": "minecraft:copper_grate",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:copper_grate"
     },
     "pattern": [
       " M ",
@@ -30295,11 +31814,13 @@
     }
   },
   "copper_grate_from_copper_block_stonecutting": {
-    "result": "minecraft:copper_grate",
+    "result": {
+      "count": 4,
+      "id": "minecraft:copper_grate"
+    },
     "ingredient": {
       "item": "minecraft:copper_block"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30308,8 +31829,8 @@
   },
   "copper_trapdoor": {
     "result": {
-      "item": "minecraft:copper_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:copper_trapdoor"
     },
     "pattern": [
       "###",
@@ -30328,7 +31849,8 @@
   },
   "crafter": {
     "result": {
-      "item": "minecraft:crafter"
+      "count": 1,
+      "id": "minecraft:crafter"
     },
     "pattern": [
       "###",
@@ -30357,7 +31879,8 @@
   },
   "exposed_chiseled_copper": {
     "result": {
-      "item": "minecraft:exposed_chiseled_copper"
+      "count": 1,
+      "id": "minecraft:exposed_chiseled_copper"
     },
     "pattern": [
       "#",
@@ -30375,11 +31898,13 @@
     }
   },
   "exposed_chiseled_copper_from_exposed_copper_stonecutting": {
-    "result": "minecraft:exposed_chiseled_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:exposed_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:exposed_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30387,11 +31912,13 @@
     }
   },
   "exposed_chiseled_copper_from_exposed_cut_copper_stonecutting": {
-    "result": "minecraft:exposed_chiseled_copper",
+    "result": {
+      "count": 1,
+      "id": "minecraft:exposed_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:exposed_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30400,8 +31927,8 @@
   },
   "exposed_copper_bulb": {
     "result": {
-      "item": "minecraft:exposed_copper_bulb",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:exposed_copper_bulb"
     },
     "pattern": [
       " C ",
@@ -30427,8 +31954,8 @@
   },
   "exposed_copper_door": {
     "result": {
-      "item": "minecraft:exposed_copper_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:exposed_copper_door"
     },
     "pattern": [
       "##",
@@ -30448,8 +31975,8 @@
   },
   "exposed_copper_grate": {
     "result": {
-      "item": "minecraft:exposed_copper_grate",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:exposed_copper_grate"
     },
     "pattern": [
       " M ",
@@ -30468,11 +31995,13 @@
     }
   },
   "exposed_copper_grate_from_exposed_copper_stonecutting": {
-    "result": "minecraft:exposed_copper_grate",
+    "result": {
+      "count": 4,
+      "id": "minecraft:exposed_copper_grate"
+    },
     "ingredient": {
       "item": "minecraft:exposed_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30481,8 +32010,8 @@
   },
   "exposed_copper_trapdoor": {
     "result": {
-      "item": "minecraft:exposed_copper_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:exposed_copper_trapdoor"
     },
     "pattern": [
       "###",
@@ -30501,7 +32030,8 @@
   },
   "oxidized_chiseled_copper": {
     "result": {
-      "item": "minecraft:oxidized_chiseled_copper"
+      "count": 1,
+      "id": "minecraft:oxidized_chiseled_copper"
     },
     "pattern": [
       "#",
@@ -30519,11 +32049,13 @@
     }
   },
   "oxidized_chiseled_copper_from_oxidized_copper_stonecutting": {
-    "result": "minecraft:oxidized_chiseled_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:oxidized_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:oxidized_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30531,11 +32063,13 @@
     }
   },
   "oxidized_chiseled_copper_from_oxidized_cut_copper_stonecutting": {
-    "result": "minecraft:oxidized_chiseled_copper",
+    "result": {
+      "count": 1,
+      "id": "minecraft:oxidized_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:oxidized_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30544,8 +32078,8 @@
   },
   "oxidized_copper_bulb": {
     "result": {
-      "item": "minecraft:oxidized_copper_bulb",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:oxidized_copper_bulb"
     },
     "pattern": [
       " C ",
@@ -30571,8 +32105,8 @@
   },
   "oxidized_copper_door": {
     "result": {
-      "item": "minecraft:oxidized_copper_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:oxidized_copper_door"
     },
     "pattern": [
       "##",
@@ -30592,8 +32126,8 @@
   },
   "oxidized_copper_grate": {
     "result": {
-      "item": "minecraft:oxidized_copper_grate",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:oxidized_copper_grate"
     },
     "pattern": [
       " M ",
@@ -30612,11 +32146,13 @@
     }
   },
   "oxidized_copper_grate_from_oxidized_copper_stonecutting": {
-    "result": "minecraft:oxidized_copper_grate",
+    "result": {
+      "count": 4,
+      "id": "minecraft:oxidized_copper_grate"
+    },
     "ingredient": {
       "item": "minecraft:oxidized_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30625,8 +32161,8 @@
   },
   "oxidized_copper_trapdoor": {
     "result": {
-      "item": "minecraft:oxidized_copper_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:oxidized_copper_trapdoor"
     },
     "pattern": [
       "###",
@@ -30645,8 +32181,8 @@
   },
   "polished_tuff": {
     "result": {
-      "item": "minecraft:polished_tuff",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_tuff"
     },
     "pattern": [
       "SS",
@@ -30664,11 +32200,13 @@
     }
   },
   "polished_tuff_from_tuff_stonecutting": {
-    "result": "minecraft:polished_tuff",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_tuff"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30677,8 +32215,8 @@
   },
   "polished_tuff_slab": {
     "result": {
-      "item": "minecraft:polished_tuff_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:polished_tuff_slab"
     },
     "pattern": [
       "###"
@@ -30695,11 +32233,13 @@
     }
   },
   "polished_tuff_slab_from_polished_tuff_stonecutting": {
-    "result": "minecraft:polished_tuff_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_tuff_slab"
+    },
     "ingredient": {
       "item": "minecraft:polished_tuff"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30707,11 +32247,13 @@
     }
   },
   "polished_tuff_slab_from_tuff_stonecutting": {
-    "result": "minecraft:polished_tuff_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:polished_tuff_slab"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30720,8 +32262,8 @@
   },
   "polished_tuff_stairs": {
     "result": {
-      "item": "minecraft:polished_tuff_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:polished_tuff_stairs"
     },
     "pattern": [
       "#  ",
@@ -30740,11 +32282,13 @@
     }
   },
   "polished_tuff_stairs_from_polished_tuff_stonecutting": {
-    "result": "minecraft:polished_tuff_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_tuff_stairs"
+    },
     "ingredient": {
       "item": "minecraft:polished_tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30752,11 +32296,13 @@
     }
   },
   "polished_tuff_stairs_from_tuff_stonecutting": {
-    "result": "minecraft:polished_tuff_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_tuff_stairs"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30765,8 +32311,8 @@
   },
   "polished_tuff_wall": {
     "result": {
-      "item": "minecraft:polished_tuff_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:polished_tuff_wall"
     },
     "pattern": [
       "###",
@@ -30784,11 +32330,13 @@
     }
   },
   "polished_tuff_wall_from_polished_tuff_stonecutting": {
-    "result": "minecraft:polished_tuff_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_tuff_wall"
+    },
     "ingredient": {
       "item": "minecraft:polished_tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30796,11 +32344,13 @@
     }
   },
   "polished_tuff_wall_from_tuff_stonecutting": {
-    "result": "minecraft:polished_tuff_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:polished_tuff_wall"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30809,8 +32359,8 @@
   },
   "tuff_brick_slab": {
     "result": {
-      "item": "minecraft:tuff_brick_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:tuff_brick_slab"
     },
     "pattern": [
       "###"
@@ -30827,11 +32377,13 @@
     }
   },
   "tuff_brick_slab_from_polished_tuff_stonecutting": {
-    "result": "minecraft:tuff_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:tuff_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:polished_tuff"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30839,11 +32391,13 @@
     }
   },
   "tuff_brick_slab_from_tuff_bricks_stonecutting": {
-    "result": "minecraft:tuff_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:tuff_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:tuff_bricks"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30851,11 +32405,13 @@
     }
   },
   "tuff_brick_slab_from_tuff_stonecutting": {
-    "result": "minecraft:tuff_brick_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:tuff_brick_slab"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30864,8 +32420,8 @@
   },
   "tuff_brick_stairs": {
     "result": {
-      "item": "minecraft:tuff_brick_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:tuff_brick_stairs"
     },
     "pattern": [
       "#  ",
@@ -30884,11 +32440,13 @@
     }
   },
   "tuff_brick_stairs_from_polished_tuff_stonecutting": {
-    "result": "minecraft:tuff_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:tuff_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:polished_tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30896,11 +32454,13 @@
     }
   },
   "tuff_brick_stairs_from_tuff_bricks_stonecutting": {
-    "result": "minecraft:tuff_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:tuff_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:tuff_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30908,11 +32468,13 @@
     }
   },
   "tuff_brick_stairs_from_tuff_stonecutting": {
-    "result": "minecraft:tuff_brick_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:tuff_brick_stairs"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30921,8 +32483,8 @@
   },
   "tuff_brick_wall": {
     "result": {
-      "item": "minecraft:tuff_brick_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:tuff_brick_wall"
     },
     "pattern": [
       "###",
@@ -30940,11 +32502,13 @@
     }
   },
   "tuff_brick_wall_from_polished_tuff_stonecutting": {
-    "result": "minecraft:tuff_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:tuff_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:polished_tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30952,11 +32516,13 @@
     }
   },
   "tuff_brick_wall_from_tuff_bricks_stonecutting": {
-    "result": "minecraft:tuff_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:tuff_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:tuff_bricks"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30964,11 +32530,13 @@
     }
   },
   "tuff_brick_wall_from_tuff_stonecutting": {
-    "result": "minecraft:tuff_brick_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:tuff_brick_wall"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -30977,8 +32545,8 @@
   },
   "tuff_bricks": {
     "result": {
-      "item": "minecraft:tuff_bricks",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:tuff_bricks"
     },
     "pattern": [
       "SS",
@@ -30996,11 +32564,13 @@
     }
   },
   "tuff_bricks_from_polished_tuff_stonecutting": {
-    "result": "minecraft:tuff_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:tuff_bricks"
+    },
     "ingredient": {
       "item": "minecraft:polished_tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31008,11 +32578,13 @@
     }
   },
   "tuff_bricks_from_tuff_stonecutting": {
-    "result": "minecraft:tuff_bricks",
+    "result": {
+      "count": 1,
+      "id": "minecraft:tuff_bricks"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31021,8 +32593,8 @@
   },
   "tuff_slab": {
     "result": {
-      "item": "minecraft:tuff_slab",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:tuff_slab"
     },
     "pattern": [
       "###"
@@ -31039,11 +32611,13 @@
     }
   },
   "tuff_slab_from_tuff_stonecutting": {
-    "result": "minecraft:tuff_slab",
+    "result": {
+      "count": 2,
+      "id": "minecraft:tuff_slab"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 2,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31052,8 +32626,8 @@
   },
   "tuff_stairs": {
     "result": {
-      "item": "minecraft:tuff_stairs",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:tuff_stairs"
     },
     "pattern": [
       "#  ",
@@ -31072,11 +32646,13 @@
     }
   },
   "tuff_stairs_from_tuff_stonecutting": {
-    "result": "minecraft:tuff_stairs",
+    "result": {
+      "count": 1,
+      "id": "minecraft:tuff_stairs"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31085,8 +32661,8 @@
   },
   "tuff_wall": {
     "result": {
-      "item": "minecraft:tuff_wall",
-      "count": 6
+      "count": 6,
+      "id": "minecraft:tuff_wall"
     },
     "pattern": [
       "###",
@@ -31104,11 +32680,13 @@
     }
   },
   "tuff_wall_from_tuff_stonecutting": {
-    "result": "minecraft:tuff_wall",
+    "result": {
+      "count": 1,
+      "id": "minecraft:tuff_wall"
+    },
     "ingredient": {
       "item": "minecraft:tuff"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31117,7 +32695,8 @@
   },
   "waxed_chiseled_copper": {
     "result": {
-      "item": "minecraft:waxed_chiseled_copper"
+      "count": 1,
+      "id": "minecraft:waxed_chiseled_copper"
     },
     "pattern": [
       "#",
@@ -31136,7 +32715,8 @@
   },
   "waxed_chiseled_copper_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_chiseled_copper"
+      "count": 1,
+      "id": "minecraft:waxed_chiseled_copper"
     },
     "ingredients": [
       {
@@ -31153,11 +32733,13 @@
     }
   },
   "waxed_chiseled_copper_from_waxed_copper_block_stonecutting": {
-    "result": "minecraft:waxed_chiseled_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:waxed_copper_block"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31165,11 +32747,13 @@
     }
   },
   "waxed_chiseled_copper_from_waxed_cut_copper_stonecutting": {
-    "result": "minecraft:waxed_chiseled_copper",
+    "result": {
+      "count": 1,
+      "id": "minecraft:waxed_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:waxed_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31178,8 +32762,8 @@
   },
   "waxed_copper_bulb": {
     "result": {
-      "item": "minecraft:waxed_copper_bulb",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_copper_bulb"
     },
     "pattern": [
       " C ",
@@ -31205,7 +32789,8 @@
   },
   "waxed_copper_bulb_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_copper_bulb"
+      "count": 1,
+      "id": "minecraft:waxed_copper_bulb"
     },
     "ingredients": [
       {
@@ -31223,8 +32808,8 @@
   },
   "waxed_copper_door": {
     "result": {
-      "item": "minecraft:waxed_copper_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:waxed_copper_door"
     },
     "pattern": [
       "##",
@@ -31244,7 +32829,8 @@
   },
   "waxed_copper_door_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_copper_door"
+      "count": 1,
+      "id": "minecraft:waxed_copper_door"
     },
     "ingredients": [
       {
@@ -31262,8 +32848,8 @@
   },
   "waxed_copper_grate": {
     "result": {
-      "item": "minecraft:waxed_copper_grate",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_copper_grate"
     },
     "pattern": [
       " M ",
@@ -31283,7 +32869,8 @@
   },
   "waxed_copper_grate_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_copper_grate"
+      "count": 1,
+      "id": "minecraft:waxed_copper_grate"
     },
     "ingredients": [
       {
@@ -31300,11 +32887,13 @@
     }
   },
   "waxed_copper_grate_from_waxed_copper_block_stonecutting": {
-    "result": "minecraft:waxed_copper_grate",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_copper_grate"
+    },
     "ingredient": {
       "item": "minecraft:waxed_copper_block"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31313,8 +32902,8 @@
   },
   "waxed_copper_trapdoor": {
     "result": {
-      "item": "minecraft:waxed_copper_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:waxed_copper_trapdoor"
     },
     "pattern": [
       "###",
@@ -31333,7 +32922,8 @@
   },
   "waxed_copper_trapdoor_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_copper_trapdoor"
+      "count": 1,
+      "id": "minecraft:waxed_copper_trapdoor"
     },
     "ingredients": [
       {
@@ -31351,7 +32941,8 @@
   },
   "waxed_exposed_chiseled_copper": {
     "result": {
-      "item": "minecraft:waxed_exposed_chiseled_copper"
+      "count": 1,
+      "id": "minecraft:waxed_exposed_chiseled_copper"
     },
     "pattern": [
       "#",
@@ -31370,7 +32961,8 @@
   },
   "waxed_exposed_chiseled_copper_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_exposed_chiseled_copper"
+      "count": 1,
+      "id": "minecraft:waxed_exposed_chiseled_copper"
     },
     "ingredients": [
       {
@@ -31387,11 +32979,13 @@
     }
   },
   "waxed_exposed_chiseled_copper_from_waxed_exposed_copper_stonecutting": {
-    "result": "minecraft:waxed_exposed_chiseled_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_exposed_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:waxed_exposed_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31399,11 +32993,13 @@
     }
   },
   "waxed_exposed_chiseled_copper_from_waxed_exposed_cut_copper_stonecutting": {
-    "result": "minecraft:waxed_exposed_chiseled_copper",
+    "result": {
+      "count": 1,
+      "id": "minecraft:waxed_exposed_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:waxed_exposed_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31412,8 +33008,8 @@
   },
   "waxed_exposed_copper_bulb": {
     "result": {
-      "item": "minecraft:waxed_exposed_copper_bulb",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_exposed_copper_bulb"
     },
     "pattern": [
       " C ",
@@ -31439,7 +33035,8 @@
   },
   "waxed_exposed_copper_bulb_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_exposed_copper_bulb"
+      "count": 1,
+      "id": "minecraft:waxed_exposed_copper_bulb"
     },
     "ingredients": [
       {
@@ -31457,8 +33054,8 @@
   },
   "waxed_exposed_copper_door": {
     "result": {
-      "item": "minecraft:waxed_exposed_copper_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:waxed_exposed_copper_door"
     },
     "pattern": [
       "##",
@@ -31478,7 +33075,8 @@
   },
   "waxed_exposed_copper_door_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_exposed_copper_door"
+      "count": 1,
+      "id": "minecraft:waxed_exposed_copper_door"
     },
     "ingredients": [
       {
@@ -31496,8 +33094,8 @@
   },
   "waxed_exposed_copper_grate": {
     "result": {
-      "item": "minecraft:waxed_exposed_copper_grate",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_exposed_copper_grate"
     },
     "pattern": [
       " M ",
@@ -31517,7 +33115,8 @@
   },
   "waxed_exposed_copper_grate_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_exposed_copper_grate"
+      "count": 1,
+      "id": "minecraft:waxed_exposed_copper_grate"
     },
     "ingredients": [
       {
@@ -31534,11 +33133,13 @@
     }
   },
   "waxed_exposed_copper_grate_from_waxed_exposed_copper_stonecutting": {
-    "result": "minecraft:waxed_exposed_copper_grate",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_exposed_copper_grate"
+    },
     "ingredient": {
       "item": "minecraft:waxed_exposed_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31547,8 +33148,8 @@
   },
   "waxed_exposed_copper_trapdoor": {
     "result": {
-      "item": "minecraft:waxed_exposed_copper_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:waxed_exposed_copper_trapdoor"
     },
     "pattern": [
       "###",
@@ -31567,7 +33168,8 @@
   },
   "waxed_exposed_copper_trapdoor_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_exposed_copper_trapdoor"
+      "count": 1,
+      "id": "minecraft:waxed_exposed_copper_trapdoor"
     },
     "ingredients": [
       {
@@ -31585,7 +33187,8 @@
   },
   "waxed_oxidized_chiseled_copper": {
     "result": {
-      "item": "minecraft:waxed_oxidized_chiseled_copper"
+      "count": 1,
+      "id": "minecraft:waxed_oxidized_chiseled_copper"
     },
     "pattern": [
       "#",
@@ -31604,7 +33207,8 @@
   },
   "waxed_oxidized_chiseled_copper_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_oxidized_chiseled_copper"
+      "count": 1,
+      "id": "minecraft:waxed_oxidized_chiseled_copper"
     },
     "ingredients": [
       {
@@ -31621,11 +33225,13 @@
     }
   },
   "waxed_oxidized_chiseled_copper_from_waxed_oxidized_copper_stonecutting": {
-    "result": "minecraft:waxed_oxidized_chiseled_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_oxidized_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:waxed_oxidized_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31633,11 +33239,13 @@
     }
   },
   "waxed_oxidized_chiseled_copper_from_waxed_oxidized_cut_copper_stonecutting": {
-    "result": "minecraft:waxed_oxidized_chiseled_copper",
+    "result": {
+      "count": 1,
+      "id": "minecraft:waxed_oxidized_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:waxed_oxidized_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31646,8 +33254,8 @@
   },
   "waxed_oxidized_copper_bulb": {
     "result": {
-      "item": "minecraft:waxed_oxidized_copper_bulb",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_oxidized_copper_bulb"
     },
     "pattern": [
       " C ",
@@ -31673,7 +33281,8 @@
   },
   "waxed_oxidized_copper_bulb_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_oxidized_copper_bulb"
+      "count": 1,
+      "id": "minecraft:waxed_oxidized_copper_bulb"
     },
     "ingredients": [
       {
@@ -31691,8 +33300,8 @@
   },
   "waxed_oxidized_copper_door": {
     "result": {
-      "item": "minecraft:waxed_oxidized_copper_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:waxed_oxidized_copper_door"
     },
     "pattern": [
       "##",
@@ -31712,7 +33321,8 @@
   },
   "waxed_oxidized_copper_door_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_oxidized_copper_door"
+      "count": 1,
+      "id": "minecraft:waxed_oxidized_copper_door"
     },
     "ingredients": [
       {
@@ -31730,8 +33340,8 @@
   },
   "waxed_oxidized_copper_grate": {
     "result": {
-      "item": "minecraft:waxed_oxidized_copper_grate",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_oxidized_copper_grate"
     },
     "pattern": [
       " M ",
@@ -31751,7 +33361,8 @@
   },
   "waxed_oxidized_copper_grate_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_oxidized_copper_grate"
+      "count": 1,
+      "id": "minecraft:waxed_oxidized_copper_grate"
     },
     "ingredients": [
       {
@@ -31768,11 +33379,13 @@
     }
   },
   "waxed_oxidized_copper_grate_from_waxed_oxidized_copper_stonecutting": {
-    "result": "minecraft:waxed_oxidized_copper_grate",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_oxidized_copper_grate"
+    },
     "ingredient": {
       "item": "minecraft:waxed_oxidized_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31781,8 +33394,8 @@
   },
   "waxed_oxidized_copper_trapdoor": {
     "result": {
-      "item": "minecraft:waxed_oxidized_copper_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:waxed_oxidized_copper_trapdoor"
     },
     "pattern": [
       "###",
@@ -31801,7 +33414,8 @@
   },
   "waxed_oxidized_copper_trapdoor_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_oxidized_copper_trapdoor"
+      "count": 1,
+      "id": "minecraft:waxed_oxidized_copper_trapdoor"
     },
     "ingredients": [
       {
@@ -31819,7 +33433,8 @@
   },
   "waxed_weathered_chiseled_copper": {
     "result": {
-      "item": "minecraft:waxed_weathered_chiseled_copper"
+      "count": 1,
+      "id": "minecraft:waxed_weathered_chiseled_copper"
     },
     "pattern": [
       "#",
@@ -31838,7 +33453,8 @@
   },
   "waxed_weathered_chiseled_copper_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_weathered_chiseled_copper"
+      "count": 1,
+      "id": "minecraft:waxed_weathered_chiseled_copper"
     },
     "ingredients": [
       {
@@ -31855,11 +33471,13 @@
     }
   },
   "waxed_weathered_chiseled_copper_from_waxed_weathered_copper_stonecutting": {
-    "result": "minecraft:waxed_weathered_chiseled_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_weathered_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:waxed_weathered_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31867,11 +33485,13 @@
     }
   },
   "waxed_weathered_chiseled_copper_from_waxed_weathered_cut_copper_stonecutting": {
-    "result": "minecraft:waxed_weathered_chiseled_copper",
+    "result": {
+      "count": 1,
+      "id": "minecraft:waxed_weathered_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:waxed_weathered_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -31880,8 +33500,8 @@
   },
   "waxed_weathered_copper_bulb": {
     "result": {
-      "item": "minecraft:waxed_weathered_copper_bulb",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_weathered_copper_bulb"
     },
     "pattern": [
       " C ",
@@ -31907,7 +33527,8 @@
   },
   "waxed_weathered_copper_bulb_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_weathered_copper_bulb"
+      "count": 1,
+      "id": "minecraft:waxed_weathered_copper_bulb"
     },
     "ingredients": [
       {
@@ -31925,8 +33546,8 @@
   },
   "waxed_weathered_copper_door": {
     "result": {
-      "item": "minecraft:waxed_weathered_copper_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:waxed_weathered_copper_door"
     },
     "pattern": [
       "##",
@@ -31946,7 +33567,8 @@
   },
   "waxed_weathered_copper_door_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_weathered_copper_door"
+      "count": 1,
+      "id": "minecraft:waxed_weathered_copper_door"
     },
     "ingredients": [
       {
@@ -31964,8 +33586,8 @@
   },
   "waxed_weathered_copper_grate": {
     "result": {
-      "item": "minecraft:waxed_weathered_copper_grate",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:waxed_weathered_copper_grate"
     },
     "pattern": [
       " M ",
@@ -31985,7 +33607,8 @@
   },
   "waxed_weathered_copper_grate_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_weathered_copper_grate"
+      "count": 1,
+      "id": "minecraft:waxed_weathered_copper_grate"
     },
     "ingredients": [
       {
@@ -32002,11 +33625,13 @@
     }
   },
   "waxed_weathered_copper_grate_from_waxed_weathered_copper_stonecutting": {
-    "result": "minecraft:waxed_weathered_copper_grate",
+    "result": {
+      "count": 4,
+      "id": "minecraft:waxed_weathered_copper_grate"
+    },
     "ingredient": {
       "item": "minecraft:waxed_weathered_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -32015,8 +33640,8 @@
   },
   "waxed_weathered_copper_trapdoor": {
     "result": {
-      "item": "minecraft:waxed_weathered_copper_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:waxed_weathered_copper_trapdoor"
     },
     "pattern": [
       "###",
@@ -32035,7 +33660,8 @@
   },
   "waxed_weathered_copper_trapdoor_from_honeycomb": {
     "result": {
-      "item": "minecraft:waxed_weathered_copper_trapdoor"
+      "count": 1,
+      "id": "minecraft:waxed_weathered_copper_trapdoor"
     },
     "ingredients": [
       {
@@ -32053,7 +33679,8 @@
   },
   "weathered_chiseled_copper": {
     "result": {
-      "item": "minecraft:weathered_chiseled_copper"
+      "count": 1,
+      "id": "minecraft:weathered_chiseled_copper"
     },
     "pattern": [
       "#",
@@ -32071,11 +33698,13 @@
     }
   },
   "weathered_chiseled_copper_from_weathered_copper_stonecutting": {
-    "result": "minecraft:weathered_chiseled_copper",
+    "result": {
+      "count": 4,
+      "id": "minecraft:weathered_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:weathered_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -32083,11 +33712,13 @@
     }
   },
   "weathered_chiseled_copper_from_weathered_cut_copper_stonecutting": {
-    "result": "minecraft:weathered_chiseled_copper",
+    "result": {
+      "count": 1,
+      "id": "minecraft:weathered_chiseled_copper"
+    },
     "ingredient": {
       "item": "minecraft:weathered_cut_copper"
     },
-    "count": 1,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -32096,8 +33727,8 @@
   },
   "weathered_copper_bulb": {
     "result": {
-      "item": "minecraft:weathered_copper_bulb",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:weathered_copper_bulb"
     },
     "pattern": [
       " C ",
@@ -32123,8 +33754,8 @@
   },
   "weathered_copper_door": {
     "result": {
-      "item": "minecraft:weathered_copper_door",
-      "count": 3
+      "count": 3,
+      "id": "minecraft:weathered_copper_door"
     },
     "pattern": [
       "##",
@@ -32144,8 +33775,8 @@
   },
   "weathered_copper_grate": {
     "result": {
-      "item": "minecraft:weathered_copper_grate",
-      "count": 4
+      "count": 4,
+      "id": "minecraft:weathered_copper_grate"
     },
     "pattern": [
       " M ",
@@ -32164,11 +33795,13 @@
     }
   },
   "weathered_copper_grate_from_weathered_copper_stonecutting": {
-    "result": "minecraft:weathered_copper_grate",
+    "result": {
+      "count": 4,
+      "id": "minecraft:weathered_copper_grate"
+    },
     "ingredient": {
       "item": "minecraft:weathered_copper"
     },
-    "count": 4,
     "type": "minecraft:stonecutting",
     "properties": {
       "feature_flag": "1.21",
@@ -32177,8 +33810,8 @@
   },
   "weathered_copper_trapdoor": {
     "result": {
-      "item": "minecraft:weathered_copper_trapdoor",
-      "count": 2
+      "count": 2,
+      "id": "minecraft:weathered_copper_trapdoor"
     },
     "pattern": [
       "###",
@@ -32193,6 +33826,463 @@
     "properties": {
       "feature_flag": "1.21",
       "version": "1.20.3"
+    }
+  },
+  "wolf_armor": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:wolf_armor"
+    },
+    "pattern": [
+      "X  ",
+      "XXX",
+      "X X"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "X": {
+        "item": "minecraft:armadillo_scute"
+      }
+    },
+    "properties": {
+      "version": "1.20.5"
+    }
+  },
+  "bolt_armor_trim_smithing_template": {
+    "result": {
+      "count": 2,
+      "id": "minecraft:bolt_armor_trim_smithing_template"
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:copper_block"
+      },
+      "S": {
+        "item": "minecraft:bolt_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "flow_armor_trim_smithing_template": {
+    "result": {
+      "count": 2,
+      "id": "minecraft:flow_armor_trim_smithing_template"
+    },
+    "pattern": [
+      "#S#",
+      "#C#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:diamond"
+      },
+      "C": {
+        "item": "minecraft:breeze_rod"
+      },
+      "S": {
+        "item": "minecraft:flow_armor_trim_smithing_template"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "infested_lingering_potion": {
+    "result": {
+      "id": "minecraft.lingering_potion.effect.infested"
+    },
+    "reagent": {
+      "item": "minecraft:dragon_breath"
+    },
+    "type": "minecraft.brewing",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.splash_potion.effect.infested"
+    }
+  },
+  "infested_potion": {
+    "result": {
+      "id": "minecraft.potion.effect.infested"
+    },
+    "reagent": {
+      "item": "minecraft:stone"
+    },
+    "type": "minecraft.brewing",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.potion.effect.awkward"
+    }
+  },
+  "infested_splash_potion": {
+    "result": {
+      "id": "minecraft.splash_potion.effect.infested"
+    },
+    "reagent": {
+      "item": "minecraft:gunpowder"
+    },
+    "type": "minecraft.brewing",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.potion.effect.infested"
+    }
+  },
+  "mace": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:mace"
+    },
+    "pattern": [
+      " # ",
+      " I "
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": {
+        "item": "minecraft:heavy_core"
+      },
+      "I": {
+        "item": "minecraft:breeze_rod"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "mundane_potion_from_trial_reagents": {
+    "result": {
+      "id": "minecraft.potion.effect.mundane"
+    },
+    "reagent": [
+      {
+        "item": "minecraft:breeze_rod"
+      },
+      {
+        "item": "minecraft:stone"
+      },
+      {
+        "item": "minecraft:cobweb"
+      },
+      {
+        "item": "minecraft:slime_block"
+      }
+    ],
+    "type": "minecraft.brewing",
+    "properties": {
+      "animated": true,
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.potion.effect.water"
+    }
+  },
+  "oozing_lingering_potion": {
+    "result": {
+      "id": "minecraft.lingering_potion.effect.oozing"
+    },
+    "reagent": {
+      "item": "minecraft:dragon_breath"
+    },
+    "type": "minecraft.brewing",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.splash_potion.effect.oozing"
+    }
+  },
+  "oozing_potion": {
+    "result": {
+      "id": "minecraft.potion.effect.oozing"
+    },
+    "reagent": {
+      "item": "minecraft:slime_block"
+    },
+    "type": "minecraft.brewing",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.potion.effect.awkward"
+    }
+  },
+  "oozing_splash_potion": {
+    "result": {
+      "id": "minecraft.splash_potion.effect.oozing"
+    },
+    "reagent": {
+      "item": "minecraft:gunpowder"
+    },
+    "type": "minecraft.brewing",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.potion.effect.oozing"
+    }
+  },
+  "splash_mundane_potion_from_trial_reagents": {
+    "result": {
+      "id": "minecraft.splash_potion.effect.mundane"
+    },
+    "reagent": [
+      {
+        "item": "minecraft:breeze_rod"
+      },
+      {
+        "item": "minecraft:stone"
+      },
+      {
+        "item": "minecraft:cobweb"
+      },
+      {
+        "item": "minecraft:slime_block"
+      }
+    ],
+    "type": "minecraft.brewing",
+    "properties": {
+      "animated": true,
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.splash_potion.effect.water"
+    }
+  },
+  "tipped_arrow_infested": {
+    "result": {
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.infested"
+    },
+    "pattern": [
+      "AAA",
+      "APA",
+      "AAA"
+    ],
+    "type": "minecraft:crafting_special_tippedarrow",
+    "key": {
+      "P": {
+        "item": "minecraft.lingering_potion.effect.infested"
+      },
+      "A": {
+        "item": "minecraft:arrow"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "tipped_arrow_oozing": {
+    "result": {
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.oozing"
+    },
+    "pattern": [
+      "AAA",
+      "APA",
+      "AAA"
+    ],
+    "type": "minecraft:crafting_special_tippedarrow",
+    "key": {
+      "P": {
+        "item": "minecraft.lingering_potion.effect.oozing"
+      },
+      "A": {
+        "item": "minecraft:arrow"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "tipped_arrow_weaving": {
+    "result": {
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.weaving"
+    },
+    "pattern": [
+      "AAA",
+      "APA",
+      "AAA"
+    ],
+    "type": "minecraft:crafting_special_tippedarrow",
+    "key": {
+      "P": {
+        "item": "minecraft.lingering_potion.effect.weaving"
+      },
+      "A": {
+        "item": "minecraft:arrow"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "tipped_arrow_wind_charged": {
+    "result": {
+      "count": 8,
+      "id": "minecraft.tipped_arrow.effect.wind_charged"
+    },
+    "pattern": [
+      "AAA",
+      "APA",
+      "AAA"
+    ],
+    "type": "minecraft:crafting_special_tippedarrow",
+    "key": {
+      "P": {
+        "item": "minecraft.lingering_potion.effect.wind_charged"
+      },
+      "A": {
+        "item": "minecraft:arrow"
+      }
+    },
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "weaving_lingering_potion": {
+    "result": {
+      "id": "minecraft.lingering_potion.effect.weaving"
+    },
+    "reagent": {
+      "item": "minecraft:dragon_breath"
+    },
+    "type": "minecraft.brewing",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.splash_potion.effect.weaving"
+    }
+  },
+  "weaving_potion": {
+    "result": {
+      "id": "minecraft.potion.effect.weaving"
+    },
+    "reagent": {
+      "item": "minecraft:cobweb"
+    },
+    "type": "minecraft.brewing",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.potion.effect.awkward"
+    }
+  },
+  "weaving_splash_potion": {
+    "result": {
+      "id": "minecraft.splash_potion.effect.weaving"
+    },
+    "reagent": {
+      "item": "minecraft:gunpowder"
+    },
+    "type": "minecraft.brewing",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.potion.effect.weaving"
+    }
+  },
+  "wind_charge": {
+    "result": {
+      "count": 4,
+      "id": "minecraft:wind_charge"
+    },
+    "ingredients": [
+      {
+        "item": "minecraft:breeze_rod"
+      }
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    }
+  },
+  "wind_charged_lingering_potion": {
+    "result": {
+      "id": "minecraft.lingering_potion.effect.wind_charged"
+    },
+    "reagent": {
+      "item": "minecraft:dragon_breath"
+    },
+    "type": "minecraft.brewing",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.splash_potion.effect.wind_charged"
+    }
+  },
+  "wind_charged_potion": {
+    "result": {
+      "id": "minecraft.potion.effect.wind_charged"
+    },
+    "reagent": {
+      "item": "minecraft:breeze_rod"
+    },
+    "type": "minecraft.brewing",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.potion.effect.awkward"
+    }
+  },
+  "wind_charged_splash_potion": {
+    "result": {
+      "id": "minecraft.splash_potion.effect.wind_charged"
+    },
+    "reagent": {
+      "item": "minecraft:gunpowder"
+    },
+    "type": "minecraft.brewing",
+    "properties": {
+      "feature_flag": "1.21",
+      "version": "1.20.5"
+    },
+    "base": {
+      "item": "minecraft.potion.effect.wind_charged"
     }
   }
 }

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -6,8 +6,8 @@ import com.tisawesomeness.minecord.database.Database;
 import com.tisawesomeness.minecord.database.VoteHandler;
 import com.tisawesomeness.minecord.mc.MCLibrary;
 import com.tisawesomeness.minecord.mc.StandardMCLibrary;
-import com.tisawesomeness.minecord.mc.item.Item;
-import com.tisawesomeness.minecord.mc.item.Recipe;
+import com.tisawesomeness.minecord.mc.item.ItemRegistry;
+import com.tisawesomeness.minecord.mc.item.RecipeRegistry;
 import com.tisawesomeness.minecord.network.APIClient;
 import com.tisawesomeness.minecord.network.OkAPIClient;
 import com.tisawesomeness.minecord.util.*;
@@ -113,8 +113,8 @@ public class Bot {
         try {
             Announcement.init(Config.getPath());
             ColorUtils.init(Config.getPath());
-            Item.init(Config.getPath());
-            Recipe.init(Config.getPath());
+            ItemRegistry.init(Config.getPath());
+            RecipeRegistry.init(Config.getPath());
         } catch (IOException ex) {
             ex.printStackTrace();
             return false;

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -44,7 +44,7 @@ public class Bot {
     public static final String github = "https://github.com/Tisawesomeness/Minecord";
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
-    private static final String version = "0.17.10";
+    private static final String version = "0.17.11";
     public static final String jdaVersion = "5.0.0-beta.22";
     public static final Color color = Color.GREEN;
 

--- a/src/com/tisawesomeness/minecord/command/admin/ReloadCommand.java
+++ b/src/com/tisawesomeness/minecord/command/admin/ReloadCommand.java
@@ -6,10 +6,9 @@ import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.command.LegacyCommand;
 import com.tisawesomeness.minecord.database.Database;
 import com.tisawesomeness.minecord.database.VoteHandler;
-import com.tisawesomeness.minecord.mc.item.Item;
-import com.tisawesomeness.minecord.mc.item.Recipe;
+import com.tisawesomeness.minecord.mc.item.ItemRegistry;
+import com.tisawesomeness.minecord.mc.item.RecipeRegistry;
 import com.tisawesomeness.minecord.util.DiscordUtils;
-
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.utils.MarkdownUtil;
@@ -62,8 +61,8 @@ public class ReloadCommand extends LegacyCommand {
                     VoteHandler.init();
                 }
                 Announcement.init(Config.getPath());
-                Item.init(Config.getPath());
-                Recipe.init(Config.getPath());
+                ItemRegistry.init(Config.getPath());
+                RecipeRegistry.init(Config.getPath());
                 Bot.reloadMCLibrary();
             } catch (SQLException | IOException ex) {
                 ex.printStackTrace();

--- a/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/IngredientCommand.java
@@ -4,8 +4,8 @@ import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.ReactMenu;
 import com.tisawesomeness.minecord.ReactMenu.MenuStatus;
 import com.tisawesomeness.minecord.command.SlashCommand;
-import com.tisawesomeness.minecord.mc.item.Item;
-import com.tisawesomeness.minecord.mc.item.Recipe;
+import com.tisawesomeness.minecord.mc.item.ItemRegistry;
+import com.tisawesomeness.minecord.mc.item.RecipeRegistry;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
@@ -46,14 +46,14 @@ public class IngredientCommand extends SlashCommand {
                 "Items and recipes are from Java Edition 1.7 to " + Config.getSupportedMCVersion() + ".\n" +
                 "All recipe types are searchable, including brewing.\n" +
                 "\n" +
-                Item.help + "\n";
+                ItemRegistry.help + "\n";
     }
 
     public Result run(SlashCommandInteractionEvent e) {
 
         // Search through the recipe database with full args first
         String search = e.getOption("item").getAsString();
-        String item = Item.search(search, "en_US");
+        String item = ItemRegistry.search(search, "en_US");
         if (item == null) {
             return new Result(Outcome.WARNING,
                     ":warning: That item does not exist! " + "\n" + "Did you spell it correctly?");
@@ -70,9 +70,9 @@ public class IngredientCommand extends SlashCommand {
             }
         }
 
-        ArrayList<String> recipes = Recipe.searchIngredient(item, "en_US");
+        ArrayList<String> recipes = RecipeRegistry.searchIngredient(item, "en_US");
         if (recipes.isEmpty()) {
-            String displayName = Item.getDistinctDisplayName(item, "en_US");
+            String displayName = ItemRegistry.getDistinctDisplayName(item, "en_US");
             return new Result(Outcome.WARNING, ":warning: " + displayName + " is not the ingredient of any recipe!");
         }
         if (page >= recipes.size()) {
@@ -86,11 +86,11 @@ public class IngredientCommand extends SlashCommand {
         MenuStatus status = ReactMenu.getMenuStatus(e);
         if (status.isValid()) {
             e.deferReply().queue();
-            new Recipe.RecipeMenu(recipes, page, "en_US").post(e);
+            new RecipeRegistry.RecipeMenu(recipes, page, "en_US").post(e);
             return new Result(Outcome.SUCCESS);
         }
-        recipes.sort(Recipe::compareRecipes);
-        EmbedBuilder eb = Recipe.displayImg(recipes.get(page), "en_US");
+        recipes.sort(RecipeRegistry::compareRecipes);
+        EmbedBuilder eb = RecipeRegistry.displayImg(recipes.get(page), "en_US");
         eb.setFooter(String.format("Page %s/%s%s", page + 1, recipes.size(), status.getReason()), null);
         return new Result(Outcome.SUCCESS, eb.build());
     }

--- a/src/com/tisawesomeness/minecord/command/utility/ItemCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/ItemCommand.java
@@ -2,7 +2,7 @@ package com.tisawesomeness.minecord.command.utility;
 
 import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.command.SlashCommand;
-import com.tisawesomeness.minecord.mc.item.Item;
+import com.tisawesomeness.minecord.mc.item.ItemRegistry;
 import com.tisawesomeness.minecord.util.MessageUtils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -37,13 +37,13 @@ public class ItemCommand extends SlashCommand {
         return "Searches for a Minecraft item.\n" +
                 "Items are from Java Edition 1.7 to " + Config.getSupportedMCVersion() + ".\n" +
                 "\n" +
-                Item.help + "\n";
+                ItemRegistry.help + "\n";
     }
 
     public Result run(SlashCommandInteractionEvent e) {
         // Search through the item database
         String search = e.getOption("item").getAsString();
-        String item = Item.search(search, "en_US");
+        String item = ItemRegistry.search(search, "en_US");
 
         // If nothing is found
         if (item == null) {
@@ -53,7 +53,7 @@ public class ItemCommand extends SlashCommand {
         }
 
         // Build message
-        EmbedBuilder eb = Item.display(item, "en_US", "/");
+        EmbedBuilder eb = ItemRegistry.display(item, "en_US", "/");
         eb = MessageUtils.addFooter(eb);
 
         return new Result(Outcome.SUCCESS, eb.build());

--- a/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/RecipeCommand.java
@@ -4,8 +4,8 @@ import com.tisawesomeness.minecord.Config;
 import com.tisawesomeness.minecord.ReactMenu;
 import com.tisawesomeness.minecord.ReactMenu.MenuStatus;
 import com.tisawesomeness.minecord.command.SlashCommand;
-import com.tisawesomeness.minecord.mc.item.Item;
-import com.tisawesomeness.minecord.mc.item.Recipe;
+import com.tisawesomeness.minecord.mc.item.ItemRegistry;
+import com.tisawesomeness.minecord.mc.item.RecipeRegistry;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
@@ -46,14 +46,14 @@ public class RecipeCommand extends SlashCommand {
                 "Items and recipes are from Java Edition 1.7 to " + Config.getSupportedMCVersion() + ".\n" +
                 "All recipe types are searchable, including brewing.\n" +
                 "\n" +
-                Item.help + "\n";
+                ItemRegistry.help + "\n";
     }
 
     public Result run(SlashCommandInteractionEvent e) {
 
         // Search through the recipe database with full args first
         String search = e.getOption("item").getAsString();
-        String item = Item.search(search, "en_US");
+        String item = ItemRegistry.search(search, "en_US");
         if (item == null) {
             return new Result(Outcome.WARNING,
                     ":warning: That item does not exist! " + "\n" + "Did you spell it correctly?");
@@ -70,9 +70,9 @@ public class RecipeCommand extends SlashCommand {
             }
         }
 
-        ArrayList<String> recipes = Recipe.searchOutput(item, "en_US");
+        ArrayList<String> recipes = RecipeRegistry.searchOutput(item, "en_US");
         if (recipes.isEmpty()) {
-            String displayName = Item.getDistinctDisplayName(item, "en_US");
+            String displayName = ItemRegistry.getDistinctDisplayName(item, "en_US");
             return new Result(Outcome.SUCCESS, ":warning: " + displayName + " does not have any recipes.");
         }
         if (page >= recipes.size()) {
@@ -86,11 +86,11 @@ public class RecipeCommand extends SlashCommand {
         MenuStatus status = ReactMenu.getMenuStatus(e);
         if (status.isValid()) {
             e.deferReply().queue();
-            new Recipe.RecipeMenu(recipes, page, "en_US").post(e);
+            new RecipeRegistry.RecipeMenu(recipes, page, "en_US").post(e);
             return new Result(Outcome.SUCCESS);
         }
-        recipes.sort(Recipe::compareRecipes);
-        EmbedBuilder eb = Recipe.displayImg(recipes.get(page), "en_US");
+        recipes.sort(RecipeRegistry::compareRecipes);
+        EmbedBuilder eb = RecipeRegistry.displayImg(recipes.get(page), "en_US");
         eb.setFooter(String.format("Page %s/%s%s", page + 1, recipes.size(), status.getReason()), null);
         return new Result(Outcome.SUCCESS, eb.build());
 

--- a/src/com/tisawesomeness/minecord/debug/ItemDebugOption.java
+++ b/src/com/tisawesomeness/minecord/debug/ItemDebugOption.java
@@ -1,7 +1,6 @@
 package com.tisawesomeness.minecord.debug;
 
-import com.tisawesomeness.minecord.mc.item.Item;
-
+import com.tisawesomeness.minecord.mc.item.ItemRegistry;
 import lombok.NonNull;
 
 public class ItemDebugOption implements DebugOption {
@@ -9,8 +8,8 @@ public class ItemDebugOption implements DebugOption {
         return "item";
     }
     public @NonNull String debug(@NonNull String extra) {
-        int hits = Item.getHits();
-        int misses = Item.getMisses();
+        int hits = ItemRegistry.getHits();
+        int misses = ItemRegistry.getMisses();
         int total = hits + misses;
         double rate = total == 0 ? 100.0 : 100.0 * hits / total;
         return String.format("Item search hit rate: `%d/%d %.2f%%`", hits, total, rate);

--- a/src/com/tisawesomeness/minecord/mc/item/ItemRegistry.java
+++ b/src/com/tisawesomeness/minecord/mc/item/ItemRegistry.java
@@ -17,7 +17,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
-public class Item {
+public class ItemRegistry {
 
     private static final Pattern CANDLE_CAKE_PATTERN = Pattern.compile("cake with (.+) candle");
     private static final String[] colorNames = new String[] { "white", "orange", "magenta", "light_blue", "yellow",

--- a/src/com/tisawesomeness/minecord/mc/item/RecipeRegistry.java
+++ b/src/com/tisawesomeness/minecord/mc/item/RecipeRegistry.java
@@ -31,7 +31,7 @@ public class RecipeRegistry {
             "1.17", "1.17.1",
             "1.18", "1.18.1", "1.18.2",
             "1.19", "1.19.1", "1.19.2", "1.19.3", "1.19.4",
-            "1.20"
+            "1.20", "1.20.1", "1.20.2", "1.20.3", "1.20.4", "1.20.5"
     };
 
     private static JSONObject recipes;
@@ -110,7 +110,11 @@ public class RecipeRegistry {
         return lines.toString();
     }
     private static String getPreviousVersion(String version) {
-        return VERSIONS[ArrayUtils.indexOf(VERSIONS, version) - 1];
+        int idx = ArrayUtils.indexOf(VERSIONS, version);
+        if (idx <= 0) {
+            return "(none)";
+        }
+        return VERSIONS[idx - 1];
     }
 
     /**
@@ -241,7 +245,7 @@ public class RecipeRegistry {
             if (resultObj == null) {
                 return recipeObj.getString("result");
             }
-            return resultObj.getString("item");
+            return resultObj.getString("id");
         }
         return null;
     }

--- a/src/com/tisawesomeness/minecord/mc/item/RecipeRegistry.java
+++ b/src/com/tisawesomeness/minecord/mc/item/RecipeRegistry.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class Recipe {
+public class RecipeRegistry {
 
     public static final String[] FEATURE_FLAGS = new String[] { "vanilla", "1.20", "1.21", "bundle" };
     public static final String[] FEATURE_FLAGS_ORDER = new String[] { "1.20", "vanilla", "1.21", "bundle" };
@@ -58,8 +58,8 @@ public class Recipe {
      */
     public static EmbedBuilder displayImg(String recipe, String lang) {
         EmbedBuilder eb = new EmbedBuilder();
-        String item = Item.searchNoStats(getResult(recipe), lang);
-        eb.setTitle(Item.getDistinctDisplayName(item, lang));
+        String item = ItemRegistry.searchNoStats(getResult(recipe), lang);
+        eb.setTitle(ItemRegistry.getDistinctDisplayName(item, lang));
         eb.setImage(Config.getRecipeImageHost() + getImage(recipe));
         eb.setColor(Bot.color);
         eb.setDescription(getMetadata(recipe, lang));
@@ -123,7 +123,7 @@ public class Recipe {
         if (item.contains("potion") || item.contains("tipped_arrow")) {
             return searchItemOutput(item, lang);
         }
-        return searchItemOutput(Item.getNamespacedID(item), lang);
+        return searchItemOutput(ItemRegistry.getNamespacedID(item), lang);
     }
 
     /**
@@ -207,7 +207,7 @@ public class Recipe {
         if (item.contains("potion") || item.contains("tipped_arrow")) {
             return searchItemIngredient(item, lang);
         }
-        return searchItemIngredient(Item.getNamespacedID(item), lang);
+        return searchItemIngredient(ItemRegistry.getNamespacedID(item), lang);
     }
 
     /**
@@ -492,7 +492,7 @@ public class Recipe {
         private void setRecipeList(List<String> recipeList) {
             this.recipeList = recipeList.stream()
                     .sequential()
-                    .sorted(Recipe::compareRecipes)
+                    .sorted(RecipeRegistry::compareRecipes)
                     .collect(Collectors.toList());
         }
 
@@ -539,7 +539,7 @@ public class Recipe {
                 }
             });
             // See what the output can craft
-            ArrayList<String> outputMore = searchIngredient(Item.searchNoStats(getResult(recipe), getLang()), getLang());
+            ArrayList<String> outputMore = searchIngredient(ItemRegistry.searchNoStats(getResult(recipe), getLang()), getLang());
             boolean hasOutput = outputMore != null && outputMore.size() > 0;
             buttons.put(Emote.UP.getCodepoint(), () -> {
                 if (hasOutput) {
@@ -592,10 +592,10 @@ public class Recipe {
                 default:
                     item = "minecraft.crafting_table";
             }
-            String table = Item.getNamespacedID(item).substring(10);
+            String table = ItemRegistry.getNamespacedID(item).substring(10);
             boolean needsTable = !recipe.equals(table);
             if (needsTable) {
-                desc += String.format("\n%s %s", Emote.T.getText(), Item.getMenuDisplayNameWithFeature(item, getLang()));
+                desc += String.format("\n%s %s", Emote.T.getText(), ItemRegistry.getMenuDisplayNameWithFeature(item, getLang()));
             }
             buttons.put(Emote.T.getCodepoint(), () -> {
                 if (needsTable) {
@@ -613,19 +613,19 @@ public class Recipe {
                 boolean isBlasting = recipes.has(recipe.replace("from_smelting", "from_blasting"));
                 if (isSmoking) {
                     desc += String.format("\n%s %s\n%s %s",
-                            Emote.N1.getText(), Item.getMenuDisplayNameWithFeature("minecraft.smoker", getLang()),
-                            Emote.N2.getText(), Item.getMenuDisplayNameWithFeature("minecraft.campfire", getLang()));
+                            Emote.N1.getText(), ItemRegistry.getMenuDisplayNameWithFeature("minecraft.smoker", getLang()),
+                            Emote.N2.getText(), ItemRegistry.getMenuDisplayNameWithFeature("minecraft.campfire", getLang()));
                     ingredientButtonCount = 2;
                 } else if (isBlasting) {
-                    desc += String.format("\n%s %s", Emote.N1.getText(), Item.getMenuDisplayNameWithFeature("minecraft.blast_furnace", getLang()));
+                    desc += String.format("\n%s %s", Emote.N1.getText(), ItemRegistry.getMenuDisplayNameWithFeature("minecraft.blast_furnace", getLang()));
                     ingredientButtonCount = 1;
                 }
                 buttons.put(Emote.N1.getCodepoint(), () -> {
                     if (isSmoking || isBlasting) {
                         if (isSmoking) {
-                            recipeList = Collections.singletonList(Item.getNamespacedID("minecraft.smoker").substring(10));
+                            recipeList = Collections.singletonList(ItemRegistry.getNamespacedID("minecraft.smoker").substring(10));
                         } else {
-                            recipeList = Collections.singletonList(Item.getNamespacedID("minecraft.blast_furnace").substring(10));
+                            recipeList = Collections.singletonList(ItemRegistry.getNamespacedID("minecraft.blast_furnace").substring(10));
                         }
                         startingIngredient = 0;
                         setPage(0);
@@ -633,7 +633,7 @@ public class Recipe {
                 });
                 buttons.put(Emote.N2.getCodepoint(), () -> {
                     if (isSmoking) {
-                        recipeList = Collections.singletonList(Item.getNamespacedID("minecraft.campfire").substring(10));
+                        recipeList = Collections.singletonList(ItemRegistry.getNamespacedID("minecraft.campfire").substring(10));
                         startingIngredient = 0;
                         setPage(0);
                     }
@@ -641,7 +641,7 @@ public class Recipe {
             } else if (type.equals("minecraft.brewing")) {
                 // Blaze powder
                 buttons.put(Emote.N1.getCodepoint(), () -> {
-                    recipeList = Collections.singletonList(Item.getNamespacedID("minecraft.blaze_powder").substring(10));
+                    recipeList = Collections.singletonList(ItemRegistry.getNamespacedID("minecraft.blaze_powder").substring(10));
                     startingIngredient = 0;
                     setPage(0);
                 });
@@ -665,10 +665,10 @@ public class Recipe {
                 ingredientsSet.toArray(ingredients);
                 int i = startingIngredient;
                 while (i < ingredients.length && ingredientButtonCount <= 9) {
-                    String ingredientItem = Item.searchNoStats(ingredients[i], getLang());
+                    String ingredientItem = ItemRegistry.searchNoStats(ingredients[i], getLang());
                     String toSearch = ingredientItem;
                     if (!ingredientItem.contains("potion") && !ingredientItem.contains("tipped_arrow")) {
-                        toSearch = Item.getNamespacedID(ingredientItem);
+                        toSearch = ItemRegistry.getNamespacedID(ingredientItem);
                     }
                     ArrayList<String> ingredientMore = searchItemOutput(toSearch, getLang());
                     if (ingredientMore.size() > 0) {
@@ -682,7 +682,7 @@ public class Recipe {
                             startingIngredient = 0;
                             setPage(0);
                         });
-                        desc += String.format("\n%s %s", emote.getText(), Item.getMenuDisplayNameWithFeature(ingredientItem, getLang()));
+                        desc += String.format("\n%s %s", emote.getText(), ItemRegistry.getMenuDisplayNameWithFeature(ingredientItem, getLang()));
                         ingredientButtonCount++;
                     }
                     i++;
@@ -713,7 +713,7 @@ public class Recipe {
                 String ingredient = getIngredients(recipeObj).toArray(new String[0])[0];
                 ArrayList<String> output = searchItemOutput(ingredient, getLang());
                 if (!output.isEmpty()) {
-                    desc += String.format("\n%s %s", Emote.N1.getText(), Item.getMenuDisplayNameWithFeature(Item.searchNoStats(ingredient, getLang()), getLang()));
+                    desc += String.format("\n%s %s", Emote.N1.getText(), ItemRegistry.getMenuDisplayNameWithFeature(ItemRegistry.searchNoStats(ingredient, getLang()), getLang()));
                     buttons.put(Emote.N1.getCodepoint(), () -> {
                         setRecipeList(output);
                         startingIngredient = 0;

--- a/src/com/tisawesomeness/minecord/util/type/Dimensions.java
+++ b/src/com/tisawesomeness/minecord/util/type/Dimensions.java
@@ -23,4 +23,9 @@ public class Dimensions {
         this.width = width;
         this.height = height;
     }
+
+    @Override
+    public String toString() {
+        return width + "x" + height;
+    }
 }

--- a/tags.json
+++ b/tags.json
@@ -1,4 +1,58 @@
 {
+  "1.21": {
+    "breaks_decorated_pots": [
+      "minecraft:mace"
+    ],
+    "decorated_pot_ingredients": [
+      "minecraft:flow_pottery_sherd",
+      "minecraft:guster_pottery_sherd",
+      "minecraft:scrape_pottery_sherd"
+    ],
+    "decorated_pot_sherds": [
+      "minecraft:flow_pottery_sherd",
+      "minecraft:guster_pottery_sherd",
+      "minecraft:scrape_pottery_sherd"
+    ],
+    "doors": [
+      "minecraft:copper_door",
+      "minecraft:exposed_copper_door",
+      "minecraft:weathered_copper_door",
+      "minecraft:oxidized_copper_door",
+      "minecraft:waxed_copper_door",
+      "minecraft:waxed_exposed_copper_door",
+      "minecraft:waxed_weathered_copper_door",
+      "minecraft:waxed_oxidized_copper_door"
+    ],
+    "slabs": [
+      "minecraft:tuff_slab",
+      "minecraft:polished_tuff_slab",
+      "minecraft:tuff_brick_slab"
+    ],
+    "stairs": [
+      "minecraft:tuff_stairs",
+      "minecraft:polished_tuff_stairs",
+      "minecraft:tuff_brick_stairs"
+    ],
+    "trapdoors": [
+      "minecraft:copper_trapdoor",
+      "minecraft:exposed_copper_trapdoor",
+      "minecraft:weathered_copper_trapdoor",
+      "minecraft:oxidized_copper_trapdoor",
+      "minecraft:waxed_copper_trapdoor",
+      "minecraft:waxed_exposed_copper_trapdoor",
+      "minecraft:waxed_weathered_copper_trapdoor",
+      "minecraft:waxed_oxidized_copper_trapdoor"
+    ],
+    "trim_templates": [
+      "minecraft:flow_armor_trim_smithing_template",
+      "minecraft:bolt_armor_trim_smithing_template"
+    ],
+    "walls": [
+      "minecraft:tuff_wall",
+      "minecraft:polished_tuff_wall",
+      "minecraft:tuff_brick_wall"
+    ]
+  },
   "vanilla": {
     "acacia_logs": [
       "minecraft:acacia_log",
@@ -10,6 +64,9 @@
       "minecraft:anvil",
       "minecraft:chipped_anvil",
       "minecraft:damaged_anvil"
+    ],
+    "armadillo_food": [
+      "minecraft:spider_eye"
     ],
     "arrows": [
       "minecraft:arrow",
@@ -24,7 +81,7 @@
       "minecraft:wooden_axe",
       "minecraft:iron_axe"
     ],
-    "axolotl_tempt_items": [
+    "axolotl_food": [
       "minecraft:tropical_fish_bucket"
     ],
     "bamboo_blocks": [
@@ -74,6 +131,9 @@
       "minecraft:white_bed",
       "minecraft:yellow_bed"
     ],
+    "bee_food": [
+      "#minecraft:flowers"
+    ],
     "birch_logs": [
       "minecraft:birch_log",
       "minecraft:birch_wood",
@@ -100,11 +160,19 @@
       "minecraft:knowledge_book"
     ],
     "breaks_decorated_pots": [
-      "#minecraft:tools"
+      "#minecraft:swords",
+      "#minecraft:axes",
+      "#minecraft:pickaxes",
+      "#minecraft:shovels",
+      "#minecraft:hoes",
+      "minecraft:trident"
     ],
     "buttons": [
       "#minecraft:wooden_buttons",
       "#minecraft:stone_buttons"
+    ],
+    "camel_food": [
+      "minecraft:cactus"
     ],
     "candles": [
       "minecraft:candle",
@@ -125,11 +193,23 @@
       "minecraft:red_candle",
       "minecraft:black_candle"
     ],
+    "cat_food": [
+      "minecraft:cod",
+      "minecraft:salmon"
+    ],
     "cherry_logs": [
       "minecraft:cherry_log",
       "minecraft:cherry_wood",
       "minecraft:stripped_cherry_log",
       "minecraft:stripped_cherry_wood"
+    ],
+    "chest_armor": [
+      "minecraft:leather_chestplate",
+      "minecraft:chainmail_chestplate",
+      "minecraft:golden_chestplate",
+      "minecraft:iron_chestplate",
+      "minecraft:diamond_chestplate",
+      "minecraft:netherite_chestplate"
     ],
     "chest_boats": [
       "minecraft:oak_chest_boat",
@@ -141,6 +221,14 @@
       "minecraft:mangrove_chest_boat",
       "minecraft:bamboo_chest_raft",
       "minecraft:cherry_chest_boat"
+    ],
+    "chicken_food": [
+      "minecraft:wheat_seeds",
+      "minecraft:melon_seeds",
+      "minecraft:pumpkin_seeds",
+      "minecraft:beetroot_seeds",
+      "minecraft:torchflower_seeds",
+      "minecraft:pitcher_pod"
     ],
     "cluster_max_harvestables": [
       "minecraft:diamond_pickaxe",
@@ -170,6 +258,9 @@
     "copper_ores": [
       "minecraft:copper_ore",
       "minecraft:deepslate_copper_ore"
+    ],
+    "cow_food": [
+      "minecraft:wheat"
     ],
     "creeper_drop_music_discs": [
       "minecraft:music_disc_13",
@@ -250,6 +341,14 @@
       "#minecraft:wooden_doors",
       "minecraft:iron_door"
     ],
+    "dyeable": [
+      "minecraft:leather_helmet",
+      "minecraft:leather_chestplate",
+      "minecraft:leather_leggings",
+      "minecraft:leather_boots",
+      "minecraft:leather_horse_armor",
+      "minecraft:wolf_armor"
+    ],
     "emerald_ores": [
       "minecraft:emerald_ore",
       "minecraft:deepslate_emerald_ore"
@@ -281,12 +380,22 @@
     ],
     "flowers": [
       "minecraft:mangrove_propagule",
+      "minecraft:cherry_leaves",
       "#minecraft:small_flowers",
       "#minecraft:tall_flowers",
       "minecraft:flowering_azalea_leaves",
       "minecraft:flowering_azalea",
-      "minecraft:cherry_leaves",
-      "minecraft:pink_petals"
+      "minecraft:pink_petals",
+      "minecraft:chorus_flower",
+      "minecraft:spore_blossom"
+    ],
+    "foot_armor": [
+      "minecraft:leather_boots",
+      "minecraft:chainmail_boots",
+      "minecraft:golden_boots",
+      "minecraft:iron_boots",
+      "minecraft:diamond_boots",
+      "minecraft:netherite_boots"
     ],
     "fox_food": [
       "minecraft:sweet_berries",
@@ -298,6 +407,12 @@
       "minecraft:leather_chestplate",
       "minecraft:leather_helmet",
       "minecraft:leather_horse_armor"
+    ],
+    "frog_food": [
+      "minecraft:slime_ball"
+    ],
+    "goat_food": [
+      "minecraft:wheat"
     ],
     "gold_ores": [
       "minecraft:gold_ore",
@@ -314,8 +429,17 @@
       "minecraft:crimson_hanging_sign",
       "minecraft:warped_hanging_sign",
       "minecraft:mangrove_hanging_sign",
-      "minecraft:cherry_hanging_sign",
-      "minecraft:bamboo_hanging_sign"
+      "minecraft:bamboo_hanging_sign",
+      "minecraft:cherry_hanging_sign"
+    ],
+    "head_armor": [
+      "minecraft:leather_helmet",
+      "minecraft:chainmail_helmet",
+      "minecraft:golden_helmet",
+      "minecraft:iron_helmet",
+      "minecraft:diamond_helmet",
+      "minecraft:netherite_helmet",
+      "minecraft:turtle_helmet"
     ],
     "hoes": [
       "minecraft:diamond_hoe",
@@ -324,6 +448,23 @@
       "minecraft:netherite_hoe",
       "minecraft:wooden_hoe",
       "minecraft:iron_hoe"
+    ],
+    "hoglin_food": [
+      "minecraft:crimson_fungus"
+    ],
+    "horse_food": [
+      "minecraft:wheat",
+      "minecraft:sugar",
+      "minecraft:hay_block",
+      "minecraft:apple",
+      "minecraft:golden_carrot",
+      "minecraft:golden_apple",
+      "minecraft:enchanted_golden_apple"
+    ],
+    "horse_tempt_items": [
+      "minecraft:golden_carrot",
+      "minecraft:golden_apple",
+      "minecraft:enchanted_golden_apple"
     ],
     "ignored_by_piglin_babies": [
       "minecraft:leather"
@@ -350,13 +491,28 @@
       "minecraft:acacia_leaves",
       "minecraft:dark_oak_leaves",
       "minecraft:mangrove_leaves",
+      "minecraft:cherry_leaves",
       "minecraft:azalea_leaves",
-      "minecraft:flowering_azalea_leaves",
-      "minecraft:cherry_leaves"
+      "minecraft:flowering_azalea_leaves"
     ],
     "lectern_books": [
       "minecraft:written_book",
       "minecraft:writable_book"
+    ],
+    "leg_armor": [
+      "minecraft:leather_leggings",
+      "minecraft:chainmail_leggings",
+      "minecraft:golden_leggings",
+      "minecraft:iron_leggings",
+      "minecraft:diamond_leggings",
+      "minecraft:netherite_leggings"
+    ],
+    "llama_food": [
+      "minecraft:wheat",
+      "minecraft:hay_block"
+    ],
+    "llama_tempt_items": [
+      "minecraft:hay_block"
     ],
     "logs": [
       "#minecraft:crimson_stems",
@@ -370,14 +526,27 @@
       "#minecraft:jungle_logs",
       "#minecraft:acacia_logs",
       "#minecraft:mangrove_logs",
-      "#minecraft:dark_oak_logs",
-      "#minecraft:cherry_logs"
+      "#minecraft:cherry_logs",
+      "#minecraft:dark_oak_logs"
     ],
     "mangrove_logs": [
       "minecraft:mangrove_log",
       "minecraft:mangrove_wood",
       "minecraft:stripped_mangrove_log",
       "minecraft:stripped_mangrove_wood"
+    ],
+    "meat": [
+      "minecraft:beef",
+      "minecraft:chicken",
+      "minecraft:cooked_beef",
+      "minecraft:cooked_chicken",
+      "minecraft:cooked_mutton",
+      "minecraft:cooked_porkchop",
+      "minecraft:cooked_rabbit",
+      "minecraft:mutton",
+      "minecraft:porkchop",
+      "minecraft:rabbit",
+      "minecraft:rotten_flesh"
     ],
     "music_discs": [
       "#minecraft:creeper_drop_music_discs",
@@ -433,6 +602,24 @@
       "minecraft:stripped_oak_log",
       "minecraft:stripped_oak_wood"
     ],
+    "ocelot_food": [
+      "minecraft:cod",
+      "minecraft:salmon"
+    ],
+    "panda_food": [
+      "minecraft:bamboo"
+    ],
+    "parrot_food": [
+      "minecraft:wheat_seeds",
+      "minecraft:melon_seeds",
+      "minecraft:pumpkin_seeds",
+      "minecraft:beetroot_seeds",
+      "minecraft:torchflower_seeds",
+      "minecraft:pitcher_pod"
+    ],
+    "parrot_poisonous_food": [
+      "minecraft:cookie"
+    ],
     "pickaxes": [
       "minecraft:diamond_pickaxe",
       "minecraft:stone_pickaxe",
@@ -440,6 +627,11 @@
       "minecraft:netherite_pickaxe",
       "minecraft:wooden_pickaxe",
       "minecraft:iron_pickaxe"
+    ],
+    "pig_food": [
+      "minecraft:carrot",
+      "minecraft:potato",
+      "minecraft:beetroot"
     ],
     "piglin_food": [
       "minecraft:porkchop",
@@ -488,6 +680,11 @@
       "minecraft:bamboo_planks",
       "minecraft:cherry_planks"
     ],
+    "rabbit_food": [
+      "minecraft:carrot",
+      "minecraft:golden_carrot",
+      "minecraft:dandelion"
+    ],
     "rails": [
       "minecraft:rail",
       "minecraft:powered_rail",
@@ -512,9 +709,12 @@
       "minecraft:acacia_sapling",
       "minecraft:dark_oak_sapling",
       "minecraft:mangrove_propagule",
+      "minecraft:cherry_sapling",
       "minecraft:azalea",
-      "minecraft:flowering_azalea",
-      "minecraft:cherry_sapling"
+      "minecraft:flowering_azalea"
+    ],
+    "sheep_food": [
+      "minecraft:wheat"
     ],
     "shovels": [
       "minecraft:diamond_shovel",
@@ -537,9 +737,18 @@
       "minecraft:bamboo_sign",
       "minecraft:cherry_sign"
     ],
+    "skulls": [
+      "minecraft:player_head",
+      "minecraft:creeper_head",
+      "minecraft:zombie_head",
+      "minecraft:skeleton_skull",
+      "minecraft:wither_skeleton_skull",
+      "minecraft:dragon_head",
+      "minecraft:piglin_head"
+    ],
     "slabs": [
-      "#minecraft:wooden_slabs",
       "minecraft:bamboo_mosaic_slab",
+      "#minecraft:wooden_slabs",
       "minecraft:stone_slab",
       "minecraft:smooth_stone_slab",
       "minecraft:stone_brick_slab",
@@ -620,8 +829,8 @@
       "minecraft:stripped_spruce_wood"
     ],
     "stairs": [
-      "#minecraft:wooden_stairs",
       "minecraft:bamboo_mosaic_stairs",
+      "#minecraft:wooden_stairs",
       "minecraft:cobblestone_stairs",
       "minecraft:sandstone_stairs",
       "minecraft:nether_brick_stairs",
@@ -684,6 +893,13 @@
       "minecraft:blackstone",
       "minecraft:cobbled_deepslate"
     ],
+    "strider_food": [
+      "minecraft:warped_fungus"
+    ],
+    "strider_tempt_items": [
+      "minecraft:warped_fungus_on_a_stick",
+      "#minecraft:strider_food"
+    ],
     "swords": [
       "minecraft:diamond_sword",
       "minecraft:stone_sword",
@@ -717,14 +933,6 @@
       "minecraft:green_terracotta",
       "minecraft:red_terracotta",
       "minecraft:black_terracotta"
-    ],
-    "tools": [
-      "#minecraft:swords",
-      "#minecraft:axes",
-      "#minecraft:pickaxes",
-      "#minecraft:shovels",
-      "#minecraft:hoes",
-      "minecraft:trident"
     ],
     "trapdoors": [
       "#minecraft:wooden_trapdoors",
@@ -761,31 +969,13 @@
       "minecraft:host_armor_trim_smithing_template"
     ],
     "trimmable_armor": [
-      "minecraft:netherite_helmet",
-      "minecraft:netherite_chestplate",
-      "minecraft:netherite_leggings",
-      "minecraft:netherite_boots",
-      "minecraft:diamond_helmet",
-      "minecraft:diamond_chestplate",
-      "minecraft:diamond_leggings",
-      "minecraft:diamond_boots",
-      "minecraft:golden_helmet",
-      "minecraft:golden_chestplate",
-      "minecraft:golden_leggings",
-      "minecraft:golden_boots",
-      "minecraft:iron_helmet",
-      "minecraft:iron_chestplate",
-      "minecraft:iron_leggings",
-      "minecraft:iron_boots",
-      "minecraft:chainmail_helmet",
-      "minecraft:chainmail_chestplate",
-      "minecraft:chainmail_leggings",
-      "minecraft:chainmail_boots",
-      "minecraft:leather_helmet",
-      "minecraft:leather_chestplate",
-      "minecraft:leather_leggings",
-      "minecraft:leather_boots",
-      "minecraft:turtle_helmet"
+      "#minecraft:foot_armor",
+      "#minecraft:leg_armor",
+      "#minecraft:chest_armor",
+      "#minecraft:head_armor"
+    ],
+    "turtle_food": [
+      "minecraft:seagrass"
     ],
     "villager_plantable_seeds": [
       "minecraft:wheat_seeds",
@@ -828,6 +1018,9 @@
     "wart_blocks": [
       "minecraft:warped_wart_block",
       "minecraft:nether_wart_block"
+    ],
+    "wolf_food": [
+      "#minecraft:meat"
     ],
     "wooden_buttons": [
       "minecraft:oak_button",


### PR DESCRIPTION
- **Added all 1.20.5 items and recipes, including experimental recipes.** This brings the total to 1,712 items and 1,718 recipes!
- Fixed `/item moving_piston` showing wrong icon
- Fixed item images with incorrect aspect ratios
- (Self-hosting change) Updated `recipes.json` format to match base game