### PR TITLE
Version 0.17.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-# Minecord [![Discord Bots](https://discordbots.org/api/widget/status/292279711034245130.png)](https://discordbots.org/bot/292279711034245130) [![Discord Bots](https://discordbots.org/api/widget/servers/292279711034245130.png)](https://discordbots.org/bot/292279711034245130) [![Discord Bots](https://discordbots.org/api/widget/upvotes/292279711034245130.png)](https://discordbots.org/bot/292279711034245130)
+# Minecord
+
 A Discord bot with many Minecraft-related features, such as name history, skin renders, color codes, and recipe lookup!
 
 - **Official Bot Invite: https://minecord.github.io/invite**
 - Bot User: `Minecord#1216`
 - Support Server: https://minecord.github.io/support
 
+### How to Install
+
+To use the bot on your Discord server, **invite the bot at https://minecord.github.io/invite**.
+
 ### Self Hosting
 
 - If you only want to use commands, simply [invite the public bot](https://minecord.github.io/invite).
-- If you want to host it locally, download the [latest release](releases/latest), unzip the archive, and follow the [installation instructions](wiki/Installation).
+- If you want to host it locally, download the [latest release](releases/latest), unzip the archive, and follow the [self-hosting instructions](wiki/Self-Hosting).
 - Want to contribute? See the [contributing guide](blob/master/CONTRIBUTING.md)!

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
         "logWebhook": "",
         "statusWebhook": "",
         "includeSpamStatuses": true,
-        "supportedMCVersion": "1.21.5",
+        "supportedMCVersion": "1.21.6",
         "author": "Tis_awesomeness",
         "authorTag": "@tis_awesomeness",
         "invite": "https://minecord.github.io/invite",

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+    "_comment": "Check the wiki for more information: https://github.com/Tisawesomeness/Minecord/wiki/Config",
     "clientToken": "your token here",
     "shardCount": 1,
     "owner": "0",
@@ -34,15 +35,6 @@
         "recipeImageHost": "https://minecord.github.io/recipe/",
         "crafatarHost": "https://crafatar.com/",
         "reuploadCrafatarImages": false
-    },
-    "botLists": {
-        "sendServerCount": false,
-        "pwToken": "your token here",
-        "orgToken": "your token here",
-        "receiveVotes": false,
-        "webhookURL": "sample",
-        "webhookPort": 8000,
-        "webhookAuth": "auth here"
     },
     "database": {
         "type": "sqlite",

--- a/items.json
+++ b/items.json
@@ -7961,14 +7961,17 @@
       "block_id": 92
     }
   },
-  "minecraft.bed": {
+  "minecraft.red_bed": {
     "lang": {
       "en_US": {
-        "display_name": "Bed"
+        "previously": "Bed",
+        "search_names": [
+          "Red Home"
+        ],
+        "display_name": "Red Bed"
       }
     },
     "properties": {
-      "image_key": "Red Bed",
       "id": 355,
       "block_id": 26
     }
@@ -8238,6 +8241,18 @@
   "minecraft.brewing_stand": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cleric",
+          "Cleric Station",
+          "Cleric Table",
+          "Cleric Site",
+          "Cleric Job Site",
+          "Priest",
+          "Priest Station",
+          "Priest Table",
+          "Priest Site",
+          "Priest Job Site"
+        ],
         "display_name": "Brewing Stand"
       }
     },
@@ -8249,6 +8264,18 @@
   "minecraft.cauldron": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Leatherworker",
+          "Leatherworker Station",
+          "Leatherworker Table",
+          "Leatherworker Site",
+          "Leatherworker Job Site",
+          "Leather Worker",
+          "Leather Worker Station",
+          "Leather Worker Table",
+          "Leather Worker Site",
+          "Leather Worker Job Site"
+        ],
         "display_name": "Cauldron"
       }
     },
@@ -10297,11 +10324,13 @@
           "13 Music Disc",
           "Disc 13",
           "C418 - 13",
+          "C418 13",
           "Thirteen Disc",
           "Thirteen Music Disc",
           "Music Disc Thirteen",
           "Disc Thirteen",
           "C418 - Thirteen",
+          "C418 Thirteen",
           "Thirteen"
         ],
         "display_name": "Music Disc",
@@ -10323,7 +10352,8 @@
           "Cat Disc",
           "Cat Music Disc",
           "Disc Cat",
-          "C418 - Cat"
+          "C418 - Cat",
+          "C418 Cat"
         ],
         "display_name": "Music Disc",
         "name_conflict": true
@@ -10344,7 +10374,8 @@
           "Blocks Disc",
           "Blocks Music Disc",
           "Disc Blocks",
-          "C418 - Blocks"
+          "C418 - Blocks",
+          "C418 Blocks"
         ],
         "display_name": "Music Disc",
         "name_conflict": true
@@ -10365,7 +10396,8 @@
           "Chirp Disc",
           "Chirp Music Disc",
           "Disc Chirp",
-          "C418 - Chirp"
+          "C418 - Chirp",
+          "C418 Chirp"
         ],
         "display_name": "Music Disc",
         "name_conflict": true
@@ -10386,7 +10418,8 @@
           "Far Disc",
           "Far Music Disc",
           "Disc Far",
-          "C418 - Far"
+          "C418 - Far",
+          "C418 Far"
         ],
         "display_name": "Music Disc",
         "name_conflict": true
@@ -10407,7 +10440,8 @@
           "Mall Disc",
           "Mall Music Disc",
           "Disc Mall",
-          "C418 - Mall"
+          "C418 - Mall",
+          "C418 Mall"
         ],
         "display_name": "Music Disc",
         "name_conflict": true
@@ -10428,7 +10462,8 @@
           "Mellohi Disc",
           "Mellohi Music Disc",
           "Disc Mellohi",
-          "C418 - Mellohi"
+          "C418 - Mellohi",
+          "C418 Mellohi"
         ],
         "display_name": "Music Disc",
         "name_conflict": true
@@ -10450,6 +10485,7 @@
           "Stal Music Disc",
           "Disc Stal",
           "C418 - Stal",
+          "C418 Stal",
           "Jschlatt"
         ],
         "display_name": "Music Disc",
@@ -10471,7 +10507,8 @@
           "Strad Disc",
           "Strad Music Disc",
           "Disc Strad",
-          "C418 - Strad"
+          "C418 - Strad",
+          "C418 Strad"
         ],
         "display_name": "Music Disc",
         "name_conflict": true
@@ -10493,6 +10530,7 @@
           "Ward Music Disc",
           "Disc Ward",
           "C418 - Ward",
+          "C418 Ward",
           "Herobrine"
         ],
         "display_name": "Music Disc",
@@ -10516,10 +10554,12 @@
           "Music Disc 11",
           "Disc 11",
           "C418 - 11",
+          "C418 11",
           "Eleven Disc",
           "Eleven Music Disc",
           "Disc Eleven",
           "C418 - Eleven",
+          "C418 Eleven",
           "Eleven"
         ],
         "display_name": "Music Disc",
@@ -10541,7 +10581,8 @@
           "Wait Disc",
           "Wait Music Disc",
           "Disc Wait",
-          "C418 - Wait"
+          "C418 - Wait",
+          "C418 Wait"
         ],
         "display_name": "Music Disc",
         "name_conflict": true
@@ -10566,6 +10607,9 @@
   "minecraft.black_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Black Home"
+        ],
         "display_name": "Black Bed"
       }
     },
@@ -10576,6 +10620,9 @@
   "minecraft.blue_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Blue Home"
+        ],
         "display_name": "Blue Bed"
       }
     },
@@ -10586,6 +10633,9 @@
   "minecraft.brown_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Brown Home"
+        ],
         "display_name": "Brown Bed"
       }
     },
@@ -10596,6 +10646,9 @@
   "minecraft.cyan_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cyan Home"
+        ],
         "display_name": "Cyan Bed"
       }
     },
@@ -10606,6 +10659,9 @@
   "minecraft.gray_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Gray Home"
+        ],
         "display_name": "Gray Bed"
       }
     },
@@ -10616,6 +10672,9 @@
   "minecraft.green_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Green Home"
+        ],
         "display_name": "Green Bed"
       }
     },
@@ -10626,6 +10685,9 @@
   "minecraft.light_blue_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Light Blue Home"
+        ],
         "display_name": "Light Blue Bed"
       }
     },
@@ -10636,6 +10698,9 @@
   "minecraft.light_gray_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Light Gray Home"
+        ],
         "display_name": "Light Gray Bed"
       }
     },
@@ -10646,6 +10711,9 @@
   "minecraft.lime_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Lime Home"
+        ],
         "display_name": "Lime Bed"
       }
     },
@@ -10656,6 +10724,9 @@
   "minecraft.magenta_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Magenta Home"
+        ],
         "display_name": "Magenta Bed"
       }
     },
@@ -10666,6 +10737,9 @@
   "minecraft.orange_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Orange Home"
+        ],
         "display_name": "Orange Bed"
       }
     },
@@ -10676,6 +10750,9 @@
   "minecraft.pink_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Pink Home"
+        ],
         "display_name": "Pink Bed"
       }
     },
@@ -10686,17 +10763,10 @@
   "minecraft.purple_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Purple Home"
+        ],
         "display_name": "Purple Bed"
-      }
-    },
-    "properties": {
-      "version": "1.12"
-    }
-  },
-  "minecraft.red_bed": {
-    "lang": {
-      "en_US": {
-        "display_name": "Red Bed"
       }
     },
     "properties": {
@@ -10706,8 +10776,12 @@
   "minecraft.white_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "White Home"
+        ],
         "uncolored": [
-          "Bed"
+          "Bed",
+          "Home"
         ],
         "display_name": "White Bed"
       }
@@ -10719,6 +10793,9 @@
   "minecraft.yellow_bed": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Yellow Home"
+        ],
         "display_name": "Yellow Bed"
       }
     },
@@ -12247,6 +12324,13 @@
   "minecraft.barrel": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Fisherman",
+          "Fisherman Station",
+          "Fisherman Table",
+          "Fisherman Site",
+          "Fisherman Job Site"
+        ],
         "display_name": "Barrel"
       }
     },
@@ -12257,6 +12341,9 @@
   "minecraft.bell": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Meeting"
+        ],
         "display_name": "Bell"
       }
     },
@@ -12304,6 +12391,18 @@
   "minecraft.blast_furnace": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Armorer",
+          "Armorer Station",
+          "Armorer Table",
+          "Armorer Site",
+          "Armorer Job Site",
+          "Armourer",
+          "Armourer Station",
+          "Armourer Table",
+          "Armourer Site",
+          "Armourer Job Site"
+        ],
         "display_name": "Blast Furnace"
       }
     },
@@ -12357,6 +12456,13 @@
   "minecraft.cartography_table": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cartographer",
+          "Cartographer Station",
+          "Cartographer Table",
+          "Cartographer Site",
+          "Cartographer Job Site"
+        ],
         "display_name": "Cartography Table"
       }
     },
@@ -12381,6 +12487,13 @@
   "minecraft.composter": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Farmer",
+          "Farmer Station",
+          "Farmer Table",
+          "Farmer Site",
+          "Farmer Job Site"
+        ],
         "display_name": "Composter"
       }
     },
@@ -12535,6 +12648,13 @@
   "minecraft.fletching_table": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Fletcher",
+          "Fletcher Station",
+          "Fletcher Table",
+          "Fletcher Site",
+          "Fletcher Job Site"
+        ],
         "display_name": "Fletching Table"
       }
     },
@@ -12628,7 +12748,12 @@
       "en_US": {
         "search_names": [
           "Grind Stone",
-          "Grinding Stone"
+          "Grinding Stone",
+          "Weaponsmith",
+          "Weaponsmith Station",
+          "Weaponsmith Table",
+          "Weaponsmith Site",
+          "Weaponsmith Job Site"
         ],
         "display_name": "Grindstone"
       }
@@ -12703,6 +12828,13 @@
   "minecraft.lectern": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Librarian",
+          "Librarian Station",
+          "Librarian Table",
+          "Librarian Site",
+          "Librarian Job Site"
+        ],
         "display_name": "Lectern"
       }
     },
@@ -12726,6 +12858,13 @@
   "minecraft.loom": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Shepherd",
+          "Shepherd Station",
+          "Shepherd Table",
+          "Shepherd Site",
+          "Shepherd Job Site"
+        ],
         "display_name": "Loom"
       }
     },
@@ -13102,6 +13241,13 @@
   "minecraft.smithing_table": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Toolsmith",
+          "Toolsmith Station",
+          "Toolsmith Table",
+          "Toolsmith Site",
+          "Toolsmith Job Site"
+        ],
         "display_name": "Smithing Table"
       }
     },
@@ -13112,6 +13258,13 @@
   "minecraft.smoker": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Butcher",
+          "Butcher Station",
+          "Butcher Table",
+          "Butcher Site",
+          "Butcher Job Site"
+        ],
         "display_name": "Smoker"
       }
     },
@@ -13245,7 +13398,12 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Stone Cutter"
+          "Stone Cutter",
+          "Mason",
+          "Mason Station",
+          "Mason Table",
+          "Mason Site",
+          "Mason Job Site"
         ],
         "display_name": "Stonecutter"
       }
@@ -13883,6 +14041,7 @@
           "Pigstep Music Disc",
           "Disc Pigstep",
           "Lena Raine - Pigstep",
+          "Lena Raine Pigstep",
           "Pigstep"
         ],
         "display_name": "Music Disc",
@@ -17246,6 +17405,7 @@
           "Otherside Music Disc",
           "Disc Otherside",
           "Lena Raine - otherside",
+          "Lena Raine otherside",
           "otherside"
         ],
         "display_name": "Music Disc",
@@ -17734,12 +17894,16 @@
           "Disc 5",
           "Samuel Aberg - 5",
           "Samuel Åberg - 5",
+          "Samuel Aberg 5",
+          "Samuel Åberg 5",
           "Five Disc",
           "Five Music Disc",
           "Music Disc Five",
           "Disc Five",
           "Samuel Aberg - Five",
           "Samuel Åberg - Five",
+          "Samuel Aberg Five",
+          "Samuel Åberg Five",
           "Five"
         ],
         "display_name": "Music Disc",
@@ -20291,6 +20455,7 @@
           "Relic Music Disc",
           "Disc Relic",
           "Aaron Cherof - Relic",
+          "Aaron Cherof Relic",
           "Relic"
         ],
         "display_name": "Music Disc",
@@ -21981,6 +22146,7 @@
           "Creator Music Disc",
           "Disc Creator",
           "Lena Raine - Creator",
+          "Lena Raine Creator",
           "Creator"
         ],
         "display_name": "Music Disc",
@@ -22001,11 +22167,13 @@
           "Creator (Music Box) Music Disc",
           "Disc Creator (Music Box)",
           "Lena Raine - Creator (Music Box)",
+          "Lena Raine Creator (Music Box)",
           "Creator (Music Box)",
           "Creator Music Box Disc",
           "Creator Music Box Music Disc",
           "Disc Creator Music Box",
           "Lena Raine - Creator Music Box",
+          "Lena Raine Creator Music Box",
           "Creator Music Box"
         ],
         "display_name": "Music Disc",
@@ -22026,6 +22194,7 @@
           "Precipice Music Disc",
           "Disc Precipice",
           "Lena Raine - Precipice",
+          "Lena Raine Precipice",
           "Precipice"
         ],
         "display_name": "Music Disc",
@@ -22076,7 +22245,7 @@
           "Border Pattern",
           "Vines Pattern",
           "Vine Pattern"
-        ],	
+        ],
         "display_name": "Bordure Indented Banner Pattern"
       }
     },
@@ -23111,6 +23280,272 @@
     },
     "properties": {
       "version": "1.21.5"
+    }
+  },
+  "minecraft.black_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Black Ghast Saddle"
+        ],
+        "display_name": "Black Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.blue_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Blue Ghast Saddle"
+        ],
+        "display_name": "Blue Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.brown_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Brown Ghast Saddle"
+        ],
+        "display_name": "Brown Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.cyan_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Cyan Ghast Saddle"
+        ],
+        "display_name": "Cyan Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.dried_ghast": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Dry Ghast",
+          "Dried Ghastling",
+          "Dry Ghastling"
+        ],
+        "display_name": "Dried Ghast"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.gray_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Gray Ghast Saddle"
+        ],
+        "display_name": "Gray Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.green_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Green Ghast Saddle"
+        ],
+        "display_name": "Green Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.happy_ghast_spawn_egg": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Spawn Happy Ghast",
+          "Happy Ghast Egg",
+          "Ghastling Spawn Egg",
+          "Spawn Ghastling",
+          "Ghastling Egg"
+        ],
+        "display_name": "Happy Ghast Spawn Egg"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.light_blue_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Light Blue Ghast Saddle"
+        ],
+        "display_name": "Light Blue Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.light_gray_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Light Gray Ghast Saddle"
+        ],
+        "display_name": "Light Gray Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.lime_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Lime Ghast Saddle"
+        ],
+        "display_name": "Lime Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.magenta_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Magenta Ghast Saddle"
+        ],
+        "display_name": "Magenta Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.music_disc_tears": {
+    "lang": {
+      "en_US": {
+        "distinct_display_name": "Music Disc Tears",
+        "lore": "Amos Roddy - Tears",
+        "search_names": [
+          "Tears Disc",
+          "Tears Music Disc",
+          "Disc Tears",
+          "Amos Roddy - Tears",
+          "Amos Roddy Tears",
+          "Tears"
+        ],
+        "display_name": "Music Disc",
+        "name_conflict": true
+      }
+    },
+    "properties": {
+      "image_key": "Music Disc Tears",
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.orange_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Orange Ghast Saddle"
+        ],
+        "display_name": "Orange Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.pink_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Pink Ghast Saddle"
+        ],
+        "display_name": "Pink Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.purple_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Purple Ghast Saddle"
+        ],
+        "display_name": "Purple Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.red_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Red Ghast Saddle"
+        ],
+        "display_name": "Red Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.white_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "White Ghast Saddle"
+        ],
+        "uncolored": [
+          "Harness",
+          "Ghast Saddle"
+        ],
+        "display_name": "White Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "minecraft.yellow_harness": {
+    "lang": {
+      "en_US": {
+        "search_names": [
+          "Yellow Ghast Saddle"
+        ],
+        "display_name": "Yellow Harness"
+      }
+    },
+    "properties": {
+      "version": "1.21.6"
     }
   },
   "minecraft.lingering_potion.effect.thick": {

--- a/items.json
+++ b/items.json
@@ -266,6 +266,9 @@
   "minecraft.oak_sapling": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Sapling"
+        ],
         "display_name": "Oak Sapling"
       }
     },
@@ -452,6 +455,9 @@
   "minecraft.oak_log": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Log"
+        ],
         "display_name": "Oak Log"
       }
     },
@@ -495,6 +501,9 @@
   "minecraft.oak_leaves": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Leaves"
+        ],
         "display_name": "Oak Leaves"
       }
     },
@@ -538,6 +547,9 @@
   "minecraft.sponge": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Dry Sponge"
+        ],
         "display_name": "Sponge"
       }
     },
@@ -608,6 +620,9 @@
   "minecraft.sandstone": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Sand Stone"
+        ],
         "display_name": "Sandstone"
       }
     },
@@ -618,6 +633,9 @@
   "minecraft.chiseled_sandstone": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Chiseled Sand Stone"
+        ],
         "display_name": "Chiseled Sandstone"
       }
     },
@@ -629,6 +647,9 @@
   "minecraft.smooth_sandstone": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Smooth Sand Stone"
+        ],
         "display_name": "Smooth Sandstone"
       }
     },
@@ -689,6 +710,10 @@
   "minecraft.cobweb": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Web",
+          "Spider Web"
+        ],
         "display_name": "Cobweb"
       }
     },
@@ -1554,7 +1579,13 @@
         "previously": "Oak Wood Stairs",
         "search_names": [
           "Oak Wood Stair",
-          "Oak Stair"
+          "Oak Stair",
+          "Stairs",
+          "Stair",
+          "Wood Stairs",
+          "Wood Stair",
+          "Wooden Stairs",
+          "Wooden Stair"
         ],
         "display_name": "Oak Stairs"
       }
@@ -1609,7 +1640,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Workbench"
+          "Workbench",
+          "WB",
+          "This is a Crafting Table"
         ],
         "display_name": "Crafting Table"
       }
@@ -1696,6 +1729,9 @@
       "en_US": {
         "previously": "Wall-mounted Sign Block",
         "search_names": [
+          "Wall Sign",
+          "Wood Wall Sign",
+          "Wooden Wall Sign",
           "Wall Mounted Sign",
           "Wall Mounted Sign Block",
           "Wall Sign Block",
@@ -1784,7 +1820,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Redstone Torch (off)"
+          "Redstone Torch (off)",
+          "Redstone Torch Off"
         ],
         "display_name": "Unlit Redstone Torch"
       }
@@ -1799,7 +1836,8 @@
       "en_US": {
         "search_names": [
           "Lit Redstone Torch",
-          "Redstone Torch (on)"
+          "Redstone Torch (on)",
+          "Redstone Torch On"
         ],
         "display_name": "Redstone Torch"
       }
@@ -1812,6 +1850,7 @@
     "lang": {
       "en_US": {
         "search_names": [
+          "Button",
           "Grian"
         ],
         "display_name": "Stone Button"
@@ -1888,6 +1927,10 @@
   "minecraft.jukebox": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Record Player",
+          "Music Box"
+        ],
         "display_name": "Jukebox"
       }
     },
@@ -1899,7 +1942,10 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Oak Wood Fence"
+          "Oak Wood Fence",
+          "Fence",
+          "Wood Fence",
+          "Wooden Fence"
         ],
         "display_name": "Oak Fence"
       }
@@ -1972,7 +2018,9 @@
         "search_names": [
           "Jack o' Lantern",
           "Jack o Lantern",
-          "Lit Pumpkin"
+          "Lit Pumpkin",
+          "Jackenstein",
+          "YOUR TAKING TOO LONG"
         ],
         "display_name": "Jack o'Lantern"
       }
@@ -2000,7 +2048,11 @@
           "White Dyed Glass",
           "White Colored Glass",
           "White Coloured Glass",
-          "White Glass"
+          "White Glass",
+          "Stained Glass",
+          "Dyed Glass",
+          "Colored Glass",
+          "Coloured Glass"
         ],
         "uncolored": [
           "Stained Glass",
@@ -2280,7 +2332,9 @@
           "Wooden Trap Door",
           "Wood Trap Door",
           "Oak Wood Trap Door",
-          "Oak Trap Door"
+          "Oak Trap Door",
+          "Trapdoor",
+          "Trap Door"
         ],
         "display_name": "Oak Trapdoor"
       }
@@ -2501,6 +2555,9 @@
   "minecraft.melon": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Me Lon"
+        ],
         "display_name": "Melon"
       }
     },
@@ -2522,6 +2579,9 @@
   "minecraft.melon_stem": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Me Lon Stem"
+        ],
         "display_name": "Melon Stem"
       }
     },
@@ -2724,6 +2784,8 @@
         "search_names": [
           "Redstone Lamp (on)",
           "Redstone Light (on)",
+          "Redstone Lamp On",
+          "Redstone Light On",
           "Lit Redstone Light"
         ],
         "display_name": "Lit Redstone Lamp"
@@ -2739,7 +2801,8 @@
         "search_names": [
           "Double Oak Slab",
           "Oak Double Slab",
-          "Oak Wood Double Slab"
+          "Oak Wood Double Slab",
+          "Double Slab"
         ],
         "display_name": "Double Oak Wood Slab"
       }
@@ -2846,7 +2909,7 @@
       "en_US": {
         "previously": "Oak Wood Slab",
         "search_names": [
-          "Wooden Slab"
+          "Slab"
         ],
         "display_name": "Oak Slab"
       }
@@ -3056,6 +3119,9 @@
   "minecraft.command_block": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "CMD"
+        ],
         "display_name": "Command Block"
       }
     },
@@ -3077,7 +3143,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Cobble Wall"
+          "Cobble Wall",
+          "Wall"
         ],
         "display_name": "Cobblestone Wall"
       }
@@ -3492,7 +3559,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Player Wall Skull"
+          "Player Wall Skull",
+          "Wall Head"
         ],
         "display_name": "Player Wall Head"
       }
@@ -3507,7 +3575,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Skeleton Wall Head"
+          "Skeleton Wall Head",
+          "Wall Skull"
         ],
         "display_name": "Skeleton Wall Skull"
       }
@@ -3561,6 +3630,9 @@
   "minecraft.trapped_chest": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Trap Chest"
+        ],
         "display_name": "Trapped Chest"
       }
     },
@@ -3584,6 +3656,8 @@
           "Golden Weighted Plate",
           "Light Plate",
           "Weighted Plate (light)",
+          "Weighted Plate Light",
+          "Weighted Pressure Plate Light",
           "Light Weighted Plate"
         ],
         "display_name": "Light Weighted Pressure Plate"
@@ -3605,6 +3679,8 @@
           "Iron Weighted Plate",
           "Heavy Plate",
           "Weighted Plate (heavy)",
+          "Weighted Plate Heavy",
+          "Weighted Pressure Plate Heavy",
           "Heavy Weighted Plate"
         ],
         "display_name": "Heavy Weighted Pressure Plate"
@@ -3618,7 +3694,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Redstone Comparator (on)"
+          "Redstone Comparator (on)",
+          "Redstone Comparator On"
         ],
         "display_name": "Powered Redstone Comparator"
       }
@@ -4055,6 +4132,10 @@
     "lang": {
       "en_US": {
         "search_names": [
+          "Stained Glass Pane",
+          "Dyed Glass Pane",
+          "Colored Glass Pane",
+          "Coloured Glass Pane",
           "White Glass Pane",
           "White Colored Glass Pane",
           "White Coloured Glass Pane",
@@ -4512,6 +4593,9 @@
   "minecraft.white_carpet": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Carpet"
+        ],
         "uncolored": [
           "Carpet"
         ],
@@ -4725,6 +4809,9 @@
   "minecraft.sunflower": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Sun Flower"
+        ],
         "display_name": "Sunflower"
       }
     },
@@ -5166,6 +5253,9 @@
   "minecraft.red_sandstone": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Red Sand Stone"
+        ],
         "display_name": "Red Sandstone"
       }
     },
@@ -5177,6 +5267,11 @@
   "minecraft.chiseled_red_sandstone": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Chiseled Red Sand Stone",
+          "Red Chiseled Sandstone",
+          "Red Chiseled Sand Stone"
+        ],
         "display_name": "Chiseled Red Sandstone"
       }
     },
@@ -5189,6 +5284,9 @@
   "minecraft.smooth_red_sandstone": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Smooth Red Sand Stone"
+        ],
         "display_name": "Smooth Red Sandstone"
       }
     },
@@ -5202,7 +5300,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Red Sandstone Stair"
+          "Red Sandstone Stair",
+          "Red Sand Stone Stairs",
+          "Red Sand Stone Stair"
         ],
         "display_name": "Red Sandstone Stairs"
       }
@@ -5216,7 +5316,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Red Sandstone Double Slab"
+          "Red Sandstone Double Slab",
+          "Double Red Sand Stone Slab",
+          "Red Sand Stone Double Slab"
         ],
         "display_name": "Double Red Sandstone Slab"
       }
@@ -5230,6 +5332,9 @@
   "minecraft.red_sandstone_slab": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Red Sand Stone Slab"
+        ],
         "display_name": "Red Sandstone Slab"
       }
     },
@@ -5905,6 +6010,9 @@
   "minecraft.white_glazed_terracotta": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Glazed Terracotta"
+        ],
         "uncolored": [
           "Glazed Terracotta"
         ],
@@ -6085,6 +6193,9 @@
   "minecraft.white_concrete": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Concrete"
+        ],
         "uncolored": [
           "Concrete"
         ],
@@ -6280,7 +6391,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "White Powder"
+          "White Powder",
+          "Concrete Powder",
+          "Powder"
         ],
         "uncolored": [
           "Concrete Powder",
@@ -6679,7 +6792,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Wood Sword"
+          "Wood Sword",
+          "Sword"
         ],
         "display_name": "Wooden Sword"
       }
@@ -6692,7 +6806,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Wood Shovel"
+          "Wood Shovel",
+          "Shovel"
         ],
         "display_name": "Wooden Shovel"
       }
@@ -6707,7 +6822,9 @@
         "search_names": [
           "Wood Pickaxe",
           "Wood Pick",
-          "Wooden Pick"
+          "Wooden Pick",
+          "Pickaxe",
+          "Pick"
         ],
         "display_name": "Wooden Pickaxe"
       }
@@ -6720,7 +6837,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Wood Axe"
+          "Wood Axe",
+          "Axe"
         ],
         "display_name": "Wooden Axe"
       }
@@ -6940,7 +7058,8 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Wood Hoe"
+          "Wood Hoe",
+          "Hoe"
         ],
         "display_name": "Wooden Hoe"
       }
@@ -7031,6 +7150,10 @@
     "lang": {
       "en_US": {
         "previously": "Leather Helmet",
+        "search_names": [
+          "Helmet",
+          "Cap"
+        ],
         "display_name": "Leather Cap"
       }
     },
@@ -7042,7 +7165,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Leather Chestplate"
+          "Leather Chestplate",
+          "Chestplate",
+          "Tunic"
         ],
         "display_name": "Leather Tunic"
       }
@@ -7054,6 +7179,10 @@
   "minecraft.leather_leggings": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Leggings",
+          "Pants"
+        ],
         "display_name": "Leather Pants"
       }
     },
@@ -7064,6 +7193,9 @@
   "minecraft.leather_boots": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Boots"
+        ],
         "display_name": "Leather Boots"
       }
     },
@@ -7355,7 +7487,9 @@
       "en_US": {
         "block_name": "Oak Door Block",
         "search_names": [
-          "Oak Wood Door"
+          "Oak Wood Door",
+          "Wood Door",
+          "Door"
         ],
         "display_name": "Oak Door"
       }
@@ -7380,7 +7514,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Bucket of Water"
+          "Bucket of Water",
+          "Water Bucket Release",
+          "Release"
         ],
         "display_name": "Water Bucket"
       }
@@ -7449,6 +7585,9 @@
   "minecraft.snowball": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Snow Ball"
+        ],
         "display_name": "Snowball"
       }
     },
@@ -8997,7 +9136,8 @@
       "en_US": {
         "search_names": [
           "Bottle of Enchanting",
-          "Bottle o Enchanting"
+          "Bottle o Enchanting",
+          "XP Bottle"
         ],
         "display_name": "Bottle o' Enchanting"
       }
@@ -9334,7 +9474,8 @@
       "en_US": {
         "previous_block_name": "Unpowered Redstone Comparator",
         "search_names": [
-          "Redstone Comparator (off)"
+          "Redstone Comparator (off)",
+          "Redstone Comparator Off"
         ],
         "display_name": "Redstone Comparator"
       }
@@ -9493,7 +9634,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Iron Horse Armour"
+          "Iron Horse Armour",
+          "Horse Armor",
+          "Horse Armour"
         ],
         "display_name": "Iron Horse Armor"
       }
@@ -9915,6 +10058,9 @@
   "minecraft.chorus_fruit": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Chorus"
+        ],
         "display_name": "Chorus Fruit"
       }
     },
@@ -10190,6 +10336,9 @@
   "minecraft.elytra": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Wings"
+        ],
         "display_name": "Elytra"
       }
     },
@@ -10273,6 +10422,9 @@
   "minecraft.totem_of_undying": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Totem"
+        ],
         "display_name": "Totem of Undying"
       }
     },
@@ -10331,7 +10483,8 @@
           "Disc Thirteen",
           "C418 - Thirteen",
           "C418 Thirteen",
-          "Thirteen"
+          "Thirteen",
+          "Music Disc"
         ],
         "display_name": "Music Disc",
         "name_conflict": true
@@ -10597,6 +10750,10 @@
   "minecraft.shulker_box": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Shulker",
+          "Box"
+        ],
         "display_name": "Shulker Box"
       }
     },
@@ -10942,6 +11099,9 @@
   "minecraft.brain_coral": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Coral"
+        ],
         "display_name": "Brain Coral"
       }
     },
@@ -10952,6 +11112,9 @@
   "minecraft.brain_coral_block": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Coral Block"
+        ],
         "display_name": "Brain Coral Block"
       }
     },
@@ -10962,6 +11125,9 @@
   "minecraft.brain_coral_fan": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Coral Fan"
+        ],
         "display_name": "Brain Coral Fan"
       }
     },
@@ -10972,6 +11138,9 @@
   "minecraft.brain_coral_wall_fan": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Coral Wall Fan"
+        ],
         "display_name": "Brain Coral Wall Fan"
       }
     },
@@ -11096,6 +11265,11 @@
   "minecraft.cut_red_sandstone": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cut Red Sand Stone",
+          "Red Cut Sandstone",
+          "Red Cut Sand Stone"
+        ],
         "display_name": "Cut Red Sandstone"
       }
     },
@@ -11106,6 +11280,11 @@
   "minecraft.cut_red_sandstone_slab": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cut Red Sand Stone Slab",
+          "Red Cut Sandstone Slab",
+          "Red Cut Sand Stone Slab"
+        ],
         "display_name": "Cut Red Sandstone Slab"
       }
     },
@@ -11116,6 +11295,9 @@
   "minecraft.cut_sandstone": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cut Sand Stone"
+        ],
         "display_name": "Cut Sandstone"
       }
     },
@@ -11126,6 +11308,9 @@
   "minecraft.cut_sandstone_slab": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Cut Sand Stone Slab"
+        ],
         "display_name": "Cut Sandstone Slab"
       }
     },
@@ -11293,6 +11478,9 @@
   "minecraft.dead_bubble_coral": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Dead Coral"
+        ],
         "display_name": "Dead Bubble Coral"
       }
     },
@@ -11303,6 +11491,9 @@
   "minecraft.dead_bubble_coral_block": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Dead Coral Block"
+        ],
         "display_name": "Dead Bubble Coral Block"
       }
     },
@@ -11313,6 +11504,9 @@
   "minecraft.dead_bubble_coral_fan": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Dead Coral Fan"
+        ],
         "display_name": "Dead Bubble Coral Fan"
       }
     },
@@ -11323,6 +11517,9 @@
   "minecraft.dead_bubble_coral_wall_fan": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Dead Coral Wall Fan"
+        ],
         "display_name": "Dead Bubble Coral Wall Fan"
       }
     },
@@ -11703,6 +11900,9 @@
   "minecraft.oak_wood": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Wood"
+        ],
         "display_name": "Oak Wood"
       }
     },
@@ -12039,6 +12239,9 @@
   "minecraft.stripped_oak_log": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Stripped Log"
+        ],
         "display_name": "Stripped Oak Log"
       }
     },
@@ -12519,7 +12722,9 @@
         "search_names": [
           "Creeper Banner Pattern",
           "Creeper Pattern",
-          "Creeper Charge Pattern"
+          "Creeper Charge Pattern",
+          "Banner Pattern",
+          "Pattern"
         ],
         "display_name": "Creeper Charge Banner Pattern"
       }
@@ -13191,6 +13396,9 @@
   "minecraft.red_sandstone_wall": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Red Sand Stone Wall"
+        ],
         "display_name": "Red Sandstone Wall"
       }
     },
@@ -13201,6 +13409,9 @@
   "minecraft.sandstone_wall": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Sand Stone Wall"
+        ],
         "display_name": "Sandstone Wall"
       }
     },
@@ -13298,6 +13509,11 @@
   "minecraft.smooth_red_sandstone_slab": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Smooth Red Sand Stone Slab",
+          "Red Smooth Sandstone Slab",
+          "Red Smooth Sand Stone Slab"
+        ],
         "display_name": "Smooth Red Sandstone Slab"
       }
     },
@@ -13309,7 +13525,13 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Smooth Red Sandstone Stair"
+          "Smooth Red Sandstone Stair",
+          "Smooth Red Sand Stone Stairs",
+          "Smooth Red Sand Stone Stair",
+          "Red Smooth Sandstone Stairs",
+          "Red Smooth Sandstone Stair",
+          "Red Smooth Sand Stone Stairs",
+          "Red Smooth Sand Stone Stair"
         ],
         "display_name": "Smooth Red Sandstone Stairs"
       }
@@ -13321,6 +13543,9 @@
   "minecraft.smooth_sandstone_slab": {
     "lang": {
       "en_US": {
+        "search_names": [
+          "Smooth Sand Stone Slab"
+        ],
         "display_name": "Smooth Sandstone Slab"
       }
     },
@@ -13332,7 +13557,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "Smooth Sandstone Stair"
+          "Smooth Sandstone Stair",
+          "Smooth Sand Stone Stairs",
+          "Smooth Sand Stone Stair"
         ],
         "display_name": "Smooth Sandstone Stairs"
       }
@@ -18946,7 +19173,8 @@
           "Archer Shard",
           "Bow Pottery Shard",
           "Pottery Shard Bow",
-          "Bow Shard"
+          "Bow Shard",
+          "Pottery Sherd"
         ],
         "display_name": "Archer Pottery Sherd"
       }
@@ -19400,7 +19628,8 @@
           "Shipwreck Trim Template",
           "Shipwreck Trim",
           "Shipwreck Smithing Template",
-          "Shipwreck Template"
+          "Shipwreck Template",
+          "Armor Trim"
         ],
         "display_name": "Coast Armor Trim"
       }
@@ -19519,7 +19748,8 @@
           "Netherite Upgrade Template",
           "Netherite Smithing Template",
           "Netherite Template",
-          "Netherite Upgrade"
+          "Netherite Upgrade",
+          "Smithing Template"
         ],
         "display_name": "Netherite Upgrade"
       }
@@ -23522,7 +23752,9 @@
     "lang": {
       "en_US": {
         "search_names": [
-          "White Ghast Saddle"
+          "White Ghast Saddle",
+          "Harness",
+          "Ghast Saddle"
         ],
         "uncolored": [
           "Harness",

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>5.3.0</version>
+      <version>5.6.1</version>
       <exclusions>
         <exclusion>
           <groupId>club.minnced</groupId>
@@ -43,12 +43,12 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.12.0</version>
+      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20250107</version>
+      <version>20250517</version>
     </dependency>
     <dependency>
       <groupId>club.minnced</groupId>
@@ -58,12 +58,12 @@
     <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
-      <version>9.2.0</version>
+      <version>9.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.49.1.0</version>
+      <version>3.50.1.0</version>
     </dependency>
     <dependency>
       <groupId>dnsjava</groupId>
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.36</version>
+      <version>1.18.38</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tisawesomeness</groupId>
   <artifactId>minecord</artifactId>
-  <version>0.17.17</version>
+  <version>0.17.18</version>
 
   <repositories>
     <repository>

--- a/recipes.json
+++ b/recipes.json
@@ -930,7 +930,10 @@
     },
     "ingredient": "#minecraft:logs_that_burn",
     "type": "minecraft:smelting",
-    "experience": 0.15
+    "experience": 0.15,
+    "properties": {
+      "animated": true
+    }
   },
   "chest": {
     "result": {
@@ -2273,7 +2276,10 @@
     },
     "ingredient": "#minecraft:smelts_to_glass",
     "type": "minecraft:smelting",
-    "experience": 0.1
+    "experience": 0.1,
+    "properties": {
+      "animated": true
+    }
   },
   "glass_bottle": {
     "result": {
@@ -2416,10 +2422,7 @@
       "minecraft:golden_horse_armor"
     ],
     "type": "minecraft:blasting",
-    "experience": 0.1,
-    "properties": {
-      "animated": true
-    }
+    "experience": 0.1
   },
   "golden_apple": {
     "result": {
@@ -3301,7 +3304,7 @@
     "type": "minecraft:smelting",
     "experience": 0.2
   },
-  "lead": {
+  "lead_legacy": {
     "result": {
       "count": 2,
       "id": "minecraft:lead"
@@ -3315,6 +3318,9 @@
     "key": {
       "~": "minecraft:string",
       "O": "minecraft:slime_ball"
+    },
+    "properties": {
+      "removed": "1.20.6"
     }
   },
   "leather_boots": {
@@ -9525,6 +9531,7 @@
     "type": "minecraft:smelting",
     "experience": 0.1,
     "properties": {
+      "animated": true,
       "version": "1.11"
     }
   },
@@ -9618,7 +9625,6 @@
     "type": "minecraft:blasting",
     "experience": 0.1,
     "properties": {
-      "animated": true,
       "version": "1.11"
     }
   },
@@ -9645,6 +9651,7 @@
     "type": "minecraft:smelting",
     "experience": 0.1,
     "properties": {
+      "animated": true,
       "version": "1.11"
     }
   },
@@ -25757,6 +25764,24 @@
     },
     "base": "minecraft.potion.effect.wind_charged"
   },
+  "lead": {
+    "result": {
+      "count": 2,
+      "id": "minecraft:lead"
+    },
+    "pattern": [
+      "~~ ",
+      "~~ ",
+      "  ~"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "~": "minecraft:string"
+    },
+    "properties": {
+      "version": "1.20.6"
+    }
+  },
   "black_bundle": {
     "result": {
       "id": "minecraft:black_bundle"
@@ -26587,6 +26612,843 @@
     },
     "properties": {
       "version": "1.21.5"
+    }
+  },
+  "black_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:black_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:black_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "blue_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:blue_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:blue_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "brown_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:brown_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:brown_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "cyan_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:cyan_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:cyan_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "dried_ghast": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:dried_ghast"
+    },
+    "pattern": [
+      "###",
+      "#X#",
+      "###"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:ghast_tear",
+      "X": "minecraft:soul_sand"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "dye_black_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:black_harness"
+    },
+    "ingredients": [
+      "minecraft:black_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_blue_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:blue_harness"
+    },
+    "ingredients": [
+      "minecraft:blue_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_brown_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:brown_harness"
+    },
+    "ingredients": [
+      "minecraft:brown_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_cyan_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:cyan_harness"
+    },
+    "ingredients": [
+      "minecraft:cyan_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_gray_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:gray_harness"
+    },
+    "ingredients": [
+      "minecraft:gray_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_green_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:green_harness"
+    },
+    "ingredients": [
+      "minecraft:green_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_light_blue_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:light_blue_harness"
+    },
+    "ingredients": [
+      "minecraft:light_blue_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_light_gray_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:light_gray_harness"
+    },
+    "ingredients": [
+      "minecraft:light_gray_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_lime_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:lime_harness"
+    },
+    "ingredients": [
+      "minecraft:lime_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_magenta_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:magenta_harness"
+    },
+    "ingredients": [
+      "minecraft:magenta_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_orange_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:orange_harness"
+    },
+    "ingredients": [
+      "minecraft:orange_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_pink_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:pink_harness"
+    },
+    "ingredients": [
+      "minecraft:pink_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_purple_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:purple_harness"
+    },
+    "ingredients": [
+      "minecraft:purple_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_red_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:red_harness"
+    },
+    "ingredients": [
+      "minecraft:red_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_white_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:white_harness"
+    },
+    "ingredients": [
+      "minecraft:white_dye",
+      [
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:yellow_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "dye_yellow_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:yellow_harness"
+    },
+    "ingredients": [
+      "minecraft:yellow_dye",
+      [
+        "minecraft:white_harness",
+        "minecraft:orange_harness",
+        "minecraft:magenta_harness",
+        "minecraft:light_blue_harness",
+        "minecraft:lime_harness",
+        "minecraft:pink_harness",
+        "minecraft:gray_harness",
+        "minecraft:light_gray_harness",
+        "minecraft:cyan_harness",
+        "minecraft:purple_harness",
+        "minecraft:blue_harness",
+        "minecraft:brown_harness",
+        "minecraft:green_harness",
+        "minecraft:red_harness",
+        "minecraft:black_harness"
+      ]
+    ],
+    "type": "minecraft:crafting_shapeless",
+    "properties": {
+      "animated": true,
+      "version": "1.21.6"
+    }
+  },
+  "gray_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:gray_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:gray_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "green_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:green_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:green_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "light_blue_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:light_blue_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:light_blue_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "light_gray_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:light_gray_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:light_gray_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "lime_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:lime_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:lime_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "magenta_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:magenta_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:magenta_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "orange_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:orange_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:orange_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "pink_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:pink_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:pink_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "purple_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:purple_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:purple_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "red_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:red_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:red_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "saddle": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:saddle"
+    },
+    "pattern": [
+      " X ",
+      "X#X"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:iron_ingot",
+      "X": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "white_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:white_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:white_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
+    }
+  },
+  "yellow_harness": {
+    "result": {
+      "count": 1,
+      "id": "minecraft:yellow_harness"
+    },
+    "pattern": [
+      "LLL",
+      "G#G"
+    ],
+    "type": "minecraft:crafting_shaped",
+    "key": {
+      "#": "minecraft:yellow_wool",
+      "G": "minecraft:glass",
+      "L": "minecraft:leather"
+    },
+    "properties": {
+      "version": "1.21.6"
     }
   }
 }

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -102,6 +102,11 @@ public class Bot {
         if (Config.getDevMode() && !devMode) return false;
         boolean reload = args.length > 0 && ArrayUtils.contains(args, "-r");
 
+        if (!reload && Config.getClientToken().equals("your token here")) {
+            System.err.println("Enter your Discord bot token in config.json, then start the bot again.");
+            System.exit(0);
+        }
+
         //Pre-init
         thread = Thread.currentThread();
         statusListener = new StatusListener();

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -46,7 +46,7 @@ public class Bot {
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
     private static final String version = "0.17.17";
-    public static final String jdaVersion = "5.3.0";
+    public static final String jdaVersion = "5.6.1";
     public static final Color color = Color.GREEN;
 
     public static ShardManager shardManager;

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -45,7 +45,7 @@ public class Bot {
     public static final String donate = "https://ko-fi.com/tis_awesomeness";
     public static final String terms = "https://minecord.github.io/terms";
     public static final String privacy = "https://minecord.github.io/privacy";
-    private static final String version = "0.17.17";
+    private static final String version = "0.17.18";
     public static final String jdaVersion = "5.6.1";
     public static final Color color = Color.GREEN;
 

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -273,6 +273,11 @@ public class Bot {
 
     }
 
+    public static double getPing() {
+        // yes, getAverageGatewayPing() really can return negative
+        return Math.max(0, Bot.shardManager.getAverageGatewayPing());
+    }
+
     public static String getVersion() {
         return version;
     }

--- a/src/com/tisawesomeness/minecord/Bot.java
+++ b/src/com/tisawesomeness/minecord/Bot.java
@@ -234,7 +234,9 @@ public class Bot {
         } catch (InterruptedException ignored) {}
 
         //Post-init
-        shardManager.retrieveUserById(Config.getOwner()).queue(u -> ownerAvatarUrl = u.getAvatarUrl());
+        if (!Config.getOwner().equals("0")) {
+            shardManager.retrieveUserById(Config.getOwner()).queue(u -> ownerAvatarUrl = u.getAvatarUrl());
+        }
         bootTime = System.currentTimeMillis() - birth;
         System.out.println("Boot Time: " + DateUtils.getBootTime());
         logger.log(":white_check_mark: **Bot started!**");

--- a/src/com/tisawesomeness/minecord/Config.java
+++ b/src/com/tisawesomeness/minecord/Config.java
@@ -160,18 +160,18 @@ public class Config {
             crafatarHost = settings.optString("crafatarHost", "https://crafatar.com/");
             reuploadCrafatarImages = settings.optBoolean("reuploadCrafatarImages", false);
 
-            JSONObject botLists = config.getJSONObject("botLists");
-            if (isSelfHosted) {
+            JSONObject botLists = config.optJSONObject("botLists");
+            if (botLists == null || isSelfHosted) {
                 sendServerCount = false;
             } else {
                 sendServerCount = botLists.getBoolean("sendServerCount");
+                pwToken = botLists.getString("pwToken");
+                orgToken = botLists.getString("orgToken");
+                receiveVotes = botLists.getBoolean("receiveVotes");
+                webhookURL = botLists.getString("webhookURL");
+                webhookPort = botLists.getInt("webhookPort");
+                webhookAuth = botLists.getString("webhookAuth");
             }
-            pwToken = botLists.getString("pwToken");
-            orgToken = botLists.getString("orgToken");
-            receiveVotes = botLists.getBoolean("receiveVotes");
-            webhookURL = botLists.getString("webhookURL");
-            webhookPort = botLists.getInt("webhookPort");
-            webhookAuth = botLists.getString("webhookAuth");
 
             JSONObject database = config.getJSONObject("database");
             type = database.getString("type");

--- a/src/com/tisawesomeness/minecord/Config.java
+++ b/src/com/tisawesomeness/minecord/Config.java
@@ -121,7 +121,7 @@ public class Config {
             logWebhook = settings.optString("logWebhook", "");
             statusWebhook = settings.optString("statusWebhook", "");
             includeSpamStatuses = settings.optBoolean("includeSpamStatuses", false);
-            supportedMCVersion = settings.optString("supportedMCVersion", "1.21.5");
+            supportedMCVersion = settings.optString("supportedMCVersion", "1.21.6");
             isSelfHosted = settings.optBoolean("isSelfHosted", true);
             if (isSelfHosted) {
                 author = settings.getString("author");

--- a/src/com/tisawesomeness/minecord/command/core/InfoCommand.java
+++ b/src/com/tisawesomeness/minecord/command/core/InfoCommand.java
@@ -57,7 +57,7 @@ public class InfoCommand extends SlashCommand {
         if (Config.isSelfHosted()) {
             eb.addField("Self-Hoster", Config.getAuthor(), true);
         }
-        eb.addField("Version", Bot.getVersion(), true);
+        eb.addField("Version", MarkdownUtil.monospace(Bot.getVersion()), true);
 
         String guilds = String.valueOf(Bot.shardManager.getGuilds().size());
         int shardCount = jda.getShardInfo().getShardTotal();

--- a/src/com/tisawesomeness/minecord/command/core/InfoCommand.java
+++ b/src/com/tisawesomeness/minecord/command/core/InfoCommand.java
@@ -69,7 +69,7 @@ public class InfoCommand extends SlashCommand {
         eb.addField("Guilds", guilds, true);
 
         eb.addField("Uptime", DateUtils.getUptime(), true);
-        eb.addField("Ping", (int) Math.ceil(Bot.shardManager.getAverageGatewayPing()) + "ms", true);
+        eb.addField("Ping", (int) Math.ceil(Bot.getPing()) + "ms", true);
         if (Config.getShowMemory() || elevated) {
             eb.addField("Memory", getMemoryString(), true);
             eb.addField("Boot Time", DateUtils.getBootTime(), true);

--- a/src/com/tisawesomeness/minecord/command/core/PingCommand.java
+++ b/src/com/tisawesomeness/minecord/command/core/PingCommand.java
@@ -2,7 +2,6 @@ package com.tisawesomeness.minecord.command.core;
 
 import com.tisawesomeness.minecord.Bot;
 import com.tisawesomeness.minecord.command.SlashCommand;
-
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 
 public class PingCommand extends SlashCommand {
@@ -28,8 +27,7 @@ public class PingCommand extends SlashCommand {
         return run();
     }
     public static Result run() {
-        double ping = Bot.shardManager.getAverageGatewayPing();
-        String msg = String.format(":ping_pong: **Pong!** `%.3f ms`\nUse `/server` to ping a server.", ping);
+        String msg = String.format(":ping_pong: **Pong!** `%.3f ms`\nUse `/server` to ping a server.", Bot.getPing());
         return new Result(Outcome.SUCCESS, msg);
     }
 

--- a/src/com/tisawesomeness/minecord/command/player/BasePlayerCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/BasePlayerCommand.java
@@ -5,7 +5,6 @@ import com.tisawesomeness.minecord.mc.external.PlayerProvider;
 import com.tisawesomeness.minecord.mc.player.Player;
 import com.tisawesomeness.minecord.mc.player.Username;
 import com.tisawesomeness.minecord.util.UuidUtils;
-
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
@@ -29,8 +28,7 @@ public abstract class BasePlayerCommand extends AbstractPlayerCommand {
 
     @Override
     public SlashCommandData addCommandSyntax(SlashCommandData builder) {
-        return builder.addOptions(new OptionData(OptionType.STRING, "player", "The player", true)
-                .setMaxLength(Player.MAX_PLAYER_ARGUMENT_LENGTH));
+        return builder.addOptions(new OptionData(OptionType.STRING, "player", "The player", true));
     }
 
     public Result run(SlashCommandInteractionEvent e) {

--- a/src/com/tisawesomeness/minecord/command/player/BaseRenderCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/BaseRenderCommand.java
@@ -8,7 +8,6 @@ import com.tisawesomeness.minecord.mc.player.RenderType;
 import com.tisawesomeness.minecord.mc.player.Username;
 import com.tisawesomeness.minecord.util.UuidUtils;
 import com.tisawesomeness.minecord.util.type.Either;
-
 import lombok.Value;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
@@ -27,8 +26,7 @@ public abstract class BaseRenderCommand extends AbstractPlayerCommand {
 
     @Override
     public SlashCommandData addCommandSyntax(SlashCommandData builder) {
-        return builder.addOptions(new OptionData(OptionType.STRING, "player", "The player", true)
-                .setMaxLength(Player.MAX_PLAYER_ARGUMENT_LENGTH));
+        return builder.addOptions(new OptionData(OptionType.STRING, "player", "The player", true));
     }
 
     /**

--- a/src/com/tisawesomeness/minecord/command/player/UuidCommand.java
+++ b/src/com/tisawesomeness/minecord/command/player/UuidCommand.java
@@ -28,8 +28,7 @@ public class UuidCommand extends AbstractPlayerCommand {
 
     @Override
     public SlashCommandData addCommandSyntax(SlashCommandData builder) {
-        return builder.addOptions(new OptionData(OptionType.STRING, "uuid_or_username", "The UUID or username of the player or entity.", true)
-                .setMaxLength(Player.MAX_PLAYER_ARGUMENT_LENGTH));
+        return builder.addOptions(new OptionData(OptionType.STRING, "uuid_or_username", "The UUID or username of the player or entity.", true));
     }
 
     @Override

--- a/src/com/tisawesomeness/minecord/command/utility/StackCommand.java
+++ b/src/com/tisawesomeness/minecord/command/utility/StackCommand.java
@@ -133,7 +133,7 @@ public class StackCommand extends SlashCommand {
     }
     private static String itemCountExactLine(ItemCount itemCount, Container container) {
         double value = itemCount.getExact(container);
-        return String.format("- **%s** %s\n", FORMAT.format(value), container.getDescription((int) value));
+        return String.format("- **%s** %s\n", FORMAT.format(value), container.getDescription(value));
     }
 
 }

--- a/src/com/tisawesomeness/minecord/mc/FeatureFlag.java
+++ b/src/com/tisawesomeness/minecord/mc/FeatureFlag.java
@@ -18,7 +18,7 @@ public enum FeatureFlag {
     WINTER_DROP("winter_drop", "Winter Drop", "1.21.4");
 
     public static final FeatureFlag[] RELEASE_ORDER = new FeatureFlag[]{
-            UPDATE_1_20, UPDATE_1_21, BUNDLE, null, WINTER_DROP
+            UPDATE_1_20, UPDATE_1_21, BUNDLE, WINTER_DROP, null
     };
     public static final Comparator<FeatureFlag> RELEASE_ORDER_COMPARATOR = (f1, f2) -> {
         int i1 = ArrayUtils.indexOf(RELEASE_ORDER, f1);

--- a/src/com/tisawesomeness/minecord/mc/item/ItemRegistry.java
+++ b/src/com/tisawesomeness/minecord/mc/item/ItemRegistry.java
@@ -30,7 +30,7 @@ public class ItemRegistry {
             "minecraft.white_stained_glass", "minecraft.white_terracotta", "minecraft.white_stained_glass_pane",
             "minecraft.shield.white", "minecraft.white_shulker_box", "minecraft.white_bed",
             "minecraft.white_glazed_terracotta", "minecraft.white_concrete", "minecraft.white_concrete_powder",
-            "minecraft.white_dye", "minecraft.white_candle" };
+            "minecraft.white_dye", "minecraft.white_candle", "minecraft.white_bundle", "minecraft.white_harness" };
 
     private static JSONObject items;
     private static JSONObject data;

--- a/src/com/tisawesomeness/minecord/mc/player/Player.java
+++ b/src/com/tisawesomeness/minecord/mc/player/Player.java
@@ -20,9 +20,6 @@ import java.util.UUID;
 public class Player implements Comparable<Player> {
     private static final Comparator<Player> COMPARATOR = initComparator();
 
-    // 37 is max length of a UUID with dashes
-    public static final int MAX_PLAYER_ARGUMENT_LENGTH = Math.max(37, Username.MAX_LENGTH);
-
     private static final Username DINNERBONE = new Username("Dinnerbone");
     private static final Username GRUMM = new Username("Grumm");
     private static final Username JEB = new Username("jeb_");

--- a/src/com/tisawesomeness/minecord/mc/recipe/Recipe.java
+++ b/src/com/tisawesomeness/minecord/mc/recipe/Recipe.java
@@ -37,7 +37,7 @@ public abstract class Recipe {
     );
 
     /**
-     * The id/key/name of this recipe. Usually the same as the filename in data/minecraft,
+     * The id/key/name of this recipe. Usually the same as the filename in data/minecraft/recipe,
      * but recipes defined in recipes.json do not need to have an in-game equivalent.
      */
     @Getter protected final String key;

--- a/src/com/tisawesomeness/minecord/mc/recipe/RecipeRegistry.java
+++ b/src/com/tisawesomeness/minecord/mc/recipe/RecipeRegistry.java
@@ -38,7 +38,7 @@ public class RecipeRegistry {
             "1.18", "1.18.1", "1.18.2",
             "1.19", "1.19.1", "1.19.2", "1.19.3", "1.19.4",
             "1.20", "1.20.1", "1.20.2", "1.20.3", "1.20.4", "1.20.5", "1.20.6",
-            "1.21", "1.21.1", "1.21.2", "1.21.3", "1.21.4", "1.21.5"
+            "1.21", "1.21.1", "1.21.2", "1.21.3", "1.21.4", "1.21.5", "1.21.6"
     };
     private static final List<Class<? extends Recipe>> RECIPE_TYPE_ORDER = Arrays.asList(
             ShapedRecipe.class, ShapelessRecipe.class, TransmuteRecipe.class, StonecuttingRecipe.class,
@@ -92,7 +92,6 @@ public class RecipeRegistry {
         eb.setTitle(ItemRegistry.getDistinctDisplayName(item));
         String img = Config.getRecipeImageHost() + getImage(recipe);
         eb.setImage(img);
-        System.out.println(img);
         eb.setColor(Bot.color);
         eb.setDescription(getMetadata(recipe));
         return eb;

--- a/src/com/tisawesomeness/minecord/util/type/HumanDecimalFormat.java
+++ b/src/com/tisawesomeness/minecord/util/type/HumanDecimalFormat.java
@@ -48,7 +48,7 @@ public class HumanDecimalFormat {
     @Builder.Default
     private final boolean includeGroupingCommas = false;
     /**
-     * Whether to prefix the number with '~' when the formatter rounds the number before formatting. This ONLY accounts
+     * Whether to prefix the number with '≈' when the formatter rounds the number before formatting. This ONLY accounts
      * for rounding due to the maximum fractional digits, not roundoff error.
      * <br>Default false.
      */
@@ -140,7 +140,7 @@ public class HumanDecimalFormat {
         }
         format.setMaximumFractionDigits(-Double.MIN_EXPONENT);
         String withAllDigits = format.format(d);
-        return original.equals(withAllDigits) ? original : "~" + original;
+        return original.equals(withAllDigits) ? original : "≈" + original;
     }
 
 }

--- a/tags.json
+++ b/tags.json
@@ -103,8 +103,10 @@
       "minecraft:flowering_azalea_leaves",
       "minecraft:flowering_azalea",
       "minecraft:pink_petals",
+      "minecraft:wildflowers",
       "minecraft:chorus_flower",
-      "minecraft:spore_blossom"
+      "minecraft:spore_blossom",
+      "minecraft:cactus_flower"
     ],
     "birch_logs": [
       "minecraft:birch_log",
@@ -124,6 +126,9 @@
       "minecraft:cherry_boat",
       "minecraft:pale_oak_boat",
       "#minecraft:chest_boats"
+    ],
+    "book_cloning_target": [
+      "minecraft:writable_book"
     ],
     "bookshelf_books": [
       "minecraft:book",
@@ -367,6 +372,11 @@
       "minecraft:leather_horse_armor",
       "minecraft:wolf_armor"
     ],
+    "eggs": [
+      "minecraft:egg",
+      "minecraft:blue_egg",
+      "minecraft:brown_egg"
+    ],
     "emerald_ores": [
       "minecraft:emerald_ore",
       "minecraft:deepslate_emerald_ore"
@@ -396,6 +406,23 @@
       "minecraft:cooked_salmon",
       "minecraft:pufferfish",
       "minecraft:tropical_fish"
+    ],
+    "flowers": [
+      "minecraft:mangrove_propagule",
+      "minecraft:cherry_leaves",
+      "#minecraft:small_flowers",
+      "minecraft:sunflower",
+      "minecraft:lilac",
+      "minecraft:peony",
+      "minecraft:rose_bush",
+      "minecraft:pitcher_plant",
+      "minecraft:flowering_azalea_leaves",
+      "minecraft:flowering_azalea",
+      "minecraft:pink_petals",
+      "minecraft:wildflowers",
+      "minecraft:chorus_flower",
+      "minecraft:spore_blossom",
+      "minecraft:cactus_flower"
     ],
     "foot_armor": [
       "minecraft:leather_boots",
@@ -451,6 +478,31 @@
       "minecraft:cherry_hanging_sign",
       "minecraft:pale_oak_hanging_sign"
     ],
+    "happy_ghast_food": [
+      "minecraft:snowball"
+    ],
+    "happy_ghast_tempt_items": [
+      "#minecraft:happy_ghast_food",
+      "#minecraft:harnesses"
+    ],
+    "harnesses": [
+      "minecraft:white_harness",
+      "minecraft:orange_harness",
+      "minecraft:magenta_harness",
+      "minecraft:light_blue_harness",
+      "minecraft:yellow_harness",
+      "minecraft:lime_harness",
+      "minecraft:pink_harness",
+      "minecraft:gray_harness",
+      "minecraft:light_gray_harness",
+      "minecraft:cyan_harness",
+      "minecraft:purple_harness",
+      "minecraft:blue_harness",
+      "minecraft:brown_harness",
+      "minecraft:green_harness",
+      "minecraft:red_harness",
+      "minecraft:black_harness"
+    ],
     "head_armor": [
       "minecraft:leather_helmet",
       "minecraft:chainmail_helmet",
@@ -476,6 +528,7 @@
       "minecraft:sugar",
       "minecraft:hay_block",
       "minecraft:apple",
+      "minecraft:carrot",
       "minecraft:golden_carrot",
       "minecraft:golden_apple",
       "minecraft:enchanted_golden_apple"
@@ -768,7 +821,6 @@
     "sand": [
       "minecraft:sand",
       "minecraft:red_sand",
-      "minecraft:suspicious_sand",
       "minecraft:suspicious_sand"
     ],
     "saplings": [


### PR DESCRIPTION
- **Added all 1.21.6 items and recipes.** This brings the total to 1,801 items and 1,808 recipes!
- Searching for an item category such as "sword", "concrete", or "stairs" will return the "primary" item in that category
- Added aliases for many items
- Used the `≈` symbol in place of `~` in `/stack`
- Changed the bot version in `/info` to monospace
- Fixed player commands not accepting non-standard UUID arguments due to the argument length limit
- Fixed `/item bed` not redirecting to Red Bed
- Fixed some items displaying with a black background
- Fixed `/recpie` not showing images for charcoal, glass, gold nugget (smelting) and iron nugget (smelting)
- Fixed `/stack` sometimes not using correct plurals for decimal numbers greater than 1 but less than 2

Self-hosting changes:
- If the token is not set in the config, the bot now exits immediately telling you to set the token
- Removed parts of the config that were unused for self-hosters from the default config
- Fixed a rare issue where you could get `-1ms` ping when hosting locally
- Fixed an exception when the owner is not set in the config
- Updated dependencies